### PR TITLE
chore: Add CancellationToken to interceptor HandleAsync methods

### DIFF
--- a/src/NetEvolve.Pulse.Extensibility/IEventInterceptor.cs
+++ b/src/NetEvolve.Pulse.Extensibility/IEventInterceptor.cs
@@ -43,7 +43,7 @@
 ///         _logger = logger;
 ///     }
 ///
-///     public async Task HandleAsync(TEvent message, Func&lt;TEvent, Task&gt; handler)
+///     public async Task HandleAsync(TEvent message, Func&lt;TEvent, Task&gt; handler, CancellationToken cancellationToken = default)
 ///     {
 ///         _logger.LogInformation(
 ///             "Publishing event {EventType} with ID {EventId} at {PublishedAt}",
@@ -92,7 +92,7 @@
 ///         _currentUser = currentUser;
 ///     }
 ///
-///     public async Task HandleAsync(TEvent message, Func&lt;TEvent, Task&gt; handler)
+///     public async Task HandleAsync(TEvent message, Func&lt;TEvent, Task&gt; handler, CancellationToken cancellationToken = default)
 ///     {
 ///         // Create audit entry before handlers execute
 ///         var auditEntry = new AuditEntry
@@ -122,7 +122,7 @@
 ///         _correlationContext = correlationContext;
 ///     }
 ///
-///     public async Task HandleAsync(TEvent message, Func&lt;TEvent, Task&gt; handler)
+///     public async Task HandleAsync(TEvent message, Func&lt;TEvent, Task&gt; handler, CancellationToken cancellationToken = default)
 ///     {
 ///         // Enrich event with correlation ID
 ///         if (string.IsNullOrEmpty(message.CorrelationId))
@@ -152,6 +152,7 @@ public interface IEventInterceptor<TEvent>
     /// </summary>
     /// <param name="message">The event being processed.</param>
     /// <param name="handler">The next handler in the pipeline to invoke. Must be called to continue execution.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    Task HandleAsync(TEvent message, Func<TEvent, Task> handler);
+    Task HandleAsync(TEvent message, Func<TEvent, Task> handler, CancellationToken cancellationToken = default);
 }

--- a/src/NetEvolve.Pulse.Extensibility/IRequestInterceptor.cs
+++ b/src/NetEvolve.Pulse.Extensibility/IRequestInterceptor.cs
@@ -53,7 +53,8 @@
 ///
 ///     public async Task&lt;TResponse&gt; HandleAsync(
 ///         TRequest request,
-///         Func&lt;TRequest, Task&lt;TResponse&gt;&gt; handler)
+///         Func&lt;TRequest, Task&lt;TResponse&gt;&gt; handler,
+///         CancellationToken cancellationToken = default)
 ///     {
 ///         var requestType = typeof(TRequest).Name;
 ///         _logger.LogInformation("Executing {RequestType}", requestType);
@@ -99,7 +100,8 @@
 ///
 ///     public async Task&lt;TResponse&gt; HandleAsync(
 ///         TRequest request,
-///         Func&lt;TRequest, Task&lt;TResponse&gt;&gt; handler)
+///         Func&lt;TRequest, Task&lt;TResponse&gt;&gt; handler,
+///         CancellationToken cancellationToken = default)
 ///     {
 ///         // Validate before calling handler
 ///         var validationResult = await _validator.ValidateAsync(request);
@@ -129,7 +131,8 @@
 ///
 ///     public async Task&lt;TResponse&gt; HandleAsync(
 ///         TRequest request,
-///         Func&lt;TRequest, Task&lt;TResponse&gt;&gt; handler)
+///         Func&lt;TRequest, Task&lt;TResponse&gt;&gt; handler,
+///         CancellationToken cancellationToken = default)
 ///     {
 ///         for (int attempt = 1; attempt &lt;= MaxRetries; attempt++)
 ///         {
@@ -179,6 +182,11 @@ public interface IRequestInterceptor<TRequest, TResponse>
     /// </summary>
     /// <param name="request">The request being processed.</param>
     /// <param name="handler">The next handler in the pipeline to invoke. Must be called to continue execution unless short-circuiting.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>A task representing the asynchronous operation, containing the request response.</returns>
-    Task<TResponse> HandleAsync(TRequest request, Func<TRequest, Task<TResponse>> handler);
+    Task<TResponse> HandleAsync(
+        TRequest request,
+        Func<TRequest, Task<TResponse>> handler,
+        CancellationToken cancellationToken = default
+    );
 }

