### PR TITLE
fix: Add retry logic to SQL Server container startup

### DIFF
--- a/tests/NetEvolve.Pulse.EntityFramework.Tests.Integration/Fixtures/SqlServerContainerFixture.cs
+++ b/tests/NetEvolve.Pulse.EntityFramework.Tests.Integration/Fixtures/SqlServerContainerFixture.cs
@@ -36,8 +36,19 @@ public sealed class SqlServerContainerFixture : IAsyncInitializer, IAsyncDisposa
     /// <returns>A task representing the asynchronous operation.</returns>
     public async Task InitializeAsync()
     {
-        await _container.StartAsync().ConfigureAwait(false);
-        await WaitUntilSqlServerIsReadyAsync().ConfigureAwait(false);
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            try
+            {
+                await _container.StartAsync().ConfigureAwait(false);
+                await WaitUntilSqlServerIsReadyAsync().ConfigureAwait(false);
+                return;
+            }
+            catch (Exception) when (attempt < 2)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+            }
+        }
     }
 
     private async Task WaitUntilSqlServerIsReadyAsync()

--- a/tests/NetEvolve.Pulse.SqlServer.Tests.Integration/Fixtures/SqlServerContainerFixture.cs
+++ b/tests/NetEvolve.Pulse.SqlServer.Tests.Integration/Fixtures/SqlServerContainerFixture.cs
@@ -37,8 +37,19 @@ public sealed partial class SqlServerContainerFixture : IAsyncInitializer, IAsyn
     /// <returns>A task representing the asynchronous operation.</returns>
     public async Task InitializeAsync()
     {
-        await _container.StartAsync().ConfigureAwait(false);
-        await WaitUntilSqlServerIsReadyAsync().ConfigureAwait(false);
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            try
+            {
+                await _container.StartAsync().ConfigureAwait(false);
+                await WaitUntilSqlServerIsReadyAsync().ConfigureAwait(false);
+                return;
+            }
+            catch (Exception) when (attempt < 2)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+            }
+        }
     }
 
     private async Task WaitUntilSqlServerIsReadyAsync()


### PR DESCRIPTION
InitializeAsync now retries up to three times to start the SQL Server container, adding a 5-second delay between attempts on failure. This improves resilience against transient startup issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved SQL Server integration test stability with enhanced container initialization. Automatic retries now handle temporary startup issues more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->