### PR TITLE
feat(outbox): Add outbox repository health checks and startup gating

### DIFF
--- a/src/NetEvolve.Pulse.EntityFramework/Outbox/EntityFrameworkOutboxRepository.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Outbox/EntityFrameworkOutboxRepository.cs
@@ -120,6 +120,12 @@ internal sealed class EntityFrameworkOutboxRepository<TContext> : IOutboxReposit
         _context.OutboxMessages.LongCountAsync(m => m.Status == OutboxMessageStatus.Pending, cancellationToken);
 
     /// <inheritdoc />
+    public Task<bool> IsHealthyAsync(CancellationToken cancellationToken)
+        // A simple connectivity check to ensure the database is reachable.
+        =>
+        _context.Database.CanConnectAsync(cancellationToken);
+
+    /// <inheritdoc />
     public async Task<IReadOnlyList<OutboxMessage>> GetFailedForRetryAsync(
         int maxRetryCount,
         int batchSize,

--- a/src/NetEvolve.Pulse.Extensibility/Outbox/IOutboxRepository.cs
+++ b/src/NetEvolve.Pulse.Extensibility/Outbox/IOutboxRepository.cs
@@ -183,4 +183,20 @@ public interface IOutboxRepository
         int batchSize,
         CancellationToken cancellationToken = default
     );
+
+    /// <summary>
+    /// Checks whether the underlying storage backend is reachable and operational.
+    /// </summary>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>
+    /// <see langword="true"/> if the storage backend is reachable; otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <remarks>
+    /// The default implementation always returns <see langword="true"/>. Override to perform
+    /// a real connectivity check against the underlying storage backend (e.g., <c>CanConnectAsync</c>
+    /// for Entity Framework providers).
+    /// This result is evaluated before each processing cycle; an unhealthy result causes the cycle
+    /// to be skipped and delays the next poll by twice the configured <c>PollingInterval</c>.
+    /// </remarks>
+    Task<bool> IsHealthyAsync(CancellationToken cancellationToken) => Task.FromResult(true);
 }

--- a/src/NetEvolve.Pulse/Outbox/OutboxProcessorHostedService.cs
+++ b/src/NetEvolve.Pulse/Outbox/OutboxProcessorHostedService.cs
@@ -70,6 +70,9 @@ internal sealed partial class OutboxProcessorHostedService : BackgroundService
     /// <summary>The transport used to deliver outbox messages to their destination.</summary>
     private readonly IMessageTransport _transport;
 
+    /// <summary>The application lifetime used to defer processing until the application has fully started.</summary>
+    private readonly IHostApplicationLifetime _lifetime;
+
     /// <summary>The resolved processor configuration options controlling polling, batch size, and retry behaviour.</summary>
     private readonly OutboxProcessorOptions _options;
 
@@ -84,22 +87,26 @@ internal sealed partial class OutboxProcessorHostedService : BackgroundService
     /// </summary>
     /// <param name="repository">The repository for outbox message persistence.</param>
     /// <param name="transport">The transport for sending messages.</param>
