### PR TITLE
chore(deps): Update TUnit packages and fix pulse.success assertions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,8 +28,8 @@
     <PackageVersion Include="Polly.Core" Version="8.6.6" />
     <PackageVersion Include="Testcontainers" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.MsSql" Version="4.11.0" />
-    <PackageVersion Include="TUnit" Version="1.12.147" />
-    <PackageVersion Include="Verify.TUnit" Version="31.10.0" />
+    <PackageVersion Include="TUnit" Version="1.21.24" />
+    <PackageVersion Include="Verify.TUnit" Version="31.13.5" />
   </ItemGroup>
   <ItemGroup Label="TargetFramework .NET 8" Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.25" />

--- a/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/ActivityAndMetricsEventInterceptorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/ActivityAndMetricsEventInterceptorTests.cs
@@ -71,7 +71,9 @@ public class ActivityAndMetricsEventInterceptorTests
         {
             _ = await Assert.That(capturedActivity).IsNotNull();
             _ = await Assert.That(capturedActivity!.Status).IsEqualTo(ActivityStatusCode.Ok);
-            _ = await Assert.That(capturedActivity.GetTagItem("pulse.success")).IsEqualTo(true);
+#pragma warning disable CS8605 // Unboxing a possibly null value.
+            _ = await Assert.That((bool)capturedActivity.GetTagItem("pulse.success")).IsTrue();
+#pragma warning restore CS8605 // Unboxing a possibly null value.
         }
     }
 
@@ -104,7 +106,9 @@ public class ActivityAndMetricsEventInterceptorTests
             _ = await Assert.That(capturedActivity).IsNotNull();
             _ = await Assert.That(capturedActivity!.Status).IsEqualTo(ActivityStatusCode.Error);
             _ = await Assert.That(capturedActivity.StatusDescription).IsEqualTo("Test exception");
-            _ = await Assert.That(capturedActivity.GetTagItem("pulse.success")).IsEqualTo(false);
+#pragma warning disable CS8605 // Unboxing a possibly null value.
+            _ = await Assert.That((bool)capturedActivity.GetTagItem("pulse.success")).IsFalse();
+#pragma warning restore CS8605 // Unboxing a possibly null value.
             _ = await Assert
                 .That(capturedActivity.GetTagItem("pulse.exception.type"))
                 .IsEqualTo("System.InvalidOperationException");

--- a/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/ActivityAndMetricsRequestInterceptorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/ActivityAndMetricsRequestInterceptorTests.cs
@@ -136,7 +136,9 @@ public class ActivityAndMetricsRequestInterceptorTests
         {
             _ = await Assert.That(capturedActivity).IsNotNull();
             _ = await Assert.That(capturedActivity!.Status).IsEqualTo(ActivityStatusCode.Ok);
-            _ = await Assert.That(capturedActivity.GetTagItem("pulse.success")).IsEqualTo(true);
+#pragma warning disable CS8605 // Unboxing a possibly null value.
+            _ = await Assert.That((bool)capturedActivity.GetTagItem("pulse.success")).IsTrue();
+#pragma warning restore CS8605 // Unboxing a possibly null value.
         }
     }
 
@@ -169,7 +171,9 @@ public class ActivityAndMetricsRequestInterceptorTests
             _ = await Assert.That(capturedActivity).IsNotNull();
             _ = await Assert.That(capturedActivity!.Status).IsEqualTo(ActivityStatusCode.Error);
             _ = await Assert.That(capturedActivity.StatusDescription).IsEqualTo("Test exception");
-            _ = await Assert.That(capturedActivity.GetTagItem("pulse.success")).IsEqualTo(false);
+#pragma warning disable CS8605 // Unboxing a possibly null value.
+            _ = await Assert.That((bool)capturedActivity.GetTagItem("pulse.success")).IsFalse();
+#pragma warning restore CS8605 // Unboxing a possibly null value.
             _ = await Assert
                 .That(capturedActivity.GetTagItem("pulse.exception.type"))
                 .IsEqualTo("System.InvalidOperationException");


### PR DESCRIPTION
Updated TUnit and Verify.TUnit package versions. Refactored test assertions for "pulse.success" tags to explicitly unbox values to bool and use IsTrue/IsFalse, suppressing CS8605 warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing framework dependencies (`TUnit` and `Verify.TUnit` to latest versions) to maintain compatibility and performance with the latest testing tooling.
  * Enhanced test implementation for improved reliability and warning suppression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->