### PR TITLE
fix: request duration calculation for metrics recording

### DIFF
--- a/src/NetEvolve.Pulse/Interceptors/ActivityAndMetricsRequestInterceptor.cs
+++ b/src/NetEvolve.Pulse/Interceptors/ActivityAndMetricsRequestInterceptor.cs
@@ -116,7 +116,7 @@ internal sealed class ActivityAndMetricsRequestInterceptor<TRequest, TResponse>
                 .SetTag(Success, true);
 
             // Record successful execution duration
-            RequestDurationHistogram.Record((startTime - endTime).TotalMilliseconds, [.. tags, new(Success, true)]);
+            RequestDurationHistogram.Record((endTime - startTime).TotalMilliseconds, [.. tags, new(Success, true)]);
 
             return response;
         }
@@ -136,7 +136,7 @@ internal sealed class ActivityAndMetricsRequestInterceptor<TRequest, TResponse>
 
             // Increment error counters and record failed execution duration
             ErrorsCounter.Add(1, tags);
-            RequestDurationHistogram.Record((startTime - errorTime).TotalMilliseconds, [.. tags, new(Success, false)]);
+            RequestDurationHistogram.Record((errorTime - startTime).TotalMilliseconds, [.. tags, new(Success, false)]);
 
             throw;
         }


### PR DESCRIPTION
Previously, request duration was calculated by subtracting the end or error time from the start time, which could result in negative values. This commit corrects the calculation to subtract the start time from the end or error time, ensuring accurate and positive duration metrics for both successful and failed requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed inaccurate request duration calculation in metrics tracking. Request durations are now recorded correctly as positive values, ensuring accurate performance measurement and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->