--- a/src/NetEvolve.Pulse.Polly/Interceptors/PollyEventInterceptor.cs
+++ b/src/NetEvolve.Pulse.Polly/Interceptors/PollyEventInterceptor.cs
@@ -98,18 +98,23 @@ public sealed class PollyEventInterceptor<TEvent> : IEventInterceptor<TEvent>
     /// </summary>
     /// <param name="message">The event message to process.</param>
     /// <param name="handler">The delegate that represents the next step in the interceptor chain, invoking all registered event handlers.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     /// <remarks>
     /// The handler execution (which may invoke multiple event handlers) is wrapped in the Polly pipeline,
     /// applying configured policies such as retry, circuit breaker, timeout, and bulkhead.
     /// If the pipeline is configured with retry, all handlers will be re-executed on failure.
     /// </remarks>
-    public async Task HandleAsync(TEvent message, Func<TEvent, Task> handler)
+    public async Task HandleAsync(
+        TEvent message,
+        Func<TEvent, Task> handler,
+        CancellationToken cancellationToken = default
+    )
     {
         ArgumentNullException.ThrowIfNull(handler);
 
         await _pipeline
-            .ExecuteAsync(async _ => await handler(message).ConfigureAwait(false), CancellationToken.None)
+            .ExecuteAsync(async _ => await handler(message).ConfigureAwait(false), cancellationToken)
             .ConfigureAwait(false);
     }
 }

--- a/src/NetEvolve.Pulse.Polly/Interceptors/PollyRequestInterceptor.cs
+++ b/src/NetEvolve.Pulse.Polly/Interceptors/PollyRequestInterceptor.cs
@@ -99,18 +99,23 @@ public sealed class PollyRequestInterceptor<TRequest, TResponse> : IRequestInter
     /// </summary>
     /// <param name="request">The request to process.</param>
     /// <param name="handler">The delegate that represents the next step in the interceptor chain.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation, containing the response from the handler.</returns>
     /// <remarks>
     /// The handler execution is wrapped in the Polly pipeline, which applies configured policies
     /// such as retry, circuit breaker, timeout, and bulkhead. The pipeline may execute the handler
     /// multiple times (retry), prevent execution (circuit breaker), or throw timeout exceptions.
     /// </remarks>
-    public async Task<TResponse> HandleAsync(TRequest request, Func<TRequest, Task<TResponse>> handler)
+    public async Task<TResponse> HandleAsync(
+        TRequest request,
+        Func<TRequest, Task<TResponse>> handler,
+        CancellationToken cancellationToken = default
+    )
     {
         ArgumentNullException.ThrowIfNull(handler);
 
         return await _pipeline
-            .ExecuteAsync(async _ => await handler(request).ConfigureAwait(false), CancellationToken.None)
+            .ExecuteAsync(async _ => await handler(request).ConfigureAwait(false), cancellationToken)
             .ConfigureAwait(false);
     }
 }

--- a/src/NetEvolve.Pulse/Interceptors/ActivityAndMetricsEventInterceptor.cs
+++ b/src/NetEvolve.Pulse/Interceptors/ActivityAndMetricsEventInterceptor.cs
@@ -75,7 +75,11 @@ internal sealed class ActivityAndMetricsEventInterceptor<TEvent> : IEventInterce
     /// <item>Marks success/failure status in both activity and metrics</item>
     /// </list>
     /// </remarks>
