### PR TITLE
fix(scrubber): refactor snapshot path logic and update test scrubbing

### DIFF
--- a/templates/Predefined.cs
+++ b/templates/Predefined.cs
@@ -22,15 +22,9 @@ internal static partial class Predefined
         DerivePathInfo(
             (sourceFile, projectDirectory, type, method) =>
             {
-                var relativePath =
-                    Path.GetDirectoryName(sourceFile) is string sourceDirectory
-                    && !projectDirectory.Equals(sourceDirectory, StringComparison.OrdinalIgnoreCase)
-                        ? sourceDirectory.Replace(
-                            projectDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
-                            string.Empty,
-                            StringComparison.OrdinalIgnoreCase
-                        )
-                        : string.Empty;
+                // Derive a relative path for snapshots based on the source file's directory structure,
+                // ensuring that snapshots are organized under a "_snapshots" folder within the project directory.
+                var relativePath = Path.GetRelativePath(projectDirectory, Path.GetDirectoryName(sourceFile) ?? string.Empty);
                 var directory = Path.Combine(projectDirectory, "_snapshots", relativePath);
                 _ = Directory.CreateDirectory(directory);
                 return new(directory, type.Name, method.Name);
@@ -42,10 +36,10 @@ internal static partial class Predefined
         VerifierSettings.SortPropertiesAlphabetically();
 
         VerifierSettings.ScrubLinesWithReplace(line =>
-            ScrubLangVersion().Replace(line, "LanguageVersion: CSharpLatest")
-        );
-
-        VerifierSettings.ScrubLinesWithReplace(line => ScrubGeneatedCodeVersion().Replace(line, "$1{version}$2"));
+        {
+            line = ScrubLangVersion().Replace(line, "CSharpLatest");
+            return ScrubGeneatedCodeVersion().Replace(line, "$1{version}$2");
+        });
 
         VerifierSettings.AddExtraSettings(o =>
         {
@@ -55,7 +49,7 @@ internal static partial class Predefined
     }
 
     /// <summary>Matches <c>LanguageVersion: CSharp&lt;N&gt;</c> tokens for version-agnostic scrubbing.</summary>
-    [GeneratedRegex(@"LanguageVersion: CSharp\d+")]
+    [GeneratedRegex(@"CSharp\d+")]
     private static partial Regex ScrubLangVersion();
 
     /// <summary>

--- a/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/PulseHandlerGeneratorTests.cs
+++ b/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/PulseHandlerGeneratorTests.cs
@@ -5,9 +5,12 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using NetEvolve.Extensions.TUnit;
 using NetEvolve.Pulse.SourceGeneration.Generators;
 using TUnit.Core;
 
+[TestGroup("SourceGeneration")]
+[TestGroup("SourceGeneration.PulseHandler")]
 public class PulseHandlerGeneratorTests
 {
     [Test]

--- a/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenEventHandlerNotAnnotatedThenPulse003Reported.verified.txt
+++ b/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenEventHandlerNotAnnotatedThenPulse003Reported.verified.txt
@@ -30,7 +30,7 @@
           Options: {
             DocumentationMode: Parse,
             Language: C#,
-            LanguageVersion: CSharp14
+            LanguageVersion: CSharpLatest
           }
         }
       },

--- a/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenMultipleUnannotatedHandlersThenPulse003ReportedForEach.verified.txt
+++ b/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenMultipleUnannotatedHandlersThenPulse003ReportedForEach.verified.txt
@@ -30,7 +30,7 @@
           Options: {
             DocumentationMode: Parse,
             Language: C#,
-            LanguageVersion: CSharp14
+            LanguageVersion: CSharpLatest
           }
         }
       },
@@ -67,7 +67,7 @@
           Options: {
             DocumentationMode: Parse,
             Language: C#,
-            LanguageVersion: CSharp14
+            LanguageVersion: CSharpLatest
           }
         }
       },

