### PR TITLE
chore: Refactor interceptors to Interceptors namespace

### DIFF
--- a/src/NetEvolve.Pulse/Interceptors/ActivityAndMetricsEventInterceptor.cs
+++ b/src/NetEvolve.Pulse/Interceptors/ActivityAndMetricsEventInterceptor.cs
@@ -1,9 +1,10 @@
-﻿namespace NetEvolve.Pulse.Internals;
+﻿namespace NetEvolve.Pulse.Interceptors;
 
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using NetEvolve.Pulse.Extensibility;
-using static Defaults.Tags;
+using NetEvolve.Pulse.Internals;
+using static Internals.Defaults.Tags;
 
 /// <summary>
 /// Internal interceptor that adds OpenTelemetry activity tracing and metrics collection for all events.

--- a/src/NetEvolve.Pulse/Interceptors/ActivityAndMetricsRequestInterceptor.cs
+++ b/src/NetEvolve.Pulse/Interceptors/ActivityAndMetricsRequestInterceptor.cs
@@ -1,9 +1,10 @@
-﻿namespace NetEvolve.Pulse.Internals;
+﻿namespace NetEvolve.Pulse.Interceptors;
 
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using NetEvolve.Pulse.Extensibility;
-using static Defaults.Tags;
+using NetEvolve.Pulse.Internals;
+using static Internals.Defaults.Tags;
 
 /// <summary>
 /// Internal interceptor that adds OpenTelemetry activity tracing and metrics collection for all requests.

--- a/src/NetEvolve.Pulse/Internals/MediatorConfigurator.cs
+++ b/src/NetEvolve.Pulse/Internals/MediatorConfigurator.cs
@@ -3,6 +3,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Interceptors;
 
 /// <summary>
 /// Internal implementation of <see cref="IMediatorConfigurator"/> that provides fluent configuration capabilities for the Pulse mediator.

--- a/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/ActivityAndMetricsEventInterceptorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/ActivityAndMetricsEventInterceptorTests.cs
@@ -1,8 +1,8 @@
-namespace NetEvolve.Pulse.Tests.Unit.Internals;
+namespace NetEvolve.Pulse.Tests.Unit.Interceptors;
 
 using System.Diagnostics;
 using NetEvolve.Pulse.Extensibility;
-using NetEvolve.Pulse.Internals;
+using NetEvolve.Pulse.Interceptors;
 using TUnit.Core;
 
 public class ActivityAndMetricsEventInterceptorTests

--- a/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/ActivityAndMetricsRequestInterceptorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/ActivityAndMetricsRequestInterceptorTests.cs
@@ -1,8 +1,9 @@
-namespace NetEvolve.Pulse.Tests.Unit.Internals;
+namespace NetEvolve.Pulse.Tests.Unit.Interceptors;
 
 using System.Diagnostics;
+using NetEvolve.Pulse;
 using NetEvolve.Pulse.Extensibility;
-using NetEvolve.Pulse.Internals;
+using NetEvolve.Pulse.Interceptors;
 using TUnit.Core;
 
 public class ActivityAndMetricsRequestInterceptorTests

--- a/tests/NetEvolve.Pulse.Tests.Unit/Internals/MediatorConfiguratorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Internals/MediatorConfiguratorTests.cs
@@ -3,6 +3,7 @@ namespace NetEvolve.Pulse.Tests.Unit.Internals;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Interceptors;
 using NetEvolve.Pulse.Internals;
 using TUnit.Core;
 

--- a/tests/NetEvolve.Pulse.Tests.Unit/ServiceCollectionExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/ServiceCollectionExtensionsTests.cs
@@ -3,6 +3,7 @@ namespace NetEvolve.Pulse.Tests.Unit;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Interceptors;
 using NetEvolve.Pulse.Internals;
 using TUnit.Core;
 


### PR DESCRIPTION
Moved activity and metrics interceptors and their tests from .Internals to .Interceptors namespace for improved clarity. Updated static imports and references in configuration and test files to match the new organization. This enhances code maintainability and separation of concerns.