### PR TITLE
chore: Add retry-scheduled index and NextRetryAt column support

### DIFF
--- a/src/NetEvolve.Pulse.EntityFramework/Configurations/MySqlOutboxMessageConfiguration.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Configurations/MySqlOutboxMessageConfiguration.cs
@@ -22,8 +22,8 @@ using NetEvolve.Pulse.Outbox;
 /// </list>
 /// <para><strong>Filtered Indexes:</strong></para>
 /// MySQL does not support partial/filtered indexes with a <c>WHERE</c> clause.
-/// <see cref="PendingMessagesFilter"/> and <see cref="CompletedMessagesFilter"/> return
-/// <see langword="null"/>, causing EF Core to emit plain (unfiltered) indexes.
+/// All filter properties inherit <see langword="null"/> from the base class,
+/// causing EF Core to emit plain (unfiltered) indexes.
 /// <para><strong>Usage:</strong></para>
 /// Either instantiate this class directly or use <see cref="OutboxMessageConfigurationFactory.Create(string,Microsoft.Extensions.Options.IOptions{OutboxOptions})"/>
 /// with a MySQL provider name.
@@ -59,14 +59,6 @@ internal sealed class MySqlOutboxMessageConfiguration : OutboxMessageConfigurati
         : base(options) { }
 
     /// <inheritdoc />
