### PR TITLE
fix(docs): Remove obsolete upgrade notes from interceptor XML docs

### DIFF
--- a/src/NetEvolve.Pulse.Extensibility/IEventInterceptor.cs
+++ b/src/NetEvolve.Pulse.Extensibility/IEventInterceptor.cs
@@ -20,12 +20,6 @@
 /// <item><description>Event filtering or routing</description></item>
 /// <item><description>Metrics and monitoring</description></item>
 /// </list>
-/// <para><strong>⚠️ Upgrade Notes:</strong></para>
-/// <para>The <paramref name="handler"/> delegate signature changed from <c>Func&lt;TEvent, Task&gt;</c>
-/// to <c>Func&lt;TEvent, CancellationToken, Task&gt;</c>. This is a <strong>breaking change</strong>:
-/// all existing interceptor implementations must update their <c>HandleAsync</c> overrides to pass
-/// the <c>cancellationToken</c> argument when invoking the handler, i.e.
-/// <c>await handler(message, cancellationToken)</c> instead of <c>await handler(message)</c>.</para>
 /// <para><strong>Best Practices:</strong></para>
 /// <list type="bullet">
 /// <item><description>Keep interceptors lightweight</description></item>

--- a/src/NetEvolve.Pulse.Extensibility/IRequestInterceptor.cs
+++ b/src/NetEvolve.Pulse.Extensibility/IRequestInterceptor.cs
@@ -28,12 +28,6 @@
 /// <item><description>Exception handling and retry logic</description></item>
 /// <item><description>Request/response transformation</description></item>
 /// </list>
-/// <para><strong>⚠️ Upgrade Notes:</strong></para>
-/// <para>The <paramref name="handler"/> delegate signature changed from <c>Func&lt;TRequest, Task&lt;TResponse&gt;&gt;</c>
-/// to <c>Func&lt;TRequest, CancellationToken, Task&lt;TResponse&gt;&gt;</c>. This is a <strong>breaking change</strong>:
-/// all existing interceptor implementations must update their <c>HandleAsync</c> overrides to forward
-/// the <c>cancellationToken</c> when invoking the handler, i.e.
-/// <c>await handler(request, cancellationToken)</c> instead of <c>await handler(request)</c>.</para>
 /// <para><strong>Best Practices:</strong></para>
 /// <list type="bullet">
 /// <item><description>Keep interceptors focused on a single concern</description></item>


### PR DESCRIPTION
Removed "Upgrade Notes" sections from IEventInterceptor.cs and IRequestInterceptor.cs XML documentation. These notes about previous breaking changes to handler delegate signatures are no longer relevant. All other documentation remains intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed upgrade notes from event and request interceptor interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->