### PR TITLE
feat: Add interceptor registration APIs and assembly scanning

### DIFF
--- a/src/NetEvolve.Pulse/HandlerRegistrationExtensions.cs
+++ b/src/NetEvolve.Pulse/HandlerRegistrationExtensions.cs
@@ -227,4 +227,202 @@ public static class HandlerRegistrationExtensions
 
         return configurator;
     }
+
+    /// <summary>
+    /// Registers a request interceptor for the specified request type.
+    /// Request interceptors enable cross-cutting concerns to be applied to both commands and queries.
+    /// </summary>
+    /// <typeparam name="TRequest">The request type that implements <see cref="IRequest{TResponse}"/>.</typeparam>
+    /// <typeparam name="TResponse">The response type returned by the request.</typeparam>
+    /// <typeparam name="TInterceptor">The interceptor implementation type that implements <see cref="IRequestInterceptor{TRequest, TResponse}"/>.</typeparam>
+    /// <param name="configurator">The mediator configurator.</param>
+    /// <param name="lifetime">The service lifetime for the interceptor (default: Scoped).</param>
+    /// <returns>The configurator for method chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="configurator"/> is null.</exception>
+    /// <remarks>
+    /// <para><strong>Multiple Interceptors:</strong></para>
+    /// Multiple interceptors can be registered for the same request type. They execute in reverse order
+    /// of registration (LIFO - Last In, First Out). The last registered interceptor runs first.
+    /// <para><strong>AOT Safety:</strong></para>
+    /// This method is fully compatible with Native AOT compilation. The <c>DynamicallyAccessedMembers</c> attribute
+    /// ensures the interceptor's public constructors are preserved during trimming.
+    /// <para><strong>Common Use Cases:</strong></para>
+    /// Logging, validation, performance monitoring, exception handling, request/response transformation.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// // Register request interceptor with default Scoped lifetime
+    /// config.AddRequestInterceptor&lt;MyRequest, MyResponse, LoggingInterceptor&lt;MyRequest, MyResponse&gt;&gt;();
+    ///
+    /// // Register with explicit Singleton lifetime for stateless interceptor
+    /// config.AddRequestInterceptor&lt;MyRequest, MyResponse, ValidationInterceptor&lt;MyRequest, MyResponse&gt;&gt;(ServiceLifetime.Singleton);
+    /// </code>
+    /// </example>
+    public static IMediatorConfigurator AddRequestInterceptor<
+        TRequest,
+        TResponse,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TInterceptor
+    >(this IMediatorConfigurator configurator, ServiceLifetime lifetime = ServiceLifetime.Scoped)
+        where TRequest : IRequest<TResponse>
+        where TInterceptor : class, IRequestInterceptor<TRequest, TResponse>
+    {
+        ArgumentNullException.ThrowIfNull(configurator);
+
+        configurator.Services.Add(
+            new ServiceDescriptor(typeof(IRequestInterceptor<TRequest, TResponse>), typeof(TInterceptor), lifetime)
+        );
+
+        return configurator;
+    }
+
+    /// <summary>
+    /// Registers a command interceptor for the specified command type.
+    /// Command interceptors enable cross-cutting concerns such as logging, validation, or transaction management for commands.
+    /// </summary>
+    /// <typeparam name="TCommand">The command type that implements <see cref="ICommand{TResponse}"/>.</typeparam>
+    /// <typeparam name="TResponse">The response type returned by the command.</typeparam>
+    /// <typeparam name="TInterceptor">The interceptor implementation type that implements <see cref="ICommandInterceptor{TCommand, TResponse}"/>.</typeparam>
+    /// <param name="configurator">The mediator configurator.</param>
+    /// <param name="lifetime">The service lifetime for the interceptor (default: Scoped).</param>
+    /// <returns>The configurator for method chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="configurator"/> is null.</exception>
+    /// <remarks>
+    /// <para><strong>Multiple Interceptors:</strong></para>
+    /// Multiple interceptors can be registered for the same command type. They execute in reverse order
+    /// of registration (LIFO - Last In, First Out). The last registered interceptor runs first.
+    /// <para><strong>AOT Safety:</strong></para>
+    /// This method is fully compatible with Native AOT compilation. The <c>DynamicallyAccessedMembers</c> attribute
+    /// ensures the interceptor's public constructors are preserved during trimming.
+    /// <para><strong>Common Use Cases:</strong></para>
+    /// Transaction management, authorization, audit logging, command validation.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// // Register command interceptor
+    /// config.AddCommandInterceptor&lt;CreateOrderCommand, OrderResult, TransactionInterceptor&lt;CreateOrderCommand, OrderResult&gt;&gt;();
+    ///
+    /// // Chain multiple interceptors (executed in reverse order)
+    /// config
+    ///     .AddCommandInterceptor&lt;CreateOrderCommand, OrderResult, LoggingInterceptor&lt;CreateOrderCommand, OrderResult&gt;&gt;()
+    ///     .AddCommandInterceptor&lt;CreateOrderCommand, OrderResult, ValidationInterceptor&lt;CreateOrderCommand, OrderResult&gt;&gt;()
+    ///     .AddCommandInterceptor&lt;CreateOrderCommand, OrderResult, AuthorizationInterceptor&lt;CreateOrderCommand, OrderResult&gt;&gt;();
+    /// </code>
+    /// </example>
+    public static IMediatorConfigurator AddCommandInterceptor<
+        TCommand,
+        TResponse,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TInterceptor
+    >(this IMediatorConfigurator configurator, ServiceLifetime lifetime = ServiceLifetime.Scoped)
+        where TCommand : ICommand<TResponse>
+        where TInterceptor : class, ICommandInterceptor<TCommand, TResponse>
+    {
+        ArgumentNullException.ThrowIfNull(configurator);
+
+        configurator.Services.Add(
+            new ServiceDescriptor(typeof(ICommandInterceptor<TCommand, TResponse>), typeof(TInterceptor), lifetime)
+        );
+
+        return configurator;
+    }
+
+    /// <summary>
+    /// Registers a query interceptor for the specified query type.
+    /// Query interceptors allow cross-cutting concerns such as caching, logging, or authorization to be applied to query execution.
+    /// </summary>
+    /// <typeparam name="TQuery">The query type that implements <see cref="IQuery{TResponse}"/>.</typeparam>
+    /// <typeparam name="TResponse">The response type returned by the query.</typeparam>
+    /// <typeparam name="TInterceptor">The interceptor implementation type that implements <see cref="IQueryInterceptor{TQuery, TResponse}"/>.</typeparam>
+    /// <param name="configurator">The mediator configurator.</param>
+    /// <param name="lifetime">The service lifetime for the interceptor (default: Scoped).</param>
+    /// <returns>The configurator for method chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="configurator"/> is null.</exception>
+    /// <remarks>
+    /// <para><strong>Multiple Interceptors:</strong></para>
+    /// Multiple interceptors can be registered for the same query type. They execute in reverse order
+    /// of registration (LIFO - Last In, First Out). The last registered interceptor runs first.
+    /// <para><strong>AOT Safety:</strong></para>
+    /// This method is fully compatible with Native AOT compilation. The <c>DynamicallyAccessedMembers</c> attribute
+    /// ensures the interceptor's public constructors are preserved during trimming.
+    /// <para><strong>Common Use Cases:</strong></para>
+    /// Response caching, read authorization checks, performance monitoring, data masking.
+    /// <para><strong>⚠️ WARNING:</strong></para>
+    /// Query interceptors should maintain the side-effect free nature of queries. Don't modify state in query interceptors.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// // Register query interceptor with caching
+    /// config.AddQueryInterceptor&lt;GetOrderQuery, Order, CachingInterceptor&lt;GetOrderQuery, Order&gt;&gt;();
+    ///
+    /// // Chain multiple interceptors for queries
+    /// config
+    ///     .AddQueryInterceptor&lt;GetOrderQuery, Order, LoggingInterceptor&lt;GetOrderQuery, Order&gt;&gt;()
+    ///     .AddQueryInterceptor&lt;GetOrderQuery, Order, AuthorizationInterceptor&lt;GetOrderQuery, Order&gt;&gt;()
+    ///     .AddQueryInterceptor&lt;GetOrderQuery, Order, CachingInterceptor&lt;GetOrderQuery, Order&gt;&gt;();
+    /// </code>
+    /// </example>
+    public static IMediatorConfigurator AddQueryInterceptor<
+        TQuery,
+        TResponse,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TInterceptor
+    >(this IMediatorConfigurator configurator, ServiceLifetime lifetime = ServiceLifetime.Scoped)
+        where TQuery : IQuery<TResponse>
+        where TInterceptor : class, IQueryInterceptor<TQuery, TResponse>
+    {
+        ArgumentNullException.ThrowIfNull(configurator);
+
+        configurator.Services.Add(
+            new ServiceDescriptor(typeof(IQueryInterceptor<TQuery, TResponse>), typeof(TInterceptor), lifetime)
+        );
+
+        return configurator;
+    }
+
+    /// <summary>
+    /// Registers an event interceptor for the specified event type.
+    /// Event interceptors enable cross-cutting concerns such as logging, auditing, or enrichment to be applied before event handlers are invoked.
+    /// </summary>
+    /// <typeparam name="TEvent">The event type that implements <see cref="IEvent"/>.</typeparam>
+    /// <typeparam name="TInterceptor">The interceptor implementation type that implements <see cref="IEventInterceptor{TEvent}"/>.</typeparam>
+    /// <param name="configurator">The mediator configurator.</param>
+    /// <param name="lifetime">The service lifetime for the interceptor (default: Scoped).</param>
+    /// <returns>The configurator for method chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="configurator"/> is null.</exception>
+    /// <remarks>
+    /// <para><strong>Multiple Interceptors:</strong></para>
+    /// Multiple interceptors can be registered for the same event type and will execute sequentially before event handlers.
+    /// <para><strong>AOT Safety:</strong></para>
+    /// This method is fully compatible with Native AOT compilation. The <c>DynamicallyAccessedMembers</c> attribute
+    /// ensures the interceptor's public constructors are preserved during trimming.
+    /// <para><strong>Common Use Cases:</strong></para>
+    /// Event logging and auditing, setting metadata (timestamps, correlation IDs), event enrichment, metrics and monitoring.
+    /// <para><strong>⚠️ WARNING:</strong></para>
+    /// Event interceptors should be fast and non-blocking. Heavy processing delays all event handlers from executing.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// // Register event interceptor for logging
+    /// config.AddEventInterceptor&lt;OrderCreatedEvent, EventLoggingInterceptor&lt;OrderCreatedEvent&gt;&gt;();
+    ///
+    /// // Chain multiple event interceptors
+    /// config
+    ///     .AddEventInterceptor&lt;OrderCreatedEvent, AuditInterceptor&lt;OrderCreatedEvent&gt;&gt;()
+    ///     .AddEventInterceptor&lt;OrderCreatedEvent, EnrichmentInterceptor&lt;OrderCreatedEvent&gt;&gt;()
+    ///     .AddEventInterceptor&lt;OrderCreatedEvent, MetricsInterceptor&lt;OrderCreatedEvent&gt;&gt;();
+    /// </code>
+    /// </example>
+    public static IMediatorConfigurator AddEventInterceptor<
+        TEvent,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TInterceptor
+    >(this IMediatorConfigurator configurator, ServiceLifetime lifetime = ServiceLifetime.Scoped)
+        where TEvent : IEvent
+        where TInterceptor : class, IEventInterceptor<TEvent>
+    {
+        ArgumentNullException.ThrowIfNull(configurator);
+
+        configurator.Services.Add(
+            new ServiceDescriptor(typeof(IEventInterceptor<TEvent>), typeof(TInterceptor), lifetime)
+        );
+
+        return configurator;
+    }
 }

