### PR TITLE
refactor: topic name resolution with new abstraction

### DIFF
--- a/src/NetEvolve.Pulse.Dapr/OutBox/DaprMessageTransport.cs
+++ b/src/NetEvolve.Pulse.Dapr/OutBox/DaprMessageTransport.cs
@@ -10,7 +10,7 @@ using NetEvolve.Pulse.Extensibility.Outbox;
 /// </summary>
 /// <remarks>
 /// <para><strong>Topic Resolution:</strong></para>
-/// Each message is published to a topic resolved by <see cref="DaprMessageTransportOptions.TopicNameResolver"/>.
+/// Each message is published to a topic resolved by <see cref="ITopicNameResolver"/>.
 /// By default, the simple class name of the event type is used (e.g., <c>"OrderCreated"</c>).
 /// <para><strong>Payload:</strong></para>
 /// The raw JSON payload from <see cref="OutboxMessage.Payload"/> is published as the CloudEvent data.
@@ -23,20 +23,30 @@ internal sealed class DaprMessageTransport : IMessageTransport
     /// <summary>The Dapr client used to publish events to the configured pub/sub component.</summary>
     private readonly DaprClient _daprClient;
 
-    /// <summary>The resolved transport options controlling the pub/sub component name and topic resolution.</summary>
+    /// <summary>The resolved transport options controlling the pub/sub component name.</summary>
     private readonly DaprMessageTransportOptions _options;
+
+    /// <summary>The topic name resolver used to determine the Dapr topic name from an outbox message.</summary>
+    private readonly ITopicNameResolver _topicNameResolver;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DaprMessageTransport"/> class.
     /// </summary>
     /// <param name="daprClient">The Dapr client for publishing events.</param>
+    /// <param name="topicNameResolver">The topic name resolver for determining topic names from outbox messages.</param>
     /// <param name="options">The transport options.</param>
-    public DaprMessageTransport(DaprClient daprClient, IOptions<DaprMessageTransportOptions> options)
+    public DaprMessageTransport(
+        DaprClient daprClient,
+        ITopicNameResolver topicNameResolver,
+        IOptions<DaprMessageTransportOptions> options
+    )
     {
         ArgumentNullException.ThrowIfNull(daprClient);
+        ArgumentNullException.ThrowIfNull(topicNameResolver);
         ArgumentNullException.ThrowIfNull(options);
 
         _daprClient = daprClient;
+        _topicNameResolver = topicNameResolver;
         _options = options.Value;
     }
 
@@ -45,7 +55,7 @@ internal sealed class DaprMessageTransport : IMessageTransport
     {
         ArgumentNullException.ThrowIfNull(message);
 
-        var topicName = _options.TopicNameResolver(message);
+        var topicName = _topicNameResolver.Resolve(message);
         var payload = JsonSerializer.Deserialize<JsonElement>(message.Payload);
 
         await _daprClient

--- a/src/NetEvolve.Pulse.Dapr/OutBox/DaprMessageTransportOptions.cs
+++ b/src/NetEvolve.Pulse.Dapr/OutBox/DaprMessageTransportOptions.cs
@@ -12,32 +12,4 @@ public sealed class DaprMessageTransportOptions
     /// </summary>
     /// <remarks>Defaults to <c>"pubsub"</c>.</remarks>
     public string PubSubName { get; set; } = "pubsub";
-
-    /// <summary>
-    /// Gets or sets the function used to resolve the Dapr topic name from an outbox message.
-    /// </summary>
-    /// <remarks>
-    /// Defaults to extracting the simple class name from <see cref="OutboxMessage.EventType"/>.
-    /// For example, <c>"MyApp.Events.OrderCreated, MyApp"</c> resolves to <c>"OrderCreated"</c>.
-    /// </remarks>
-    public Func<OutboxMessage, string> TopicNameResolver { get; set; } = DefaultTopicNameResolver;
-
-    /// <summary>
-    /// Extracts the simple class name from an assembly-qualified type name stored in <see cref="OutboxMessage.EventType"/>.
-    /// For example, <c>"MyApp.Events.OrderCreated, MyApp, Version=1.0.0.0, ..."</c> resolves to <c>"OrderCreated"</c>.
-    /// </summary>
-    /// <param name="message">The outbox message whose <see cref="OutboxMessage.EventType"/> is resolved.</param>
-    /// <returns>The simple (unqualified) class name of the event type.</returns>
-    internal static string DefaultTopicNameResolver(OutboxMessage message)
-    {
-        var typeName = message.EventType;
-        var commaIndex = typeName.IndexOf(',', StringComparison.Ordinal);
-        if (commaIndex > 0)
-        {
-            typeName = typeName[..commaIndex];
-        }
-
-        var dotIndex = typeName.LastIndexOf('.');
-        return dotIndex >= 0 ? typeName[(dotIndex + 1)..] : typeName;
-    }
 }

