### PR TITLE
fix: Implement IDisposable in EntityFrameworkOutboxRepository

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -272,6 +272,7 @@ dotnet_diagnostic.IDE0290.severity                                      = sugges
 
 # IDE0060: Remove unused parameter
 dotnet_diagnostic.IDE0060.severity                                      = warning
+dotnet_diagnostic.RCS1163.severity                                      = none
 dotnet_code_quality_unused_parameters                                   = all
 
 # [CSharpier] Incompatible rules deactivated

--- a/src/NetEvolve.Pulse.EntityFramework/Outbox/EntityFrameworkOutboxRepository.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Outbox/EntityFrameworkOutboxRepository.cs
@@ -17,7 +17,7 @@ using NetEvolve.Pulse.Extensibility.Outbox;
 /// consider using the SQL Server ADO.NET provider with explicit locking.
 /// </remarks>
 /// <typeparam name="TContext">The DbContext type that implements <see cref="IOutboxDbContext"/>.</typeparam>
-internal sealed class EntityFrameworkOutboxRepository<TContext> : IOutboxRepository
+internal sealed class EntityFrameworkOutboxRepository<TContext> : IOutboxRepository, IDisposable
     where TContext : DbContext, IOutboxDbContext
 {
     /// <summary>The DbContext used to build LINQ queries passed to the executor.</summary>
@@ -31,6 +31,7 @@ internal sealed class EntityFrameworkOutboxRepository<TContext> : IOutboxReposit
     /// (change-tracking + <c>SaveChangesAsync</c> vs. bulk <c>ExecuteUpdate</c> / <c>ExecuteDelete</c>).
     /// </summary>
     private readonly IOutboxOperationsExecutor _executor;
+    private bool _disposedValue;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="EntityFrameworkOutboxRepository{TContext}"/> class.
@@ -294,5 +295,25 @@ internal sealed class EntityFrameworkOutboxRepository<TContext> : IOutboxReposit
                 cancellationToken
             )
             .ConfigureAwait(false);
+    }
+
+    private void Dispose(bool disposing)
+    {
+        if (!_disposedValue)
+        {
+            if (disposing)
+            {
+                _executor.Dispose();
+            }
+
+            _disposedValue = true;
+        }
+    }
+
+    public void Dispose()
+    {
+        // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
     }
 }

--- a/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/EntityFrameworkOutboxRepositoryTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/EntityFrameworkOutboxRepositoryTests.cs
@@ -1,4 +1,4 @@
-namespace NetEvolve.Pulse.Tests.Unit.EntityFramework;
+﻿namespace NetEvolve.Pulse.Tests.Unit.EntityFramework;
 
 using System;
 using System.Threading.Tasks;
@@ -37,7 +37,7 @@ public sealed class EntityFrameworkOutboxRepositoryTests
             .Options;
         await using var context = new TestDbContext(options);
 
-        var repository = new EntityFrameworkOutboxRepository<TestDbContext>(context, TimeProvider.System);
+        using var repository = new EntityFrameworkOutboxRepository<TestDbContext>(context, TimeProvider.System);
 
         _ = await Assert.That(repository).IsNotNull();
     }
@@ -49,7 +49,7 @@ public sealed class EntityFrameworkOutboxRepositoryTests
             .UseInMemoryDatabase(nameof(AddAsync_WithNullMessage_ThrowsArgumentNullException))
             .Options;
         await using var context = new TestDbContext(options);
-        var repository = new EntityFrameworkOutboxRepository<TestDbContext>(context, TimeProvider.System);
+        using var repository = new EntityFrameworkOutboxRepository<TestDbContext>(context, TimeProvider.System);
 
         _ = await Assert
             .That(async () => await repository.AddAsync(null!, cancellationToken).ConfigureAwait(false))
@@ -63,7 +63,7 @@ public sealed class EntityFrameworkOutboxRepositoryTests
             .UseInMemoryDatabase(nameof(IsHealthyAsync_WithInMemoryProvider_ReturnsTrue))
             .Options;
         await using var context = new TestDbContext(options);
-        var repository = new EntityFrameworkOutboxRepository<TestDbContext>(context, TimeProvider.System);
+        using var repository = new EntityFrameworkOutboxRepository<TestDbContext>(context, TimeProvider.System);
 
         var result = await repository.IsHealthyAsync(cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
Added IDisposable implementation to EntityFrameworkOutboxRepository<TContext> for proper resource cleanup. The _executor field is now disposed when the repository is disposed, preventing potential memory leaks and improving resource management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved resource management for internal components to ensure proper cleanup
  * Updated code analysis configuration settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->