--- a/tests/NetEvolve.Pulse.Tests.Unit/HandlerRegistrationExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/HandlerRegistrationExtensionsTests.cs
@@ -360,4 +360,328 @@ public class HandlerRegistrationExtensionsTests
     {
         public Task HandleAsync(TestEvent @event, CancellationToken cancellationToken = default) => Task.CompletedTask;
     }
+
+    // Interceptor registration tests
+    [Test]
+    public void AddRequestInterceptor_WithNullConfigurator_ThrowsArgumentNullException()
+    {
+        IMediatorConfigurator? configurator = null;
+
+        _ = Assert.Throws<ArgumentNullException>(() =>
+            configurator!.AddRequestInterceptor<TestCommand, string, TestRequestInterceptor>()
+        );
+    }
+
+    [Test]
+    public async Task AddRequestInterceptor_RegistersInterceptorWithScopedLifetime()
+    {
+        var services = new ServiceCollection();
+
+        _ = services.AddPulse(config => config.AddRequestInterceptor<TestCommand, string, TestRequestInterceptor>());
+
+        var descriptor = services.FirstOrDefault(x =>
+            x.ServiceType == typeof(IRequestInterceptor<TestCommand, string>)
+        );
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor).IsNotNull();
+            _ = await Assert.That(descriptor!.ImplementationType).IsEqualTo(typeof(TestRequestInterceptor));
+            _ = await Assert.That(descriptor.Lifetime).IsEqualTo(ServiceLifetime.Scoped);
+        }
+    }
+
+    [Test]
+    public async Task AddRequestInterceptor_WithExplicitLifetime_RegistersInterceptorWithSpecifiedLifetime()
+    {
+        var services = new ServiceCollection();
+
+        _ = services.AddPulse(config =>
+            config.AddRequestInterceptor<TestCommand, string, TestRequestInterceptor>(ServiceLifetime.Singleton)
+        );
+
+        var descriptor = services.FirstOrDefault(x =>
+            x.ServiceType == typeof(IRequestInterceptor<TestCommand, string>)
+        );
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor).IsNotNull();
+            _ = await Assert.That(descriptor!.ImplementationType).IsEqualTo(typeof(TestRequestInterceptor));
+            _ = await Assert.That(descriptor.Lifetime).IsEqualTo(ServiceLifetime.Singleton);
+        }
+    }
+
+    [Test]
+    public async Task AddRequestInterceptor_ReturnsConfigurator()
+    {
+        var services = new ServiceCollection();
+        IMediatorConfigurator? capturedConfig = null;
+        IMediatorConfigurator? result = null;
+
+        _ = services.AddPulse(config =>
+        {
+            capturedConfig = config;
+            result = config.AddRequestInterceptor<TestCommand, string, TestRequestInterceptor>();
+        });
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(capturedConfig).IsNotNull();
+            _ = await Assert.That(result).IsSameReferenceAs(capturedConfig);
+        }
+    }
+
+    [Test]
+    public void AddCommandInterceptor_WithNullConfigurator_ThrowsArgumentNullException()
+    {
+        IMediatorConfigurator? configurator = null;
+
+        _ = Assert.Throws<ArgumentNullException>(() =>
+            configurator!.AddCommandInterceptor<TestCommand, string, TestCommandInterceptor>()
+        );
+    }
+
+    [Test]
+    public async Task AddCommandInterceptor_RegistersInterceptorWithScopedLifetime()
+    {
+        var services = new ServiceCollection();
+
+        _ = services.AddPulse(config => config.AddCommandInterceptor<TestCommand, string, TestCommandInterceptor>());
+
+        var descriptor = services.FirstOrDefault(x =>
+            x.ServiceType == typeof(ICommandInterceptor<TestCommand, string>)
+        );
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor).IsNotNull();
+            _ = await Assert.That(descriptor!.ImplementationType).IsEqualTo(typeof(TestCommandInterceptor));
+            _ = await Assert.That(descriptor.Lifetime).IsEqualTo(ServiceLifetime.Scoped);
+        }
+    }
+
+    [Test]
+    public async Task AddCommandInterceptor_WithExplicitLifetime_RegistersInterceptorWithSpecifiedLifetime()
+    {
+        var services = new ServiceCollection();
+
+        _ = services.AddPulse(config =>
+            config.AddCommandInterceptor<TestCommand, string, TestCommandInterceptor>(ServiceLifetime.Singleton)
+        );
+
+        var descriptor = services.FirstOrDefault(x =>
+            x.ServiceType == typeof(ICommandInterceptor<TestCommand, string>)
+        );
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor).IsNotNull();
+            _ = await Assert.That(descriptor!.ImplementationType).IsEqualTo(typeof(TestCommandInterceptor));
+            _ = await Assert.That(descriptor.Lifetime).IsEqualTo(ServiceLifetime.Singleton);
+        }
+    }
+
+    [Test]
+    public async Task AddCommandInterceptor_ReturnsConfigurator()
+    {
+        var services = new ServiceCollection();
+        IMediatorConfigurator? capturedConfig = null;
+        IMediatorConfigurator? result = null;
+
+        _ = services.AddPulse(config =>
+        {
+            capturedConfig = config;
+            result = config.AddCommandInterceptor<TestCommand, string, TestCommandInterceptor>();
+        });
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(capturedConfig).IsNotNull();
+            _ = await Assert.That(result).IsSameReferenceAs(capturedConfig);
+        }
+    }
+
+    [Test]
+    public void AddQueryInterceptor_WithNullConfigurator_ThrowsArgumentNullException()
+    {
+        IMediatorConfigurator? configurator = null;
+
+        _ = Assert.Throws<ArgumentNullException>(() =>
+            configurator!.AddQueryInterceptor<TestQuery, string, TestQueryInterceptor>()
+        );
+    }
+
+    [Test]
+    public async Task AddQueryInterceptor_RegistersInterceptorWithScopedLifetime()
+    {
+        var services = new ServiceCollection();
+
+        _ = services.AddPulse(config => config.AddQueryInterceptor<TestQuery, string, TestQueryInterceptor>());
+
+        var descriptor = services.FirstOrDefault(x => x.ServiceType == typeof(IQueryInterceptor<TestQuery, string>));
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor).IsNotNull();
+            _ = await Assert.That(descriptor!.ImplementationType).IsEqualTo(typeof(TestQueryInterceptor));
+            _ = await Assert.That(descriptor.Lifetime).IsEqualTo(ServiceLifetime.Scoped);
+        }
+    }
+
+    [Test]
+    public async Task AddQueryInterceptor_WithExplicitLifetime_RegistersInterceptorWithSpecifiedLifetime()
+    {
+        var services = new ServiceCollection();
+
+        _ = services.AddPulse(config =>
+            config.AddQueryInterceptor<TestQuery, string, TestQueryInterceptor>(ServiceLifetime.Singleton)
+        );
+
+        var descriptor = services.FirstOrDefault(x => x.ServiceType == typeof(IQueryInterceptor<TestQuery, string>));
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor).IsNotNull();
+            _ = await Assert.That(descriptor!.ImplementationType).IsEqualTo(typeof(TestQueryInterceptor));
+            _ = await Assert.That(descriptor.Lifetime).IsEqualTo(ServiceLifetime.Singleton);
+        }
+    }
+
+    [Test]
+    public async Task AddQueryInterceptor_ReturnsConfigurator()
+    {
+        var services = new ServiceCollection();
+        IMediatorConfigurator? capturedConfig = null;
+        IMediatorConfigurator? result = null;
+
+        _ = services.AddPulse(config =>
+        {
+            capturedConfig = config;
+            result = config.AddQueryInterceptor<TestQuery, string, TestQueryInterceptor>();
+        });
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(capturedConfig).IsNotNull();
+            _ = await Assert.That(result).IsSameReferenceAs(capturedConfig);
+        }
+    }
+
+    [Test]
+    public void AddEventInterceptor_WithNullConfigurator_ThrowsArgumentNullException()
+    {
+        IMediatorConfigurator? configurator = null;
+
+        _ = Assert.Throws<ArgumentNullException>(() =>
+            configurator!.AddEventInterceptor<TestEvent, TestEventInterceptor>()
+        );
+    }
+
+    [Test]
+    public async Task AddEventInterceptor_RegistersInterceptorWithScopedLifetime()
+    {
+        var services = new ServiceCollection();
+
+        _ = services.AddPulse(config => config.AddEventInterceptor<TestEvent, TestEventInterceptor>());
+
+        var descriptor = services.FirstOrDefault(x => x.ServiceType == typeof(IEventInterceptor<TestEvent>));
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor).IsNotNull();
+            _ = await Assert.That(descriptor!.ImplementationType).IsEqualTo(typeof(TestEventInterceptor));
+            _ = await Assert.That(descriptor.Lifetime).IsEqualTo(ServiceLifetime.Scoped);
+        }
+    }
+
+    [Test]
+    public async Task AddEventInterceptor_WithExplicitLifetime_RegistersInterceptorWithSpecifiedLifetime()
+    {
+        var services = new ServiceCollection();
+
+        _ = services.AddPulse(config =>
+            config.AddEventInterceptor<TestEvent, TestEventInterceptor>(ServiceLifetime.Singleton)
+        );
+
+        var descriptor = services.FirstOrDefault(x => x.ServiceType == typeof(IEventInterceptor<TestEvent>));
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor).IsNotNull();
+            _ = await Assert.That(descriptor!.ImplementationType).IsEqualTo(typeof(TestEventInterceptor));
+            _ = await Assert.That(descriptor.Lifetime).IsEqualTo(ServiceLifetime.Singleton);
+        }
+    }
+
+    [Test]
+    public async Task AddEventInterceptor_ReturnsConfigurator()
+    {
+        var services = new ServiceCollection();
+        IMediatorConfigurator? capturedConfig = null;
+        IMediatorConfigurator? result = null;
+
+        _ = services.AddPulse(config =>
+        {
+            capturedConfig = config;
+            result = config.AddEventInterceptor<TestEvent, TestEventInterceptor>();
+        });
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(capturedConfig).IsNotNull();
+            _ = await Assert.That(result).IsSameReferenceAs(capturedConfig);
+        }
+    }
+
+    [Test]
+    public async Task AddEventInterceptor_AllowsMultipleInterceptorsForSameEvent()
+    {
+        var services = new ServiceCollection();
+
+        _ = services.AddPulse(config =>
+            config
+                .AddEventInterceptor<TestEvent, TestEventInterceptor>()
+                .AddEventInterceptor<TestEvent, AnotherTestEventInterceptor>()
+        );
+
+        var descriptors = services.Where(x => x.ServiceType == typeof(IEventInterceptor<TestEvent>)).ToList();
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptors).Count().IsEqualTo(2);
+            _ = await Assert.That(descriptors.Any(d => d.ImplementationType == typeof(TestEventInterceptor))).IsTrue();
+            _ = await Assert
+                .That(descriptors.Any(d => d.ImplementationType == typeof(AnotherTestEventInterceptor)))
+                .IsTrue();
+        }
+    }
+
+    // Test helper interceptor types
+    private sealed partial class TestRequestInterceptor : IRequestInterceptor<TestCommand, string>
+    {
+        public Task<string> HandleAsync(TestCommand request, Func<TestCommand, Task<string>> handler) =>
+            handler(request);
+    }
+
+    private sealed partial class TestCommandInterceptor : ICommandInterceptor<TestCommand, string>
+    {
+        public Task<string> HandleAsync(TestCommand request, Func<TestCommand, Task<string>> handler) =>
+            handler(request);
+    }
+
+    private sealed partial class TestQueryInterceptor : IQueryInterceptor<TestQuery, string>
+    {
+        public Task<string> HandleAsync(TestQuery request, Func<TestQuery, Task<string>> handler) => handler(request);
+    }
+
+    private sealed partial class TestEventInterceptor : IEventInterceptor<TestEvent>
+    {
+        public Task HandleAsync(TestEvent message, Func<TestEvent, Task> handler) => handler(message);
+    }
+
+    private sealed partial class AnotherTestEventInterceptor : IEventInterceptor<TestEvent>
+    {
+        public Task HandleAsync(TestEvent message, Func<TestEvent, Task> handler) => handler(message);
+    }
 }


### PR DESCRIPTION
Introduce extension methods for registering request, command, query, and event interceptors via both explicit and assembly scanning approaches. Includes AOT-safe registration methods and reflection-based scanning with appropriate warnings for Native AOT/IL trimming. Adds comprehensive XML docs and extensive unit tests for all registration scenarios. Enhances support for cross-cutting concerns in the mediator pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic discovery and registration of interceptors from assemblies
  * Manual registration methods for request, command, query, and event interceptors
  * Multiple assembly scanning strategies (by assembly, marker type, calling/entry/executing)

* **Documentation**
  * Added usage notes and AOT/IL-trimming caveats for the new scanning APIs

* **Tests**
  * Comprehensive unit tests covering scanning, registration lifetimes, chaining, and null checks

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->