+    /// <param name="lifetime">The application lifetime for coordinating startup and shutdown.</param>
     /// <param name="options">The processor configuration options.</param>
     /// <param name="logger">The logger for diagnostic output.</param>
     public OutboxProcessorHostedService(
         IOutboxRepository repository,
         IMessageTransport transport,
+        IHostApplicationLifetime lifetime,
         IOptions<OutboxProcessorOptions> options,
         ILogger<OutboxProcessorHostedService> logger
     )
     {
         ArgumentNullException.ThrowIfNull(repository);
         ArgumentNullException.ThrowIfNull(transport);
+        ArgumentNullException.ThrowIfNull(lifetime);
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(logger);
 
         _repository = repository;
         _transport = transport;
+        _lifetime = lifetime;
         _options = options.Value;
         _logger = logger;
 
@@ -114,15 +121,34 @@ internal sealed partial class OutboxProcessorHostedService : BackgroundService
     /// <inheritdoc />
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        var applicationStarted = new TaskCompletionSource();
+        _ = _lifetime.ApplicationStarted.Register(() => applicationStarted.TrySetResult());
+
+        await applicationStarted.Task.ConfigureAwait(false);
+
         LogProcessorStarted(_logger, _options.PollingInterval, _options.BatchSize);
 
         while (!stoppingToken.IsCancellationRequested)
         {
+            if (_options.DisableProcessing)
+            {
+                await Task.Delay(_options.PollingInterval, stoppingToken).ConfigureAwait(false);
+            }
+
             try
             {
+                // Check database health before processing
+                var isDatabaseHealthy = await _repository.IsHealthyAsync(stoppingToken).ConfigureAwait(false);
+                if (!isDatabaseHealthy)
+                {
+                    LogDatabaseUnhealthy(_logger);
+                    await Task.Delay(_options.PollingInterval * 2, stoppingToken).ConfigureAwait(false);
+                    continue;
+                }
+
                 // Check transport health before processing
-                var isHealthy = await _transport.IsHealthyAsync(stoppingToken).ConfigureAwait(false);
-                if (!isHealthy)
+                var isTransportHealthy = await _transport.IsHealthyAsync(stoppingToken).ConfigureAwait(false);
+                if (!isTransportHealthy)
                 {
                     LogTransportUnhealthy(_logger);
                     await Task.Delay(_options.PollingInterval, stoppingToken).ConfigureAwait(false);
@@ -569,4 +595,8 @@ internal sealed partial class OutboxProcessorHostedService : BackgroundService
     /// <summary>Logs a warning when recording an outbox metric fails, so metric errors never interrupt processing.</summary>
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to record outbox metric")]
     private static partial void LogMetricRecordingWarning(ILogger logger, Exception exception);
+
+    /// <summary>Logs an error that the database is currently unhealthy and the processing cycle is being skipped.</summary>
+    [LoggerMessage(Level = LogLevel.Error, Message = "Database is unhealthy, skipping processing cycle")]
+    private static partial void LogDatabaseUnhealthy(ILogger logger);
 }

--- a/src/NetEvolve.Pulse/Outbox/OutboxProcessorOptions.cs
+++ b/src/NetEvolve.Pulse/Outbox/OutboxProcessorOptions.cs
@@ -92,6 +92,13 @@ public sealed class OutboxProcessorOptions
     public bool AddJitter { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets a value indicating whether to suspend outbox message dispatching.
+    /// When <see langword="true"/>, each polling cycle is preceded by an additional
+    /// <see cref="PollingInterval"/> delay without dispatching any messages.
+    /// </summary>
+    internal bool DisableProcessing { get; set; }
+
+    /// <summary>
     /// Gets per-event-type configuration overrides via a thread-safe concurrent dictionary.
     /// </summary>
     /// <remarks>

--- a/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/EntityFrameworkOutboxRepositoryTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/EntityFrameworkOutboxRepositoryTests.cs
@@ -55,4 +55,18 @@ public sealed class EntityFrameworkOutboxRepositoryTests
             .That(async () => await repository.AddAsync(null!).ConfigureAwait(false))
             .Throws<ArgumentNullException>();
     }
+
+    [Test]
+    public async Task IsHealthyAsync_WithInMemoryProvider_ReturnsTrue()
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase(nameof(IsHealthyAsync_WithInMemoryProvider_ReturnsTrue))
+            .Options;
+        await using var context = new TestDbContext(options);
+        var repository = new EntityFrameworkOutboxRepository<TestDbContext>(context, TimeProvider.System);
+
+        var result = await repository.IsHealthyAsync(CancellationToken.None).ConfigureAwait(false);
+
+        _ = await Assert.That(result).IsTrue();
+    }
 }

--- a/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorHostedServiceTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorHostedServiceTests.cs
@@ -2,6 +2,7 @@ namespace NetEvolve.Pulse.Tests.Unit.Outbox;
 
 using System.Diagnostics.Metrics;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
@@ -27,7 +28,7 @@ public sealed class OutboxProcessorHostedServiceTests
 
         _ = Assert.Throws<ArgumentNullException>(
             "repository",
-            () => _ = new OutboxProcessorHostedService(repository!, transport, options, logger)
+            () => _ = new OutboxProcessorHostedService(repository!, transport, CreateLifetime(), options, logger)
         );
     }
 
@@ -41,7 +42,7 @@ public sealed class OutboxProcessorHostedServiceTests
 
         _ = Assert.Throws<ArgumentNullException>(
             "transport",
-            () => _ = new OutboxProcessorHostedService(repository, transport!, options, logger)
+            () => _ = new OutboxProcessorHostedService(repository, transport!, CreateLifetime(), options, logger)
         );
     }
 
@@ -55,7 +56,7 @@ public sealed class OutboxProcessorHostedServiceTests
 
         _ = Assert.Throws<ArgumentNullException>(
             "options",
-            () => _ = new OutboxProcessorHostedService(repository, transport, options!, logger)
+            () => _ = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options!, logger)
         );
     }
 