--- a/src/NetEvolve.Pulse.Extensibility/Outbox/ITopicNameResolver.cs
+++ b/src/NetEvolve.Pulse.Extensibility/Outbox/ITopicNameResolver.cs
@@ -1,0 +1,19 @@
+namespace NetEvolve.Pulse.Extensibility.Outbox;
+
+/// <summary>
+/// Defines a contract for resolving topic or queue names from outbox messages.
+/// </summary>
+/// <remarks>
+/// Implementations can extract routing destinations from message metadata,
+/// typically from <see cref="OutboxMessage.EventType"/>, to support event-driven
+/// architectures with topic-based routing (e.g., Dapr pub/sub, Azure Service Bus topics).
+/// </remarks>
+public interface ITopicNameResolver
+{
+    /// <summary>
+    /// Resolves the topic or queue name for a given outbox message.
+    /// </summary>
+    /// <param name="message">The outbox message to resolve the topic name from.</param>
+    /// <returns>The resolved topic or queue name.</returns>
+    string Resolve(OutboxMessage message);
+}

--- a/src/NetEvolve.Pulse/Outbox/DefaultTopicNameResolver.cs
+++ b/src/NetEvolve.Pulse/Outbox/DefaultTopicNameResolver.cs
@@ -1,0 +1,51 @@
+namespace NetEvolve.Pulse.Extensibility.Outbox;
+
+using System.Collections.Concurrent;
+
+/// <summary>
+/// Default implementation of <see cref="ITopicNameResolver"/> that extracts the simple class name
+/// from an assembly-qualified type name.
+/// </summary>
+/// <remarks>
+/// For example, <c>"MyApp.Events.OrderCreated, MyApp, Version=1.0.0.0, ..."</c> resolves to <c>"OrderCreated"</c>.
+/// </remarks>
+internal sealed class DefaultTopicNameResolver : ITopicNameResolver
+{
+    /// <summary>Cache for resolved topic names to avoid repeated string parsing operations.</summary>
+    private readonly ConcurrentDictionary<string, string> _cache = new(StringComparer.Ordinal);
+
+    /// <inheritdoc />
+    public string Resolve(OutboxMessage message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        var eventType = message.EventType;
+
+        // Fast path for cache hits - avoids delegate invocation
+        if (_cache.TryGetValue(eventType, out var cached))
+        {
+            return cached;
+        }
+
+        return _cache.GetOrAdd(eventType, ExtractSimpleTypeName);
+    }
+
+    /// <summary>
+    /// Extracts the simple class name from an assembly-qualified type name.
+    /// </summary>
+    /// <param name="eventType">The assembly-qualified type name (e.g., <c>"MyApp.Events.OrderCreated, MyApp, Version=1.0.0.0"</c>).</param>
+    /// <returns>The simple class name (e.g., <c>"OrderCreated"</c>).</returns>
+    private static string ExtractSimpleTypeName(string eventType)
+    {
+        var span = eventType.AsSpan();
+
+        var commaIndex = span.IndexOf(',');
+        if (commaIndex > 0)
+        {
+            span = span[..commaIndex];
+        }
+
+        var dotIndex = span.LastIndexOf('.');
+        return (dotIndex >= 0 ? span[(dotIndex + 1)..] : span).ToString();
+    }
+}

--- a/src/NetEvolve.Pulse/Outbox/InMemoryMessageTransport.cs
+++ b/src/NetEvolve.Pulse/Outbox/InMemoryMessageTransport.cs
@@ -27,7 +27,7 @@ internal sealed class InMemoryMessageTransport : IMessageTransport
     private static readonly ConcurrentDictionary<
         Type,
         Func<IMediator, IEvent, CancellationToken, Task>
