### PR TITLE
feat: Update event dispatcher invoker to support cancellation

### DIFF
--- a/src/NetEvolve.Pulse.Extensibility/IEventDispatcher.cs
+++ b/src/NetEvolve.Pulse.Extensibility/IEventDispatcher.cs
@@ -68,6 +68,7 @@ public interface IEventDispatcher
     /// <param name="invoker">
     /// A delegate that invokes a single handler with the event.
     /// This delegate wraps handler invocation with interceptor pipeline execution and error handling.
+    /// The delegate receives the handler, the event message, and a cancellation token.
     /// </param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>A task representing the asynchronous dispatch operation.</returns>
@@ -90,7 +91,7 @@ public interface IEventDispatcher
     Task DispatchAsync<TEvent>(
         TEvent message,
         IEnumerable<IEventHandler<TEvent>> handlers,
-        Func<IEventHandler<TEvent>, TEvent, Task> invoker,
+        Func<IEventHandler<TEvent>, TEvent, CancellationToken, Task> invoker,
         CancellationToken cancellationToken
     )
         where TEvent : IEvent;

--- a/src/NetEvolve.Pulse.Extensibility/IOutboxRepository.cs
+++ b/src/NetEvolve.Pulse.Extensibility/IOutboxRepository.cs
@@ -64,7 +64,7 @@ public interface IOutboxRepository
             .ForEachAsync(
                 messageIds,
                 cancellationToken,
-                async (id, ct) => await MarkAsCompletedAsync(id, ct).ConfigureAwait(false)
+                async (id, token) => await MarkAsCompletedAsync(id, token).ConfigureAwait(false)
             )
             .ConfigureAwait(false);
 
@@ -99,7 +99,7 @@ public interface IOutboxRepository
             .ForEachAsync(
                 messageIds,
                 cancellationToken,
-                async (id, ct) => await MarkAsFailedAsync(id, errorMessage, ct).ConfigureAwait(false)
+                async (id, token) => await MarkAsFailedAsync(id, errorMessage, token).ConfigureAwait(false)
             )
             .ConfigureAwait(false);
 
@@ -128,7 +128,7 @@ public interface IOutboxRepository
             .ForEachAsync(
                 messageIds,
                 cancellationToken,
-                async (id, ct) => await MarkAsDeadLetterAsync(id, errorMessage, ct).ConfigureAwait(false)
+                async (id, token) => await MarkAsDeadLetterAsync(id, errorMessage, token).ConfigureAwait(false)
             )
             .ConfigureAwait(false);
 

--- a/src/NetEvolve.Pulse.Polly/Interceptors/PollyEventInterceptor.cs
+++ b/src/NetEvolve.Pulse.Polly/Interceptors/PollyEventInterceptor.cs
@@ -114,7 +114,7 @@ public sealed class PollyEventInterceptor<TEvent> : IEventInterceptor<TEvent>
         ArgumentNullException.ThrowIfNull(handler);
 
         await _pipeline
-            .ExecuteAsync(async ct => await handler(message, ct).ConfigureAwait(false), cancellationToken)
+            .ExecuteAsync(async token => await handler(message, token).ConfigureAwait(false), cancellationToken)
             .ConfigureAwait(false);
     }
 }

--- a/src/NetEvolve.Pulse.Polly/Interceptors/PollyRequestInterceptor.cs
+++ b/src/NetEvolve.Pulse.Polly/Interceptors/PollyRequestInterceptor.cs
@@ -115,7 +115,7 @@ public sealed class PollyRequestInterceptor<TRequest, TResponse> : IRequestInter
         ArgumentNullException.ThrowIfNull(handler);
 
         return await _pipeline
-            .ExecuteAsync(async ct => await handler(request, ct).ConfigureAwait(false), cancellationToken)
+            .ExecuteAsync(async token => await handler(request, token).ConfigureAwait(false), cancellationToken)
             .ConfigureAwait(false);
     }
 }

--- a/src/NetEvolve.Pulse.Polly/PollyMediatorConfiguratorExtensions.cs
+++ b/src/NetEvolve.Pulse.Polly/PollyMediatorConfiguratorExtensions.cs
@@ -111,10 +111,12 @@ public static class PollyMediatorConfiguratorExtensions
         ArgumentNullException.ThrowIfNull(configurator);
         ArgumentNullException.ThrowIfNull(configure);
 