@@ -69,7 +70,22 @@ public sealed class OutboxProcessorHostedServiceTests
 
         _ = Assert.Throws<ArgumentNullException>(
             "logger",
-            () => _ = new OutboxProcessorHostedService(repository, transport, options, logger!)
+            () => _ = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger!)
+        );
+    }
+
+    [Test]
+    public async Task Constructor_WithNullLifetime_ThrowsArgumentNullException()
+    {
+        var repository = new InMemoryOutboxRepository();
+        var transport = new InMemoryMessageTransport();
+        IHostApplicationLifetime? lifetime = null;
+        var options = Options.Create(new OutboxProcessorOptions());
+        var logger = CreateLogger();
+
+        _ = Assert.Throws<ArgumentNullException>(
+            "lifetime",
+            () => _ = new OutboxProcessorHostedService(repository, transport, lifetime!, options, logger)
         );
     }
 
@@ -81,7 +97,7 @@ public sealed class OutboxProcessorHostedServiceTests
         var options = Options.Create(new OutboxProcessorOptions());
         var logger = CreateLogger();
 
-        using var service = new OutboxProcessorHostedService(repository, transport, options, logger);
+        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
 
         _ = await Assert.That(service).IsNotNull();
     }
@@ -93,7 +109,7 @@ public sealed class OutboxProcessorHostedServiceTests
         var transport = new InMemoryMessageTransport();
         var options = Options.Create(new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50) });
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, options, logger);
+        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
 
         using var cts = new CancellationTokenSource();
 
@@ -116,7 +132,7 @@ public sealed class OutboxProcessorHostedServiceTests
         var transport = new InMemoryMessageTransport();
         var options = Options.Create(new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50) });
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, options, logger);
+        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
 
         using var cts = new CancellationTokenSource();
 
@@ -137,7 +153,7 @@ public sealed class OutboxProcessorHostedServiceTests
         var transport = new InMemoryMessageTransport();
         var options = Options.Create(new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50) });
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, options, logger);
+        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
 
         // Add a pending message
         var message = CreateMessage();
@@ -168,7 +184,7 @@ public sealed class OutboxProcessorHostedServiceTests
         var transport = new InMemoryMessageTransport();
         var options = Options.Create(new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50) });
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, options, logger);
+        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
 
         // Add multiple messages
         var message1 = CreateMessage();
@@ -200,7 +216,7 @@ public sealed class OutboxProcessorHostedServiceTests
         var transport = new InMemoryMessageTransport();
         var options = Options.Create(new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(200) });
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, options, logger);
+        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
 
         using var cts = new CancellationTokenSource();
 
@@ -223,7 +239,7 @@ public sealed class OutboxProcessorHostedServiceTests
             new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50), MaxRetryCount = 3 }
         );
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, options, logger);
+        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
 
         var message = CreateMessage();
         await repository.AddAsync(message).ConfigureAwait(false);
@@ -248,7 +264,7 @@ public sealed class OutboxProcessorHostedServiceTests
             new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50), MaxRetryCount = 2 }
         );
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, options, logger);
+        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
 
         // Add a message that has already been retried once
         var message = CreateMessage();
@@ -275,7 +291,7 @@ public sealed class OutboxProcessorHostedServiceTests
             new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50), MaxRetryCount = 3 }
         );
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, options, logger);
+        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
 
         var message = CreateMessage();
         await repository.AddAsync(message).ConfigureAwait(false);
@@ -301,7 +317,7 @@ public sealed class OutboxProcessorHostedServiceTests
             new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50), EnableBatchSending = true }
         );
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, options, logger);
+        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
 
         var message1 = CreateMessage();
         var message2 = CreateMessage();
@@ -332,7 +348,7 @@ public sealed class OutboxProcessorHostedServiceTests
             new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50), EnableBatchSending = true }
         );
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, options, logger);
+        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
 
         var message1 = CreateMessage();
         var message2 = CreateMessage();
@@ -370,7 +386,7 @@ public sealed class OutboxProcessorHostedServiceTests
             new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50), BatchSize = 2 }
         );
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, options, logger);
+        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
 
         // Add more messages than batch size
         for (var i = 0; i < 5; i++)
@@ -407,7 +423,7 @@ public sealed class OutboxProcessorHostedServiceTests
             }
         );
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, options, logger);
+        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
 
         // Message of type CriticalEvent should use override (MaxRetryCount = 1)
         var message = CreateMessage(typeof(CriticalEvent));
@@ -464,7 +480,7 @@ public sealed class OutboxProcessorHostedServiceTests
             }
         );
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, options, logger);
+        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
 
         // SlowEvent message should time out and be marked as failed/dead-lettered
         var message = CreateMessage(typeof(SlowEvent));
