### PR TITLE
chore: Change Map* methods to return IEndpointConventionBuilder

### DIFF
--- a/src/NetEvolve.Pulse.AspNetCore/EndpointRouteBuilderExtensions.cs
+++ b/src/NetEvolve.Pulse.AspNetCore/EndpointRouteBuilderExtensions.cs
@@ -41,7 +41,7 @@ public static class EndpointRouteBuilderExtensions
     /// app.MapCommand&lt;UpdateOrderCommand, OrderResult&gt;("/orders/{id}", CommandHttpMethod.Put);
     /// </code>
     /// </example>
-    public static RouteHandlerBuilder MapCommand<TCommand, TResponse>(
+    public static IEndpointConventionBuilder MapCommand<TCommand, TResponse>(
         [NotNull] this IEndpointRouteBuilder endpoints,
         [NotNull] string pattern,
         CommandHttpMethod httpMethod = CommandHttpMethod.Post
@@ -87,7 +87,7 @@ public static class EndpointRouteBuilderExtensions
     /// app.MapCommand&lt;DeleteOrderCommand&gt;("/orders/{id}", CommandHttpMethod.Delete);
     /// </code>
     /// </example>
-    public static RouteHandlerBuilder MapCommand<TCommand>(
+    public static IEndpointConventionBuilder MapCommand<TCommand>(
         [NotNull] this IEndpointRouteBuilder endpoints,
         [NotNull] string pattern,
         CommandHttpMethod httpMethod = CommandHttpMethod.Post
@@ -126,7 +126,7 @@ public static class EndpointRouteBuilderExtensions
     /// app.MapQuery&lt;GetOrderQuery, OrderDto&gt;("/orders/{id}");
     /// </code>
     /// </example>
-    public static RouteHandlerBuilder MapQuery<TQuery, TResponse>(
+    public static IEndpointConventionBuilder MapQuery<TQuery, TResponse>(
         [NotNull] this IEndpointRouteBuilder endpoints,
         [NotNull] string pattern
     )


### PR DESCRIPTION
Updated MapCommand and MapQuery extension methods in EndpointRouteBuilderExtensions to return IEndpointConventionBuilder instead of RouteHandlerBuilder. This improves compatibility and flexibility for endpoint configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Endpoint mapping methods now return a different interface type for configuration. If you use `MapCommand` or `MapQuery` methods, you may need to update how you chain configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->