-    /// <remarks>MySQL does not support filtered indexes — returns <see langword="null"/>.</remarks>
-    protected override string? PendingMessagesFilter => null;
-
-    /// <inheritdoc />
-    /// <remarks>MySQL does not support filtered indexes — returns <see langword="null"/>.</remarks>
-    protected override string? CompletedMessagesFilter => null;
-
-    /// <inheritdoc />
     protected override void ApplyColumnTypes(EntityTypeBuilder<OutboxMessage> builder)
     {
         // char(36) is the canonical UUID string format used by Pomelo and Oracle MySQL provider
@@ -79,6 +71,7 @@ internal sealed class MySqlOutboxMessageConfiguration : OutboxMessageConfigurati
         _ = builder.Property(m => m.CreatedAt).HasColumnType("datetime(6)");
         _ = builder.Property(m => m.UpdatedAt).HasColumnType("datetime(6)");
         _ = builder.Property(m => m.ProcessedAt).HasColumnType("datetime(6)");
+        _ = builder.Property(m => m.NextRetryAt).HasColumnType("datetime(6)");
         _ = builder.Property(m => m.RetryCount).HasColumnType("int");
         _ = builder.Property(m => m.Error).HasColumnType("longtext");
         _ = builder.Property(m => m.Status).HasColumnType("int");

--- a/src/NetEvolve.Pulse.EntityFramework/Configurations/OutboxMessageConfigurationBase.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Configurations/OutboxMessageConfigurationBase.cs
@@ -45,8 +45,21 @@ internal abstract class OutboxMessageConfigurationBase : IEntityTypeConfiguratio
     /// Covers <see cref="OutboxMessageStatus.Pending"/> and <see cref="OutboxMessageStatus.Failed"/> rows.
     /// Return <see langword="null"/> when the target database does not support filtered indexes
     /// (e.g. MySQL) — EF Core will omit the filter clause entirely.
+    /// The default implementation returns <see langword="null"/>, which is suitable for databases
+    /// that do not support filtered/partial indexes.
     /// </summary>
-    protected abstract string? PendingMessagesFilter { get; }
+    protected virtual string? PendingMessagesFilter => null;
+
+    /// <summary>
+    /// Gets the raw SQL filter expression used for the retry-scheduled messages index.
+    /// Covers <see cref="OutboxMessageStatus.Failed"/> rows with non-null <see cref="OutboxMessage.NextRetryAt"/>.
+    /// Used when exponential backoff is enabled to efficiently query messages scheduled for retry.
+    /// Return <see langword="null"/> when the target database does not support filtered indexes
+    /// (e.g. MySQL) — EF Core will omit the filter clause entirely.
+    /// The default implementation returns <see langword="null"/>, which is suitable for databases
+    /// that do not support filtered/partial indexes.
+    /// </summary>
+    protected virtual string? RetryScheduledMessagesFilter => null;
 
     /// <summary>
     /// Applies provider-specific column type overrides to the entity mapping.
@@ -66,8 +79,10 @@ internal abstract class OutboxMessageConfigurationBase : IEntityTypeConfiguratio
     /// Covers <see cref="OutboxMessageStatus.Completed"/> rows.
     /// Return <see langword="null"/> when the target database does not support filtered indexes
     /// (e.g. MySQL) — EF Core will omit the filter clause entirely.
+    /// The default implementation returns <see langword="null"/>, which is suitable for databases
+    /// that do not support filtered/partial indexes.
     /// </summary>
-    protected abstract string? CompletedMessagesFilter { get; }
+    protected virtual string? CompletedMessagesFilter => null;
 
     /// <inheritdoc />
     public void Configure(EntityTypeBuilder<OutboxMessage> builder)
@@ -140,6 +155,12 @@ internal abstract class OutboxMessageConfigurationBase : IEntityTypeConfiguratio
             .HasIndex(m => new { m.Status, m.CreatedAt })
             .HasFilter(PendingMessagesFilter)
             .HasDatabaseName("IX_OutboxMessage_Status_CreatedAt");
+
+        // Index for retry-scheduled message polling (with exponential backoff)
+        _ = builder
+            .HasIndex(m => new { m.Status, m.NextRetryAt })
+            .HasFilter(RetryScheduledMessagesFilter)
+            .HasDatabaseName("IX_OutboxMessage_Status_NextRetryAt");
 
         // Index for completed message cleanup
         _ = builder

--- a/src/NetEvolve.Pulse.EntityFramework/Configurations/PostgreSqlOutboxMessageConfiguration.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Configurations/PostgreSqlOutboxMessageConfiguration.cs
@@ -55,6 +55,10 @@ internal sealed class PostgreSqlOutboxMessageConfiguration : OutboxMessageConfig
         $"\"{OutboxMessageSchema.Columns.Status}\" IN ({(int)OutboxMessageStatus.Pending}, {(int)OutboxMessageStatus.Failed})";
 
     /// <inheritdoc />
+    protected override string RetryScheduledMessagesFilter =>
+        $"\"{OutboxMessageSchema.Columns.Status}\" = {(int)OutboxMessageStatus.Failed} AND \"{OutboxMessageSchema.Columns.NextRetryAt}\" IS NOT NULL";
+
+    /// <inheritdoc />
     protected override string CompletedMessagesFilter =>
         $"\"{OutboxMessageSchema.Columns.Status}\" = {(int)OutboxMessageStatus.Completed}";
 
@@ -71,6 +75,7 @@ internal sealed class PostgreSqlOutboxMessageConfiguration : OutboxMessageConfig
         _ = builder.Property(m => m.CreatedAt).HasColumnType("timestamp with time zone");
         _ = builder.Property(m => m.UpdatedAt).HasColumnType("timestamp with time zone");
         _ = builder.Property(m => m.ProcessedAt).HasColumnType("timestamp with time zone");
+        _ = builder.Property(m => m.NextRetryAt).HasColumnType("timestamp with time zone");
         _ = builder.Property(m => m.RetryCount).HasColumnType("integer");
         _ = builder.Property(m => m.Error).HasColumnType("text");
         _ = builder.Property(m => m.Status).HasColumnType("integer");

--- a/src/NetEvolve.Pulse.EntityFramework/Configurations/SqlServerOutboxMessageConfiguration.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Configurations/SqlServerOutboxMessageConfiguration.cs
@@ -58,6 +58,10 @@ internal sealed class SqlServerOutboxMessageConfiguration : OutboxMessageConfigu
         $"[{OutboxMessageSchema.Columns.Status}] IN ({(int)OutboxMessageStatus.Pending}, {(int)OutboxMessageStatus.Failed})";
 
     /// <inheritdoc />
+    protected override string RetryScheduledMessagesFilter =>
+        $"[{OutboxMessageSchema.Columns.Status}] = {(int)OutboxMessageStatus.Failed} AND [{OutboxMessageSchema.Columns.NextRetryAt}] IS NOT NULL";
+
+    /// <inheritdoc />
     protected override string CompletedMessagesFilter =>
         $"[{OutboxMessageSchema.Columns.Status}] = {(int)OutboxMessageStatus.Completed}";
 
@@ -71,6 +75,7 @@ internal sealed class SqlServerOutboxMessageConfiguration : OutboxMessageConfigu
         _ = builder.Property(m => m.CreatedAt).HasColumnType("datetimeoffset");
         _ = builder.Property(m => m.UpdatedAt).HasColumnType("datetimeoffset");
         _ = builder.Property(m => m.ProcessedAt).HasColumnType("datetimeoffset");
+        _ = builder.Property(m => m.NextRetryAt).HasColumnType("datetimeoffset");
         _ = builder.Property(m => m.RetryCount).HasColumnType("int");
         _ = builder.Property(m => m.Error).HasColumnType("nvarchar(max)");
         _ = builder.Property(m => m.Status).HasColumnType("int");

--- a/src/NetEvolve.Pulse.EntityFramework/Configurations/SqliteOutboxMessageConfiguration.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Configurations/SqliteOutboxMessageConfiguration.cs
@@ -57,6 +57,10 @@ internal sealed class SqliteOutboxMessageConfiguration : OutboxMessageConfigurat
         $"\"{OutboxMessageSchema.Columns.Status}\" IN ({(int)OutboxMessageStatus.Pending}, {(int)OutboxMessageStatus.Failed})";
 
     /// <inheritdoc />
+    protected override string RetryScheduledMessagesFilter =>
+        $"\"{OutboxMessageSchema.Columns.Status}\" = {(int)OutboxMessageStatus.Failed} AND \"{OutboxMessageSchema.Columns.NextRetryAt}\" IS NOT NULL";
+
+    /// <inheritdoc />
     protected override string CompletedMessagesFilter =>
         $"\"{OutboxMessageSchema.Columns.Status}\" = {(int)OutboxMessageStatus.Completed}";
 
@@ -74,6 +78,7 @@ internal sealed class SqliteOutboxMessageConfiguration : OutboxMessageConfigurat
         _ = builder.Property(m => m.CreatedAt).HasColumnType("TEXT");
         _ = builder.Property(m => m.UpdatedAt).HasColumnType("TEXT");
         _ = builder.Property(m => m.ProcessedAt).HasColumnType("TEXT");
+        _ = builder.Property(m => m.NextRetryAt).HasColumnType("TEXT");
         _ = builder.Property(m => m.RetryCount).HasColumnType("INTEGER");
         _ = builder.Property(m => m.Error).HasColumnType("TEXT");
         _ = builder.Property(m => m.Status).HasColumnType("INTEGER");


### PR DESCRIPTION
Introduce NextRetryAt property and map it in all provider-specific outbox configurations. Add a new (Status, NextRetryAt) index with provider-specific filters for efficient retry scheduling. Make filter properties virtual with default nulls for better extensibility and update documentation accordingly. This enhances querying and indexing of retry-scheduled outbox messages across all supported databases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retry scheduling across all supported database providers (MySQL, PostgreSQL, SQL Server, SQLite).

* **Refactor**
  * Simplified filter configuration to use sensible defaults, reducing boilerplate code for database-specific implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->