@@ -497,7 +513,7 @@ public sealed class OutboxProcessorHostedServiceTests
             }
         );
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, options, logger);
+        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
 
         // Add two messages of the overridden type: should be batch-sent
         var message1 = CreateMessage(typeof(BatchEvent));
@@ -629,7 +645,7 @@ public sealed class OutboxProcessorHostedServiceTests
         var transport = new InMemoryMessageTransport();
         var options = Options.Create(new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50) });
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, options, logger);
+        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
 
         var message = CreateMessage();
         await repository.AddAsync(message).ConfigureAwait(false);
@@ -676,7 +692,7 @@ public sealed class OutboxProcessorHostedServiceTests
             new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50), MaxRetryCount = 3 }
         );
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, options, logger);
+        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
 
         var message = CreateMessage();
         await repository.AddAsync(message).ConfigureAwait(false);
@@ -721,7 +737,7 @@ public sealed class OutboxProcessorHostedServiceTests
             new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50), MaxRetryCount = 2 }
         );
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, options, logger);
+        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
 
         var message = CreateMessage();
         message.RetryCount = 1;
@@ -765,7 +781,7 @@ public sealed class OutboxProcessorHostedServiceTests
         var transport = new InMemoryMessageTransport();
         var options = Options.Create(new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50) });
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, options, logger);
+        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
 
         using var cts = new CancellationTokenSource();
         await service.StartAsync(cts.Token).ConfigureAwait(false);
@@ -805,7 +821,7 @@ public sealed class OutboxProcessorHostedServiceTests
         var transport = new InMemoryMessageTransport();
         var options = Options.Create(new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50) });
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, options, logger);
+        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
 
         // Add 3 pending messages before starting
         await repository.AddAsync(CreateMessage()).ConfigureAwait(false);
@@ -854,7 +870,7 @@ public sealed class OutboxProcessorHostedServiceTests
             }
         );
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, options, logger);
+        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
 
         var message = CreateMessage();
         await repository.AddAsync(message).ConfigureAwait(false);
@@ -903,7 +919,7 @@ public sealed class OutboxProcessorHostedServiceTests
             }
         );
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, options, logger);
+        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
 
         var message = CreateMessage();
         await repository.AddAsync(message).ConfigureAwait(false);
@@ -1000,11 +1016,101 @@ public sealed class OutboxProcessorHostedServiceTests
         _ = await Assert.That(failedForRetry.Count).IsEqualTo(1);
     }
 
+    [Test]
+    public async Task ExecuteAsync_WaitsForApplicationStarted_BeforeProcessingMessages()
+    {
+        var repository = new InMemoryOutboxRepository();
+        var transport = new InMemoryMessageTransport();
+        var options = Options.Create(new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50) });
+        var logger = CreateLogger();
+        using var lifetime = new PendingStartLifetime();
+        using var service = new OutboxProcessorHostedService(repository, transport, lifetime, options, logger);
+
+        await repository.AddAsync(CreateMessage()).ConfigureAwait(false);
+
+        using var cts = new CancellationTokenSource();
+        await service.StartAsync(cts.Token).ConfigureAwait(false);
+
+        // Give the service ample time to run polling cycles if it were already started.
+        await Task.Delay(200).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(transport.SentMessages).IsEmpty();
+            _ = await Assert.That(repository.GetPendingCallCount).IsEqualTo(0);
+        }
+
+        // Now signal that the application has fully started.
+        lifetime.SignalStarted();
+
+        await Task.Delay(200).ConfigureAwait(false);
+        await cts.CancelAsync().ConfigureAwait(false);
+        await service.StopAsync(CancellationToken.None).ConfigureAwait(false);
+
+        // Processing must have happened after ApplicationStarted fired.
+        _ = await Assert.That(transport.SentMessages).HasSingleItem();
+    }
+
+    [Test]
+    public async Task ExecuteAsync_WhenDatabaseIsUnhealthy_SkipsProcessingCycle()
+    {
+        var repository = new InMemoryOutboxRepository { IsHealthy = false };
+        var transport = new InMemoryMessageTransport();
+        var options = Options.Create(new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50) });
+        var logger = CreateLogger();
+        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+
+        await repository.AddAsync(CreateMessage()).ConfigureAwait(false);
+
+        using var cts = new CancellationTokenSource();
+        await service.StartAsync(cts.Token).ConfigureAwait(false);
+        await Task.Delay(300).ConfigureAwait(false);
+        await cts.CancelAsync().ConfigureAwait(false);
+        await service.StopAsync(CancellationToken.None).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(transport.SentMessages).IsEmpty();
+            _ = await Assert.That(repository.CompletedMessageIds).IsEmpty();
+        }
+    }
+
+    [Test]
+    public async Task ExecuteAsync_WhenDatabaseBecomesHealthy_ResumesProcessing()
+    {
+        var repository = new InMemoryOutboxRepository { IsHealthy = false };
+        var transport = new InMemoryMessageTransport();
+        var options = Options.Create(new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50) });
+        var logger = CreateLogger();
+        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+
+        await repository.AddAsync(CreateMessage()).ConfigureAwait(false);
+
+        using var cts = new CancellationTokenSource();
+        await service.StartAsync(cts.Token).ConfigureAwait(false);
+
+        // Allow several unhealthy cycles to pass.
+        await Task.Delay(150).ConfigureAwait(false);
+
+        _ = await Assert.That(transport.SentMessages).IsEmpty();
+
+        // Restore database health and allow processing to resume.
+        repository.IsHealthy = true;
+
+        await Task.Delay(300).ConfigureAwait(false);
+        await cts.CancelAsync().ConfigureAwait(false);
+        await service.StopAsync(CancellationToken.None).ConfigureAwait(false);
+
+        _ = await Assert.That(transport.SentMessages).HasSingleItem();
+    }
+
     private static ILogger<OutboxProcessorHostedService> CreateLogger() =>
         new ServiceCollection()
             .AddLogging()
             .BuildServiceProvider()
             .GetRequiredService<ILogger<OutboxProcessorHostedService>>();
