### PR TITLE
refactor: telemetry to use shared ActivitySource and Meter

### DIFF
--- a/src/NetEvolve.Pulse/Interceptors/ActivityAndMetricsEventInterceptor.cs
+++ b/src/NetEvolve.Pulse/Interceptors/ActivityAndMetricsEventInterceptor.cs
@@ -16,19 +16,9 @@ internal sealed class ActivityAndMetricsEventInterceptor<TEvent> : IEventInterce
     where TEvent : IEvent
 {
     /// <summary>
-    /// The activity source for creating distributed tracing activities.
-    /// </summary>
-    private static readonly ActivitySource _activitySource = new ActivitySource("NetEvolve.Pulse", Defaults.Version);
-
-    /// <summary>
-    /// The meter for creating metrics instruments.
-    /// </summary>
-    private static readonly Meter _meter = new Meter("NetEvolve.Pulse", Defaults.Version);
-
-    /// <summary>
     /// Counter tracking the total number of events processed, tagged by event type.
     /// </summary>
-    private static readonly Counter<long> _eventCounter = _meter.CreateCounter<long>(
+    private static readonly Counter<long> EventCounter = Defaults.Meter.CreateCounter<long>(
         "pulse.events.total",
         "events",
         "Total number of events processed."
@@ -37,7 +27,7 @@ internal sealed class ActivityAndMetricsEventInterceptor<TEvent> : IEventInterce
     /// <summary>
     /// Counter tracking the total number of event errors, tagged by event type.
     /// </summary>
-    private static readonly Counter<long> _errorsCounter = _meter.CreateCounter<long>(
+    private static readonly Counter<long> ErrorsCounter = Defaults.Meter.CreateCounter<long>(
         "pulse.event.errors",
         "errors",
         "Total number of event errors."
@@ -46,7 +36,7 @@ internal sealed class ActivityAndMetricsEventInterceptor<TEvent> : IEventInterce
     /// <summary>
     /// Histogram measuring event processing duration in milliseconds, with percentile distributions.
     /// </summary>
-    private static readonly Histogram<double> _eventDurationHistogram = _meter.CreateHistogram<double>(
+    private static readonly Histogram<double> EventDurationHistogram = Defaults.Meter.CreateHistogram<double>(
         "pulse.event.duration",
         "ms",
         "Duration of event processing in milliseconds."
@@ -87,7 +77,7 @@ internal sealed class ActivityAndMetricsEventInterceptor<TEvent> : IEventInterce
         // Prepare tags for consistent labeling across activity and metrics
         var tags = new TagList { { EventType, eventType }, { EventName, eventName } };
 
-        using var activity = _activitySource.StartActivity(
+        using var activity = Defaults.ActivitySource.StartActivity(
             $"{eventType}.{eventName}",
             ActivityKind.Internal,
             null,
@@ -100,7 +90,7 @@ internal sealed class ActivityAndMetricsEventInterceptor<TEvent> : IEventInterce
             ?.SetStartTime(startTime.UtcDateTime)
             .SetTag(EventCorrelationId, message.CorrelationId)
             .SetTag(EventTimestamp, startTime);
-        _eventCounter.Add(1, tags);
+        EventCounter.Add(1, tags);
 
         try
         {
@@ -117,7 +107,7 @@ internal sealed class ActivityAndMetricsEventInterceptor<TEvent> : IEventInterce
                 .SetTag(Success, true);
 
             // Record successful execution duration
-            _eventDurationHistogram.Record((endTime - startTime).TotalMilliseconds, [.. tags, new(Success, true)]);
+            EventDurationHistogram.Record((endTime - startTime).TotalMilliseconds, [.. tags, new(Success, true)]);
         }
         catch (Exception ex)
         {
@@ -134,8 +124,8 @@ internal sealed class ActivityAndMetricsEventInterceptor<TEvent> : IEventInterce
                 .SetTag(Success, false);
 
             // Increment error counters and record failed execution duration
-            _errorsCounter.Add(1, tags);
-            _eventDurationHistogram.Record((errorTime - startTime).TotalMilliseconds, [.. tags, new(Success, false)]);
+            ErrorsCounter.Add(1, tags);
+            EventDurationHistogram.Record((errorTime - startTime).TotalMilliseconds, [.. tags, new(Success, false)]);
 
             throw;
         }

--- a/src/NetEvolve.Pulse/Interceptors/ActivityAndMetricsRequestInterceptor.cs
+++ b/src/NetEvolve.Pulse/Interceptors/ActivityAndMetricsRequestInterceptor.cs
@@ -18,19 +18,9 @@ internal sealed class ActivityAndMetricsRequestInterceptor<TRequest, TResponse>
     where TRequest : IRequest<TResponse>
 {
     /// <summary>
-    /// The activity source for creating distributed tracing activities.
-    /// </summary>
-    private static readonly ActivitySource _activitySource = new ActivitySource("NetEvolve.Pulse", Defaults.Version);
-
-    /// <summary>
-    /// The meter for creating metrics instruments.
-    /// </summary>
-    private static readonly Meter _meter = new Meter("NetEvolve.Pulse", Defaults.Version);
-
-    /// <summary>
     /// Counter tracking the total number of requests processed, tagged by request type.
     /// </summary>
-    private static readonly Counter<long> _requestCounter = _meter.CreateCounter<long>(
+    private static readonly Counter<long> RequestCounter = Defaults.Meter.CreateCounter<long>(
         "pulse.requests.total",
         "requests",
         "Total number of requests processed."
@@ -39,7 +29,7 @@ internal sealed class ActivityAndMetricsRequestInterceptor<TRequest, TResponse>
     /// <summary>
     /// Counter tracking the total number of request errors, tagged by request type.
     /// </summary>
-    private static readonly Counter<long> _errorsCounter = _meter.CreateCounter<long>(
+    private static readonly Counter<long> ErrorsCounter = Defaults.Meter.CreateCounter<long>(
         "pulse.request.errors",
         "errors",
         "Total number of request errors."
@@ -48,7 +38,7 @@ internal sealed class ActivityAndMetricsRequestInterceptor<TRequest, TResponse>
     /// <summary>
     /// Histogram measuring request processing duration in milliseconds, with percentile distributions.
     /// </summary>
-    private static readonly Histogram<double> _requestDurationHistogram = _meter.CreateHistogram<double>(
+    private static readonly Histogram<double> RequestDurationHistogram = Defaults.Meter.CreateHistogram<double>(
         "pulse.request.duration",
         "ms",
         "Duration of request processing in milliseconds."
@@ -96,7 +86,7 @@ internal sealed class ActivityAndMetricsRequestInterceptor<TRequest, TResponse>
             { ResponseType, responseType },
         };
 
-        using var activity = _activitySource.StartActivity(
+        using var activity = Defaults.ActivitySource.StartActivity(
             $"{requestType}.{requestName}",
             ActivityKind.Internal,
             null,
@@ -109,7 +99,7 @@ internal sealed class ActivityAndMetricsRequestInterceptor<TRequest, TResponse>
             ?.SetStartTime(startTime.UtcDateTime)
             .SetTag(RequestCorrelationId, request.CorrelationId)
             .SetTag(RequestTimestamp, startTime);
-        _requestCounter.Add(1, tags);
+        RequestCounter.Add(1, tags);
 
         try
         {
@@ -126,7 +116,7 @@ internal sealed class ActivityAndMetricsRequestInterceptor<TRequest, TResponse>
                 .SetTag(Success, true);
 
             // Record successful execution duration
-            _requestDurationHistogram.Record((startTime - endTime).TotalMilliseconds, [.. tags, new(Success, true)]);
+            RequestDurationHistogram.Record((startTime - endTime).TotalMilliseconds, [.. tags, new(Success, true)]);
 
             return response;
         }
@@ -145,8 +135,8 @@ internal sealed class ActivityAndMetricsRequestInterceptor<TRequest, TResponse>
                 .SetTag(Success, false);
 
             // Increment error counters and record failed execution duration
-            _errorsCounter.Add(1, tags);
-            _requestDurationHistogram.Record((startTime - errorTime).TotalMilliseconds, [.. tags, new(Success, false)]);
+            ErrorsCounter.Add(1, tags);
+            RequestDurationHistogram.Record((startTime - errorTime).TotalMilliseconds, [.. tags, new(Success, false)]);
 
             throw;
         }

--- a/src/NetEvolve.Pulse/Internals/Defaults.cs
+++ b/src/NetEvolve.Pulse/Internals/Defaults.cs
@@ -1,10 +1,43 @@
 ﻿namespace NetEvolve.Pulse.Internals;
 
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
 /// <summary>
 /// Provides default values and constants used throughout the Pulse mediator implementation.
 /// </summary>
 internal static class Defaults
 {
+    /// <summary>
+    /// Lazy-initialized backing field for the <see cref="ActivitySource"/> instance.
+    /// Thread-safe initialization is ensured via <see cref="LazyThreadSafetyMode.ExecutionAndPublication"/>.
+    /// </summary>
+    private static readonly Lazy<ActivitySource> LazyActivitySource = new(
+        () => new ActivitySource("NetEvolve.Pulse", Version),
+        LazyThreadSafetyMode.ExecutionAndPublication
+    );
+
+    /// <summary>
+    /// Gets the <see cref="System.Diagnostics.ActivitySource"/> used by the Pulse mediator for OpenTelemetry distributed tracing.
+    /// The source name is <c>"NetEvolve.Pulse"</c> and the version matches the assembly version.
+    /// </summary>
+    public static ActivitySource ActivitySource => LazyActivitySource.Value;
+
+    /// <summary>
+    /// Lazy-initialized backing field for the <see cref="Meter"/> instance.
+    /// Thread-safe initialization is ensured via <see cref="LazyThreadSafetyMode.ExecutionAndPublication"/>.
+    /// </summary>
+    private static readonly Lazy<Meter> LazyMeter = new(
+        () => new Meter("NetEvolve.Pulse", Version),
+        LazyThreadSafetyMode.ExecutionAndPublication
+    );
+
+    /// <summary>
+    /// Gets the <see cref="System.Diagnostics.Metrics.Meter"/> used by the Pulse mediator for metrics collection.
+    /// The meter name is <c>"NetEvolve.Pulse"</c> and the version matches the assembly version.
+    /// </summary>
+    public static Meter Meter => LazyMeter.Value;
+
     /// <summary>
     /// Gets the version of the Pulse library, extracted from the assembly's version information.
     /// This version is used for activity source and meter naming in telemetry.


### PR DESCRIPTION
Refactored interceptors to use lazily-initialized, shared ActivitySource and Meter instances from the Defaults class. Updated metric instrument fields to use PascalCase and reference Defaults.Meter. Ensured thread-safe, singleton initialization for telemetry sources, promoting consistency and efficiency in OpenTelemetry instrumentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated telemetry instrumentation sources across interceptors to use centralized defaults, ensuring consistent metrics and activity tracking throughout the library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->