-    public async Task HandleAsync(TEvent message, Func<TEvent, Task> handler)
+    public async Task HandleAsync(
+        TEvent message,
+        Func<TEvent, Task> handler,
+        CancellationToken cancellationToken = default
+    )
     {
         const string eventType = "Event";
         var eventName = typeof(TEvent).Name;

--- a/src/NetEvolve.Pulse/Interceptors/ActivityAndMetricsRequestInterceptor.cs
+++ b/src/NetEvolve.Pulse/Interceptors/ActivityAndMetricsRequestInterceptor.cs
@@ -77,7 +77,11 @@ internal sealed class ActivityAndMetricsRequestInterceptor<TRequest, TResponse>
     /// <item>Marks success/failure status in both activity and metrics</item>
     /// </list>
     /// </remarks>
-    public async Task<TResponse> HandleAsync(TRequest request, Func<TRequest, Task<TResponse>> handler)
+    public async Task<TResponse> HandleAsync(
+        TRequest request,
+        Func<TRequest, Task<TResponse>> handler,
+        CancellationToken cancellationToken = default
+    )
     {
         // Determine request categorization (Command/Query/Request)
         var requestType = GetRequestType(request);

--- a/tests/NetEvolve.Pulse.Tests.Integration/PulseMediatorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/PulseMediatorTests.cs
@@ -317,7 +317,11 @@ public sealed class PulseMediatorTests
 
     private sealed class FirstInterceptor : IRequestInterceptor<OrderCommand, string>
     {
-        public async Task<string> HandleAsync(OrderCommand request, Func<OrderCommand, Task<string>> next)
+        public async Task<string> HandleAsync(
+            OrderCommand request,
+            Func<OrderCommand, Task<string>> next,
+            CancellationToken cancellationToken = default
+        )
         {
             var result = await next(request);
             return $"First->{result}";
@@ -326,7 +330,11 @@ public sealed class PulseMediatorTests
 
     private sealed class SecondInterceptor : IRequestInterceptor<OrderCommand, string>
     {
-        public async Task<string> HandleAsync(OrderCommand request, Func<OrderCommand, Task<string>> next)
+        public async Task<string> HandleAsync(
+            OrderCommand request,
+            Func<OrderCommand, Task<string>> next,
+            CancellationToken cancellationToken = default
+        )
         {
             var result = await next(request);
             return $"Second->{result}";

--- a/tests/NetEvolve.Pulse.Tests.Integration/ServiceCollectionExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/ServiceCollectionExtensionsTests.cs
@@ -225,7 +225,11 @@ public sealed class ServiceCollectionExtensionsTests
     {
         public bool Executed { get; private set; }
 
-        public async Task<TestResponse> HandleAsync(TestCommand request, Func<TestCommand, Task<TestResponse>> next)
+        public async Task<TestResponse> HandleAsync(
+            TestCommand request,
+            Func<TestCommand, Task<TestResponse>> next,
+            CancellationToken cancellationToken = default
+        )
         {
             Executed = true;
             return await next(request);

--- a/tests/NetEvolve.Pulse.Tests.Unit/AssemblyScanningExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/AssemblyScanningExtensionsTests.cs
@@ -595,24 +595,37 @@ public class AssemblyScanningExtensionsTests
     // Test helper interceptor types for assembly scanning
     private sealed partial class ScanTestRequestInterceptor : IRequestInterceptor<ScanTestCommand, string>
     {
-        public Task<string> HandleAsync(ScanTestCommand request, Func<ScanTestCommand, Task<string>> handler) =>
-            handler(request);
+        public Task<string> HandleAsync(
+            ScanTestCommand request,
+            Func<ScanTestCommand, Task<string>> handler,
+            CancellationToken cancellationToken = default
+        ) => handler(request);
     }
 
     private sealed partial class ScanTestCommandInterceptor : ICommandInterceptor<ScanTestCommand, string>
     {
-        public Task<string> HandleAsync(ScanTestCommand request, Func<ScanTestCommand, Task<string>> handler) =>
-            handler(request);
+        public Task<string> HandleAsync(
+            ScanTestCommand request,
+            Func<ScanTestCommand, Task<string>> handler,
+            CancellationToken cancellationToken = default
+        ) => handler(request);
     }
 
     private sealed partial class ScanTestQueryInterceptor : IQueryInterceptor<ScanTestQuery, string>
     {
-        public Task<string> HandleAsync(ScanTestQuery request, Func<ScanTestQuery, Task<string>> handler) =>
-            handler(request);
+        public Task<string> HandleAsync(
+            ScanTestQuery request,
+            Func<ScanTestQuery, Task<string>> handler,
+            CancellationToken cancellationToken = default
+        ) => handler(request);
     }
 
     private sealed partial class ScanTestEventInterceptor : IEventInterceptor<ScanTestEvent>
     {
-        public Task HandleAsync(ScanTestEvent message, Func<ScanTestEvent, Task> handler) => handler(message);
+        public Task HandleAsync(
+            ScanTestEvent message,
+            Func<ScanTestEvent, Task> handler,
+            CancellationToken cancellationToken = default
+        ) => handler(message);
     }
 }

--- a/tests/NetEvolve.Pulse.Tests.Unit/HandlerRegistrationExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/HandlerRegistrationExtensionsTests.cs
@@ -660,28 +660,46 @@ public class HandlerRegistrationExtensionsTests
     // Test helper interceptor types
     private sealed partial class TestRequestInterceptor : IRequestInterceptor<TestCommand, string>
     {
-        public Task<string> HandleAsync(TestCommand request, Func<TestCommand, Task<string>> handler) =>
-            handler(request);
+        public Task<string> HandleAsync(
+            TestCommand request,
+            Func<TestCommand, Task<string>> handler,
+            CancellationToken cancellationToken = default
+        ) => handler(request);
     }
 
     private sealed partial class TestCommandInterceptor : ICommandInterceptor<TestCommand, string>
     {
-        public Task<string> HandleAsync(TestCommand request, Func<TestCommand, Task<string>> handler) =>
-            handler(request);
+        public Task<string> HandleAsync(
+            TestCommand request,
+            Func<TestCommand, Task<string>> handler,
+            CancellationToken cancellationToken = default
+        ) => handler(request);
     }
 
     private sealed partial class TestQueryInterceptor : IQueryInterceptor<TestQuery, string>
     {
-        public Task<string> HandleAsync(TestQuery request, Func<TestQuery, Task<string>> handler) => handler(request);
+        public Task<string> HandleAsync(
+            TestQuery request,
+            Func<TestQuery, Task<string>> handler,
+            CancellationToken cancellationToken = default
+        ) => handler(request);
     }
 
     private sealed partial class TestEventInterceptor : IEventInterceptor<TestEvent>
     {
-        public Task HandleAsync(TestEvent message, Func<TestEvent, Task> handler) => handler(message);
+        public Task HandleAsync(
+            TestEvent message,
+            Func<TestEvent, Task> handler,
+            CancellationToken cancellationToken = default
+        ) => handler(message);
     }
 
     private sealed partial class AnotherTestEventInterceptor : IEventInterceptor<TestEvent>
     {
-        public Task HandleAsync(TestEvent message, Func<TestEvent, Task> handler) => handler(message);
+        public Task HandleAsync(
+            TestEvent message,
+            Func<TestEvent, Task> handler,
+            CancellationToken cancellationToken = default
+        ) => handler(message);
     }
 }

--- a/tests/NetEvolve.Pulse.Tests.Unit/Internals/PulseMediatorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Internals/PulseMediatorTests.cs
@@ -425,7 +425,11 @@ public class PulseMediatorTests
     {
         public List<TestCommand> InterceptedCommands { get; } = [];
 
-        public async Task<string> HandleAsync(TestCommand request, Func<TestCommand, Task<string>> handler)
+        public async Task<string> HandleAsync(
+            TestCommand request,
+            Func<TestCommand, Task<string>> handler,
+            CancellationToken cancellationToken = default
+        )
         {
             InterceptedCommands.Add(request);
             return await handler(request);
@@ -436,7 +440,11 @@ public class PulseMediatorTests
     {
         public List<TestQuery> InterceptedQueries { get; } = [];
 
-        public async Task<string> HandleAsync(TestQuery request, Func<TestQuery, Task<string>> handler)
+        public async Task<string> HandleAsync(
+            TestQuery request,
+            Func<TestQuery, Task<string>> handler,
+            CancellationToken cancellationToken = default
+        )
         {
             InterceptedQueries.Add(request);
             return await handler(request);
@@ -447,7 +455,11 @@ public class PulseMediatorTests
     {
         public List<TestEvent> InterceptedEvents { get; } = [];
 
-        public async Task HandleAsync(TestEvent message, Func<TestEvent, Task> handler)
+        public async Task HandleAsync(
+            TestEvent message,
+            Func<TestEvent, Task> handler,
+            CancellationToken cancellationToken = default
+        )
         {
             InterceptedEvents.Add(message);
             await handler(message);


### PR DESCRIPTION
Introduce CancellationToken parameter (with default) to all HandleAsync methods in IEventInterceptor<TEvent> and IRequestInterceptor<TRequest, TResponse> interfaces, their implementations, and usages. Update PulseMediator and all related test classes to propagate cancellation tokens through the interceptor pipeline, enabling cooperative cancellation for all request and event handling operations. Update XML docs and method signatures accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cancellation token support to the mediator pipeline, enabling graceful cancellation of long-running operations across requests, events, and responses.

* **Improvements**
  * Polly-based interceptors now respect cancellation requests, improving operational control and reliability during pipeline execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->