### PR TITLE
fix(test): Track GetPendingCountAsync invocations in test class

### DIFF
--- a/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorHostedServiceTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorHostedServiceTests.cs
@@ -1045,6 +1045,7 @@ public sealed class OutboxProcessorHostedServiceTests
         {
             lock (_lock)
             {
+                GetPendingCallCount++;
                 var count = _messages.Count(m => m.Status == OutboxMessageStatus.Pending);
                 return Task.FromResult((long)count);
             }


### PR DESCRIPTION
Increment GetPendingCallCount each time GetPendingCountAsync is called in OutboxProcessorHostedServiceTests to enable tracking of method invocations for testing and debugging purposes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test instrumentation to track pending query invocations in outbox processor tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->