+        var typeOfIRequestInterceptor = typeof(IRequestInterceptor<TRequest, TResponse>);
+        var typeOfPollyInterceptor = typeof(PollyRequestInterceptor<TRequest, TResponse>);
+
         // Remove existing interceptor registration
         var existingInterceptor = configurator.Services.FirstOrDefault(d =>
-            d.ServiceType == typeof(IRequestInterceptor<TRequest, TResponse>)
-            && d.ImplementationType == typeof(PollyRequestInterceptor<TRequest, TResponse>)
+            d.ServiceType == typeOfIRequestInterceptor && d.ImplementationType == typeOfPollyInterceptor
         );
         if (existingInterceptor is not null)
         {
@@ -126,7 +128,7 @@ public static class PollyMediatorConfiguratorExtensions
             new ServiceDescriptor(
                 typeof(ResiliencePipeline<TResponse>),
                 typeof(TRequest),
-                (sp, key) =>
+                (_, _) =>
                 {
                     var builder = new ResiliencePipelineBuilder<TResponse>();
                     configure(builder);
@@ -137,13 +139,7 @@ public static class PollyMediatorConfiguratorExtensions
         );
 
         // Register the interceptor
-        configurator.Services.Add(
-            new ServiceDescriptor(
-                typeof(IRequestInterceptor<TRequest, TResponse>),
-                typeof(PollyRequestInterceptor<TRequest, TResponse>),
-                lifetime
-            )
-        );
+        configurator.Services.Add(new ServiceDescriptor(typeOfIRequestInterceptor, typeOfPollyInterceptor, lifetime));
 
         return configurator;
     }

--- a/src/NetEvolve.Pulse.SqlServer/SqlServerOutboxRepository.cs
+++ b/src/NetEvolve.Pulse.SqlServer/SqlServerOutboxRepository.cs
@@ -217,7 +217,7 @@ public sealed class SqlServerOutboxRepository : IOutboxRepository
             .ForEachAsync(
                 messageIds,
                 cancellationToken,
-                async (id, ct) => await MarkAsFailedAsync(id, errorMessage, ct).ConfigureAwait(false)
+                async (id, token) => await MarkAsFailedAsync(id, errorMessage, token).ConfigureAwait(false)
             )
             .ConfigureAwait(false);
 

--- a/src/NetEvolve.Pulse/Dispatchers/ParallelEventDispatcher.cs
+++ b/src/NetEvolve.Pulse/Dispatchers/ParallelEventDispatcher.cs
@@ -49,7 +49,7 @@ public sealed class ParallelEventDispatcher : IEventDispatcher
     public async Task DispatchAsync<TEvent>(
         TEvent message,
         IEnumerable<IEventHandler<TEvent>> handlers,
-        Func<IEventHandler<TEvent>, TEvent, Task> invoker,
+        Func<IEventHandler<TEvent>, TEvent, CancellationToken, Task> invoker,
         CancellationToken cancellationToken
     )
         where TEvent : IEvent
@@ -60,11 +60,11 @@ public sealed class ParallelEventDispatcher : IEventDispatcher
             .ForEachAsync(
                 handlers,
                 cancellationToken,
-                async (handler, _) =>
+                async (handler, token) =>
                 {
                     try
                     {
-                        await invoker(handler, message).ConfigureAwait(false);
+                        await invoker(handler, message, token).ConfigureAwait(false);
                     }
                     catch (Exception ex)
                     {

--- a/src/NetEvolve.Pulse/Dispatchers/PrioritizedEventDispatcher.cs
+++ b/src/NetEvolve.Pulse/Dispatchers/PrioritizedEventDispatcher.cs
@@ -61,7 +61,7 @@ public sealed class PrioritizedEventDispatcher : IEventDispatcher
     public async Task DispatchAsync<TEvent>(
         TEvent message,
         IEnumerable<IEventHandler<TEvent>> handlers,
-        Func<IEventHandler<TEvent>, TEvent, Task> invoker,
+        Func<IEventHandler<TEvent>, TEvent, CancellationToken, Task> invoker,
         CancellationToken cancellationToken
     )
         where TEvent : IEvent
@@ -78,7 +78,7 @@ public sealed class PrioritizedEventDispatcher : IEventDispatcher
         foreach (var handler in orderedHandlers)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await invoker(handler, message).ConfigureAwait(false);
+            await invoker(handler, message, cancellationToken).ConfigureAwait(false);
         }
     }
 

--- a/src/NetEvolve.Pulse/Dispatchers/RateLimitedEventDispatcher.cs
+++ b/src/NetEvolve.Pulse/Dispatchers/RateLimitedEventDispatcher.cs
@@ -95,7 +95,7 @@ public sealed class RateLimitedEventDispatcher : IEventDispatcher, IDisposable
     public async Task DispatchAsync<TEvent>(
         TEvent message,
         IEnumerable<IEventHandler<TEvent>> handlers,
-        Func<IEventHandler<TEvent>, TEvent, Task> invoker,
+        Func<IEventHandler<TEvent>, TEvent, CancellationToken, Task> invoker,
         CancellationToken cancellationToken
     )
         where TEvent : IEvent
@@ -107,7 +107,7 @@ public sealed class RateLimitedEventDispatcher : IEventDispatcher, IDisposable
             await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                await invoker(handler, message).ConfigureAwait(false);
+                await invoker(handler, message, cancellationToken).ConfigureAwait(false);
             }
             finally
             {

--- a/src/NetEvolve.Pulse/Dispatchers/SequentialEventDispatcher.cs
+++ b/src/NetEvolve.Pulse/Dispatchers/SequentialEventDispatcher.cs
@@ -49,7 +49,7 @@ public sealed class SequentialEventDispatcher : IEventDispatcher
     public async Task DispatchAsync<TEvent>(
         TEvent message,
         IEnumerable<IEventHandler<TEvent>> handlers,
-        Func<IEventHandler<TEvent>, TEvent, Task> invoker,
+        Func<IEventHandler<TEvent>, TEvent, CancellationToken, Task> invoker,
         CancellationToken cancellationToken
     )
         where TEvent : IEvent
@@ -64,7 +64,7 @@ public sealed class SequentialEventDispatcher : IEventDispatcher
             cancellationToken.ThrowIfCancellationRequested();
             try
             {
-                await invoker(handler, message).ConfigureAwait(false);
+                await invoker(handler, message, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/src/NetEvolve.Pulse/Dispatchers/TransactionalEventDispatcher.cs
+++ b/src/NetEvolve.Pulse/Dispatchers/TransactionalEventDispatcher.cs
@@ -84,7 +84,7 @@ public sealed class TransactionalEventDispatcher : IEventDispatcher
     public Task DispatchAsync<TEvent>(
         TEvent message,
         IEnumerable<IEventHandler<TEvent>> handlers,
-        Func<IEventHandler<TEvent>, TEvent, Task> invoker,
+        Func<IEventHandler<TEvent>, TEvent, CancellationToken, Task> invoker,
         CancellationToken cancellationToken
     )
         where TEvent : IEvent =>

--- a/src/NetEvolve.Pulse/Internals/PulseMediator.cs
+++ b/src/NetEvolve.Pulse/Internals/PulseMediator.cs
@@ -108,7 +108,7 @@ internal sealed partial class PulseMediator : IMediator
         // Resolve the appropriate handler for the query
         var handler = _serviceProvider.GetRequiredService<IQueryHandler<TQuery, TResponse>>();
 
-        return ExecuteAsync(query, (q, ct) => handler.HandleAsync(q, ct), cancellationToken);
+        return ExecuteAsync(query, handler.HandleAsync, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -128,7 +128,7 @@ internal sealed partial class PulseMediator : IMediator
         // Resolve the appropriate handler for the command
         var handler = _serviceProvider.GetRequiredService<ICommandHandler<TCommand, TResponse>>();
 
-        return ExecuteAsync(command, (c, ct) => handler.HandleAsync(c, ct), cancellationToken);
+        return ExecuteAsync(command, handler.HandleAsync, cancellationToken);
     }
 
     /// <summary>
@@ -152,31 +152,26 @@ internal sealed partial class PulseMediator : IMediator
         var dispatcher = _serviceProvider.GetKeyedService<IEventDispatcher>(typeof(TEvent)) ?? _eventDispatcher;
 
         // Create the dispatch action that uses the resolved dispatcher
-        Task DispatchAsync(TEvent message, CancellationToken ct) =>
-            dispatcher.DispatchAsync(
-                message,
-                handlers,
-                (handler, eventMessage) => InvokeHandlerAsync(handler, eventMessage, ct),
-                ct
-            );
+        Task DispatchAsync(TEvent message, CancellationToken token) =>
+            dispatcher.DispatchAsync(message, handlers, InvokeHandlerAsync, token);
+
+        // Build the interceptor chain from innermost (dispatcher) to outermost (first interceptor)
+        var next = DispatchAsync;
 
         // Retrieve all registered event interceptors and reverse for correct pipeline order
         var interceptors = _serviceProvider.GetServices<IEventInterceptor<TEvent>>().Reverse().ToArray();
         if (interceptors.Length == 0)
         {
             // No interceptors registered, execute dispatcher directly
-            return DispatchAsync(msg, cancellationToken);
+            return next(msg, cancellationToken);
         }
-
-        // Build the interceptor chain from innermost (dispatcher) to outermost (first interceptor)
-        var next = (Func<TEvent, CancellationToken, Task>)DispatchAsync;
 
         foreach (var interceptor in interceptors)
         {
             var currentInterceptor = interceptor;
-            var nextCopy = next;
+            var currentNext = next;
             // Wrap the next action with the current interceptor
-            next = (req, ct) => currentInterceptor.HandleAsync(req, nextCopy, ct);
+            next = (req, token) => currentInterceptor.HandleAsync(req, currentNext, token);
         }
 
         return next(msg, cancellationToken);
@@ -218,7 +213,7 @@ internal sealed partial class PulseMediator : IMediator
             var currentInterceptor = interceptor;
             var nextCopy = next;
             // Wrap the next action with the current interceptor
-            next = (req, ct) => currentInterceptor.HandleAsync(req, nextCopy, ct);
+            next = (req, token) => currentInterceptor.HandleAsync(req, nextCopy, token);
         }
 
         return next(request, cancellationToken);

--- a/tests/NetEvolve.Pulse.Tests.Unit/Dispatchers/ParallelEventDispatcherTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Dispatchers/ParallelEventDispatcherTests.cs
@@ -23,7 +23,7 @@ public class ParallelEventDispatcherTests
             .DispatchAsync(
                 testEvent,
                 handlers,
-                async (handler, evt) => await handler.HandleAsync(evt, CancellationToken.None).ConfigureAwait(false),
+                async (handler, evt, ct) => await handler.HandleAsync(evt, ct).ConfigureAwait(false),
                 CancellationToken.None
             )
             .ConfigureAwait(false);
@@ -48,7 +48,7 @@ public class ParallelEventDispatcherTests
             .DispatchAsync(
                 testEvent,
                 handlers,
-                async (handler, evt) => await handler.HandleAsync(evt, CancellationToken.None).ConfigureAwait(false),
+                async (handler, evt, ct) => await handler.HandleAsync(evt, ct).ConfigureAwait(false),
                 CancellationToken.None
             )
             .ConfigureAwait(false);
@@ -66,7 +66,7 @@ public class ParallelEventDispatcherTests
             .DispatchAsync(
                 testEvent,
                 handlers,
-                async (handler, evt) => await handler.HandleAsync(evt, CancellationToken.None).ConfigureAwait(false),
+                async (handler, evt, ct) => await handler.HandleAsync(evt, ct).ConfigureAwait(false),
                 CancellationToken.None
             )
             .ConfigureAwait(false);
@@ -89,8 +89,7 @@ public class ParallelEventDispatcherTests
                 .DispatchAsync(
                     testEvent,
                     handlers,
-                    async (handler, evt) =>
-                        await handler.HandleAsync(evt, CancellationToken.None).ConfigureAwait(false),
+                    async (handler, evt, ct) => await handler.HandleAsync(evt, ct).ConfigureAwait(false),
                     cts.Token
                 )
                 .ConfigureAwait(false)

--- a/tests/NetEvolve.Pulse.Tests.Unit/Dispatchers/PrioritizedEventDispatcherTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Dispatchers/PrioritizedEventDispatcherTests.cs
@@ -29,7 +29,7 @@ public class PrioritizedEventDispatcherTests
             .DispatchAsync(
                 message,
                 handlers,
-                (handler, msg) => handler.HandleAsync(msg, CancellationToken.None),
+                (handler, msg, ct) => handler.HandleAsync(msg, ct),
                 CancellationToken.None
             )
             .ConfigureAwait(false);
@@ -62,7 +62,7 @@ public class PrioritizedEventDispatcherTests
             .DispatchAsync(
                 message,
                 handlers,
-                (handler, msg) => handler.HandleAsync(msg, CancellationToken.None),
+                (handler, msg, ct) => handler.HandleAsync(msg, ct),
                 CancellationToken.None
             )
             .ConfigureAwait(false);
@@ -96,7 +96,7 @@ public class PrioritizedEventDispatcherTests
             .DispatchAsync(
                 message,
                 handlers,
-                (handler, msg) => handler.HandleAsync(msg, CancellationToken.None),
+                (handler, msg, ct) => handler.HandleAsync(msg, ct),
                 CancellationToken.None
             )
             .ConfigureAwait(false);
@@ -127,12 +127,7 @@ public class PrioritizedEventDispatcherTests
 
         _ = await Assert.ThrowsAsync<OperationCanceledException>(async () =>
             await dispatcher
-                .DispatchAsync(
-                    message,
-                    handlers,
-                    (handler, msg) => handler.HandleAsync(msg, CancellationToken.None),
-                    cts.Token
-                )
+                .DispatchAsync(message, handlers, (handler, msg, ct) => handler.HandleAsync(msg, ct), cts.Token)
                 .ConfigureAwait(false)
         );
 
@@ -157,7 +152,7 @@ public class PrioritizedEventDispatcherTests
             .DispatchAsync(
                 message,
                 handlers,
-                (handler, msg) => handler.HandleAsync(msg, CancellationToken.None),
+                (handler, msg, ct) => handler.HandleAsync(msg, ct),
                 CancellationToken.None
             )
             .ConfigureAwait(false);

--- a/tests/NetEvolve.Pulse.Tests.Unit/Dispatchers/RateLimitedEventDispatcherTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Dispatchers/RateLimitedEventDispatcherTests.cs
@@ -59,7 +59,7 @@ public class RateLimitedEventDispatcherTests
             .DispatchAsync(
                 message,
                 handlers,
-                (handler, msg) => handler.HandleAsync(msg, CancellationToken.None),
+                (handler, msg, ct) => handler.HandleAsync(msg, ct),
                 CancellationToken.None
             )
             .ConfigureAwait(false);
@@ -111,7 +111,7 @@ public class RateLimitedEventDispatcherTests
             .DispatchAsync(
                 message,
                 handlers,
-                async (handler, msg) => await handler.HandleAsync(msg, CancellationToken.None).ConfigureAwait(false),
+                async (handler, msg, ct) => await handler.HandleAsync(msg, ct).ConfigureAwait(false),
                 CancellationToken.None
             )
             .ConfigureAwait(false);
@@ -133,7 +133,7 @@ public class RateLimitedEventDispatcherTests
                 .DispatchAsync(
                     message,
                     handlers,
-                    (handler, msg) => handler.HandleAsync(msg, CancellationToken.None),
+                    (handler, msg, ct) => handler.HandleAsync(msg, ct),
                     CancellationToken.None
                 )
                 .ConfigureAwait(false)

--- a/tests/NetEvolve.Pulse.Tests.Unit/Dispatchers/SequentialEventDispatcherTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Dispatchers/SequentialEventDispatcherTests.cs
@@ -24,7 +24,7 @@ public class SequentialEventDispatcherTests
             .DispatchAsync(
                 testEvent,
                 handlers,
-                async (handler, evt) => await handler.HandleAsync(evt, CancellationToken.None).ConfigureAwait(false),
+                async (handler, evt, ct) => await handler.HandleAsync(evt, ct).ConfigureAwait(false),
                 CancellationToken.None
             )
             .ConfigureAwait(false);
@@ -49,7 +49,7 @@ public class SequentialEventDispatcherTests
             .DispatchAsync(
                 testEvent,
                 handlers,
-                async (handler, evt) => await handler.HandleAsync(evt, CancellationToken.None).ConfigureAwait(false),
+                async (handler, evt, ct) => await handler.HandleAsync(evt, ct).ConfigureAwait(false),
                 CancellationToken.None
             )
             .ConfigureAwait(false);
@@ -67,7 +67,7 @@ public class SequentialEventDispatcherTests
             .DispatchAsync(
                 testEvent,
                 handlers,
-                async (handler, evt) => await handler.HandleAsync(evt, CancellationToken.None).ConfigureAwait(false),
+                async (handler, evt, ct) => await handler.HandleAsync(evt, ct).ConfigureAwait(false),
                 CancellationToken.None
             )
             .ConfigureAwait(false);
@@ -94,8 +94,7 @@ public class SequentialEventDispatcherTests
                 .DispatchAsync(
                     testEvent,
                     handlers,
-                    async (handler, evt) =>
-                        await handler.HandleAsync(evt, CancellationToken.None).ConfigureAwait(false),
+                    async (handler, evt, ct) => await handler.HandleAsync(evt, ct).ConfigureAwait(false),
                     cts.Token
                 )
                 .ConfigureAwait(false)
@@ -150,7 +149,7 @@ public class SequentialEventDispatcherTests
             .DispatchAsync(
                 testEvent,
                 handlers,
-                async (handler, evt) => await handler.HandleAsync(evt, CancellationToken.None).ConfigureAwait(false),
+                async (handler, evt, ct) => await handler.HandleAsync(evt, ct).ConfigureAwait(false),
                 CancellationToken.None
             )
             .ConfigureAwait(false);

--- a/tests/NetEvolve.Pulse.Tests.Unit/Dispatchers/TransactionalEventDispatcherTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Dispatchers/TransactionalEventDispatcherTests.cs
@@ -31,7 +31,7 @@ public class TransactionalEventDispatcherTests
             .DispatchAsync(
                 message,
                 handlers,
-                (handler, msg) => handler.HandleAsync(msg, CancellationToken.None),
+                (handler, msg, ct) => handler.HandleAsync(msg, ct),
                 CancellationToken.None
             )
             .ConfigureAwait(false);
@@ -56,10 +56,10 @@ public class TransactionalEventDispatcherTests
             .DispatchAsync(
                 message,
                 handlers,
-                (handler, msg) =>
+                (handler, msg, ct) =>
                 {
                     // This invoker should NOT be called by TransactionalEventDispatcher
-                    return handler.HandleAsync(msg, CancellationToken.None);
+                    return handler.HandleAsync(msg, ct);
                 },
                 CancellationToken.None
             )
@@ -80,12 +80,7 @@ public class TransactionalEventDispatcherTests
 
         _ = await Assert.ThrowsAsync<OperationCanceledException>(async () =>
             await dispatcher
-                .DispatchAsync(
-                    message,
-                    handlers,
-                    (handler, msg) => handler.HandleAsync(msg, CancellationToken.None),
-                    cts.Token
-                )
+                .DispatchAsync(message, handlers, (handler, msg, ct) => handler.HandleAsync(msg, ct), cts.Token)
                 .ConfigureAwait(false)
         );
     }
@@ -103,7 +98,7 @@ public class TransactionalEventDispatcherTests
                 .DispatchAsync(
                     message,
                     handlers,
-                    (handler, msg) => handler.HandleAsync(msg, CancellationToken.None),
+                    (handler, msg, ct) => handler.HandleAsync(msg, ct),
                     CancellationToken.None
                 )
                 .ConfigureAwait(false)
@@ -122,7 +117,7 @@ public class TransactionalEventDispatcherTests
             .DispatchAsync(
                 message,
                 handlers,
-                (handler, msg) => handler.HandleAsync(msg, CancellationToken.None),
+                (handler, msg, ct) => handler.HandleAsync(msg, ct),
                 CancellationToken.None
             )
             .ConfigureAwait(false);


### PR DESCRIPTION
Refactor IEventDispatcher.DispatchAsync and all implementations to require the invoker delegate to accept a CancellationToken. Update all event dispatcher classes, Polly interceptors, PulseMediator, and related tests to use the new signature, ensuring proper cancellation token propagation and improved cancellation support throughout the event handling pipeline. Also includes minor refactoring in PollyMediatorConfiguratorExtensions for clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced cancellation token propagation across event dispatchers to ensure cancellation requests properly flow through handler execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->