--- a/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenNoHandlerInterfaceImplementedThenPulse001MessageContainsTypeName.verified.txt
+++ b/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenNoHandlerInterfaceImplementedThenPulse001MessageContainsTypeName.verified.txt
@@ -30,7 +30,7 @@
           Options: {
             DocumentationMode: Parse,
             Language: C#,
-            LanguageVersion: CSharp14
+            LanguageVersion: CSharpLatest
           }
         }
       },

--- a/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenNoHandlerInterfaceImplementedThenPulse001Reported.verified.txt
+++ b/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenNoHandlerInterfaceImplementedThenPulse001Reported.verified.txt
@@ -30,7 +30,7 @@
           Options: {
             DocumentationMode: Parse,
             Language: C#,
-            LanguageVersion: CSharp14
+            LanguageVersion: CSharpLatest
           }
         }
       },

--- a/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenNoHandlerInterfaceThenNoSourceGenerated.verified.txt
+++ b/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenNoHandlerInterfaceThenNoSourceGenerated.verified.txt
@@ -30,7 +30,7 @@
           Options: {
             DocumentationMode: Parse,
             Language: C#,
-            LanguageVersion: CSharp14
+            LanguageVersion: CSharpLatest
           }
         }
       },

--- a/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenNoPulseHandlerClassesThenNoOutputGenerated.verified.txt
+++ b/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenNoPulseHandlerClassesThenNoOutputGenerated.verified.txt
@@ -30,7 +30,7 @@
           Options: {
             DocumentationMode: Parse,
             Language: C#,
-            LanguageVersion: CSharp14
+            LanguageVersion: CSharpLatest
           }
         }
       },

--- a/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenOpenGenericHandlerAnnotatedThenPulse004Reported.verified.txt
+++ b/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenOpenGenericHandlerAnnotatedThenPulse004Reported.verified.txt
@@ -30,7 +30,7 @@
           Options: {
             DocumentationMode: Parse,
             Language: C#,
-            LanguageVersion: CSharp14
+            LanguageVersion: CSharpLatest
           }
         }
       },

--- a/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenQueryHandlerNotAnnotatedThenPulse003Reported.verified.txt
+++ b/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenQueryHandlerNotAnnotatedThenPulse003Reported.verified.txt
@@ -30,7 +30,7 @@
           Options: {
             DocumentationMode: Parse,
             Language: C#,
-            LanguageVersion: CSharp14
+            LanguageVersion: CSharpLatest
           }
         }
       },

--- a/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenRecordHandlerNotAnnotatedThenPulse003Reported.verified.txt
+++ b/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenRecordHandlerNotAnnotatedThenPulse003Reported.verified.txt
@@ -30,7 +30,7 @@
           Options: {
             DocumentationMode: Parse,
             Language: C#,
-            LanguageVersion: CSharp14
+            LanguageVersion: CSharpLatest
           }
         }
       },

--- a/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenStreamQueryHandlerNotAnnotatedThenPulse003Reported.verified.txt
+++ b/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenStreamQueryHandlerNotAnnotatedThenPulse003Reported.verified.txt
@@ -30,7 +30,7 @@
           Options: {
             DocumentationMode: Parse,
             Language: C#,
-            LanguageVersion: CSharp14
+            LanguageVersion: CSharpLatest
           }
         }
       },


### PR DESCRIPTION
Simplify snapshot path derivation using Path.GetRelativePath and organize snapshots under a "_snapshots" folder. Refactor line scrubbing to match and replace any "CSharp<N>" language version with "CSharpLatest" for consistency. Add [TestGroup] attributes to PulseHandlerGeneratorTests for better categorization. Update all verified test outputs to reflect the new language version scrubbing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refactored snapshot directory derivation to compute relative paths consistently.
  * Optimized line scrubbing callbacks to apply language-version and generated-code scrubbing sequentially in a single operation.
  * Updated language-version matching logic to align with modified replacement scope.
  * Added test grouping attributes for improved test organization and categorization.

* **Tests**
  * Updated test snapshots to reflect latest C# language version configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->