+
+    private static FakeHostApplicationLifetime CreateLifetime() => new();
 
     private static OutboxMessage CreateMessage(Type? eventType = null) =>
         new()
@@ -1040,6 +1146,10 @@ public sealed class OutboxProcessorHostedServiceTests
 
         public Task<int> DeleteCompletedAsync(TimeSpan olderThan, CancellationToken cancellationToken = default) =>
             Task.FromResult(0);
+
+        public bool IsHealthy { get; set; } = true;
+
+        public Task<bool> IsHealthyAsync(CancellationToken cancellationToken) => Task.FromResult(IsHealthy);
 
         public Task<long> GetPendingCountAsync(CancellationToken cancellationToken = default)
         {
@@ -1313,5 +1423,34 @@ public sealed class OutboxProcessorHostedServiceTests
         public string? CorrelationId { get; set; }
         public string Id { get; init; } = Guid.NewGuid().ToString();
         public DateTimeOffset? PublishedAt { get; set; }
+    }
+
+    private sealed class FakeHostApplicationLifetime : IHostApplicationLifetime
+    {
+        // A pre-cancelled token signals that the application has already started,
+        // causing ExecuteAsync to proceed immediately without allocating a CancellationTokenSource.
+        private static readonly CancellationToken s_startedToken = new(canceled: true);
+
+        public CancellationToken ApplicationStarted => s_startedToken;
+        public CancellationToken ApplicationStopping => CancellationToken.None;
+        public CancellationToken ApplicationStopped => CancellationToken.None;
+
+        public void StopApplication() { }
+    }
+
+    private sealed class PendingStartLifetime : IHostApplicationLifetime, IDisposable
+    {
+        private readonly CancellationTokenSource _startedCts = new();
+
+        // Not yet cancelled: ExecuteAsync will block until SignalStarted() is called.
+        public CancellationToken ApplicationStarted => _startedCts.Token;
+        public CancellationToken ApplicationStopping => CancellationToken.None;
+        public CancellationToken ApplicationStopped => CancellationToken.None;
+
+        public void Dispose() => _startedCts.Dispose();
+
+        public void StopApplication() { }
+
+        public void SignalStarted() => _startedCts.Cancel();
     }
 }


### PR DESCRIPTION
Introduce health checks for the outbox repository via a new IsHealthyAsync method on IOutboxRepository, with EntityFrameworkOutboxRepository using CanConnectAsync for connectivity. OutboxProcessorHostedService now waits for application startup and checks both database and transport health before each processing cycle, skipping cycles and logging errors if unhealthy. Tests updated to cover new behaviors, including startup gating and health transitions. Adds DisableProcessing option for advanced scenarios. Improves reliability and testability of outbox processing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added database health checks to the outbox processor for improved reliability and operational visibility.
  * Message processing now properly defers until application startup completes.
  * Added option to disable outbox message dispatching.

* **Tests**
  * Enhanced test coverage for health check and startup sequencing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->