-    > _publishDelegates = new();
+    > PublishDelegates = new();
 
     /// <summary>The mediator used to publish deserialized events in-process.</summary>
     private readonly IMediator _mediator;
@@ -80,12 +80,14 @@ internal sealed class InMemoryMessageTransport : IMessageTransport
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>A task representing the asynchronous publish operation.</returns>
     private Task PublishEventAsync(IEvent @event, CancellationToken cancellationToken) =>
-        _publishDelegates.GetOrAdd(@event.GetType(), CreatePublishDelegate)(_mediator, @event, cancellationToken);
+        PublishDelegates.GetOrAdd(@event.GetType(), CreatePublishDelegate)(_mediator, @event, cancellationToken);
 
     /// <summary>
     /// Builds a compiled expression-tree delegate that calls <see cref="IMediator.PublishAsync{TEvent}"/>
     /// with the given concrete <paramref name="eventType"/>. Called once per event type and cached.
     /// </summary>
+    /// <param name="eventType">The concrete event type for which to create a publish delegate.</param>
+    /// <returns>A compiled delegate that can publish events of the specified type through the mediator.</returns>
     private static Func<IMediator, IEvent, CancellationToken, Task> CreatePublishDelegate(Type eventType)
     {
         var mediatorParam = Expression.Parameter(typeof(IMediator), "mediator");

--- a/src/NetEvolve.Pulse/OutboxMediatorConfiguratorExtensions.cs
+++ b/src/NetEvolve.Pulse/OutboxMediatorConfiguratorExtensions.cs
@@ -1,10 +1,11 @@
-﻿namespace NetEvolve.Pulse.Outbox;
+﻿namespace NetEvolve.Pulse;
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using NetEvolve.Pulse.Extensibility;
 using NetEvolve.Pulse.Extensibility.Outbox;
+using NetEvolve.Pulse.Outbox;
 
 /// <summary>
 /// Extension methods for configuring outbox services on <see cref="IMediatorConfigurator"/>.
@@ -25,7 +26,8 @@ public static class OutboxMediatorConfiguratorExtensions
     /// <item><description><see cref="OutboxOptions"/> - Configuration options (Singleton)</description></item>
     /// <item><description><see cref="OutboxProcessorOptions"/> - Processor options (Singleton)</description></item>
     /// <item><description><see cref="IEventOutbox"/> as <see cref="OutboxEventStore"/> (Scoped)</description></item>
-    /// <item><description><see cref="IMessageTransport"/> as <see cref="InMemoryMessageTransport"/> (Scoped)</description></item>
+    /// <item><description><see cref="IMessageTransport"/> as <see cref="InMemoryMessageTransport"/> (Singleton)</description></item>
+    /// <item><description><see cref="ITopicNameResolver"/> as <see cref="DefaultTopicNameResolver"/> (Singleton)</description></item>
     /// <item><description><see cref="OutboxProcessorHostedService"/> (Hosted service)</description></item>
     /// <item><description><see cref="TimeProvider"/> - System time provider (Singleton)</description></item>
     /// </list>
@@ -63,6 +65,7 @@ public static class OutboxMediatorConfiguratorExtensions
         // Register core services
         services.TryAddScoped<IEventOutbox, OutboxEventStore>();
         services.TryAddSingleton<IMessageTransport, InMemoryMessageTransport>();
+        services.TryAddSingleton<ITopicNameResolver, DefaultTopicNameResolver>();
 
         // Register background processor (TryAddEnumerable prevents duplicate registrations)
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, OutboxProcessorHostedService>());


### PR DESCRIPTION
Introduce ITopicNameResolver interface and DefaultTopicNameResolver implementation to decouple topic name resolution from DaprMessageTransportOptions. Refactor DaprMessageTransport to depend on the new abstraction. Update service registrations to add ITopicNameResolver as a singleton and make InMemoryMessageTransport singleton. Remove old delegate-based resolver from options. Improve documentation and code clarity. This enhances flexibility and maintainability of outbox message routing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Redesigned topic name resolution through dependency injection interface for greater flexibility and extensibility.
  * Implemented caching for topic name resolution to improve performance.
  * Updated message transport lifecycle configuration to singleton.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->