### PR TITLE
test: EF outbox management for provider compatibility

### DIFF
--- a/src/NetEvolve.Pulse.EntityFramework/Outbox/BulkOutboxManagementExecutor.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Outbox/BulkOutboxManagementExecutor.cs
@@ -21,6 +21,7 @@ internal sealed class BulkOutboxManagementExecutor<TContext>(TContext context) :
         context
             .OutboxMessages.Where(m => m.Status == OutboxMessageStatus.DeadLetter)
             .OrderByDescending(m => m.UpdatedAt)
+            .ThenByDescending(m => m.Id)
             .Skip(skip)
             .Take(take)
             .AsNoTracking();

--- a/src/NetEvolve.Pulse.EntityFramework/Outbox/BulkOutboxManagementExecutor.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Outbox/BulkOutboxManagementExecutor.cs
@@ -1,0 +1,65 @@
+namespace NetEvolve.Pulse.Outbox;
+
+using Microsoft.EntityFrameworkCore;
+using NetEvolve.Pulse.Extensibility.Outbox;
+
+/// <summary>
+/// <see cref="IOutboxManagementExecutor"/> implementation that issues bulk
+/// <c>ExecuteUpdateAsync</c> statements per operation.
+/// </summary>
+/// <remarks>
+/// Suitable for any EF Core provider that supports <c>ExecuteUpdateAsync</c> and correctly
+/// handles value converters in the update parameters (SQL Server, PostgreSQL, SQLite,
+/// Pomelo MySQL, and others).
+/// </remarks>
+/// <typeparam name="TContext">The DbContext type that implements <see cref="IOutboxDbContext"/>.</typeparam>
+internal sealed class BulkOutboxManagementExecutor<TContext>(TContext context) : IOutboxManagementExecutor
+    where TContext : DbContext, IOutboxDbContext
+{
+    /// <inheritdoc />
+    public IQueryable<OutboxMessage> GetDeadLetterMessages(int skip, int take) =>
+        context
+            .OutboxMessages.Where(m => m.Status == OutboxMessageStatus.DeadLetter)
+            .OrderByDescending(m => m.UpdatedAt)
+            .Skip(skip)
+            .Take(take)
+            .AsNoTracking();
+
+    /// <inheritdoc />
+    public Task<OutboxMessage?> GetDeadLetterMessageAsync(Guid id, CancellationToken cancellationToken) =>
+        context
+            .OutboxMessages.Where(m => m.Id == id && m.Status == OutboxMessageStatus.DeadLetter)
+            .AsNoTracking()
+            .FirstOrDefaultAsync(cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<bool> ReplayByIdAsync(Guid id, DateTimeOffset updatedAt, CancellationToken cancellationToken)
+    {
+        var updated = await context
+            .OutboxMessages.Where(m => m.Id == id && m.Status == OutboxMessageStatus.DeadLetter)
+            .ExecuteUpdateAsync(
+                m =>
+                    m.SetProperty(p => p.Status, OutboxMessageStatus.Pending)
+                        .SetProperty(p => p.RetryCount, 0)
+                        .SetProperty(p => p.Error, (string?)null)
+                        .SetProperty(p => p.UpdatedAt, updatedAt),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        return updated > 0;
+    }
+
+    /// <inheritdoc />
+    public Task<int> ReplayAllAsync(DateTimeOffset updatedAt, CancellationToken cancellationToken) =>
+        context
+            .OutboxMessages.Where(m => m.Status == OutboxMessageStatus.DeadLetter)
+            .ExecuteUpdateAsync(
+                m =>
+                    m.SetProperty(p => p.Status, OutboxMessageStatus.Pending)
+                        .SetProperty(p => p.RetryCount, 0)
+                        .SetProperty(p => p.Error, (string?)null)
+                        .SetProperty(p => p.UpdatedAt, updatedAt),
+                cancellationToken
+            );
+}

--- a/src/NetEvolve.Pulse.EntityFramework/Outbox/EntityFrameworkOutboxManagement.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Outbox/EntityFrameworkOutboxManagement.cs
@@ -60,6 +60,13 @@ internal sealed class EntityFrameworkOutboxManagement<TContext> : IOutboxManagem
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pageSize);
         ArgumentOutOfRangeException.ThrowIfNegative(page);
 
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pageSize);
+        ArgumentOutOfRangeException.ThrowIfNegative(page);
+        if (page > int.MaxValue / pageSize)
+        {
+            throw new ArgumentOutOfRangeException(nameof(page), "The requested page is too large.");
+        }
+
         return await _executor
             .GetDeadLetterMessages(page * pageSize, pageSize)
             .ToListAsync(cancellationToken)

--- a/src/NetEvolve.Pulse.EntityFramework/Outbox/EntityFrameworkOutboxManagement.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Outbox/EntityFrameworkOutboxManagement.cs
@@ -7,41 +7,26 @@ using NetEvolve.Pulse.Extensibility.Outbox;
 /// Entity Framework Core implementation of <see cref="IOutboxManagement"/>.
 /// Provides dead-letter inspection, replay, and statistics queries using any EF Core database provider.
 /// </summary>
+/// <remarks>
+/// Read and write operations are dispatched to a provider-specific <see cref="IOutboxManagementExecutor"/>
+/// selected at construction time. The count query and statistics aggregation run directly against
+/// <see cref="IOutboxDbContext.OutboxMessages"/> and are provider-agnostic.
+/// </remarks>
 /// <typeparam name="TContext">The DbContext type that implements <see cref="IOutboxDbContext"/>.</typeparam>
 internal sealed class EntityFrameworkOutboxManagement<TContext> : IOutboxManagement
     where TContext : DbContext, IOutboxDbContext
 {
-    /// <summary>Pre-compiled paged dead-letter query; eliminates expression-tree overhead on every call.</summary>
-    private static readonly Func<TContext, int, int, IAsyncEnumerable<OutboxMessage>> DeadLetterPageQuery =
-        EF.CompileAsyncQuery(
-            (TContext ctx, int skip, int take) =>
-                ctx
-                    .OutboxMessages.Where(m => m.Status == OutboxMessageStatus.DeadLetter)
-                    .OrderByDescending(m => m.UpdatedAt)
-                    .Skip(skip)
-                    .Take(take)
-                    .AsNoTracking()
-        );
-
-    /// <summary>Pre-compiled single dead-letter lookup; eliminates expression-tree overhead on every call.</summary>
-    private static readonly Func<TContext, Guid, Task<OutboxMessage?>> DeadLetterByIdQuery = EF.CompileAsyncQuery(
-        (TContext ctx, Guid id) =>
-            ctx
-                .OutboxMessages.Where(m => m.Id == id && m.Status == OutboxMessageStatus.DeadLetter)
-                .AsNoTracking()
-                .FirstOrDefault()
-    );
-
-    /// <summary>Pre-compiled dead-letter count query; eliminates expression-tree overhead on every call.</summary>
-    private static readonly Func<TContext, Task<long>> DeadLetterCountQuery = EF.CompileAsyncQuery(
-        (TContext ctx) => ctx.OutboxMessages.LongCount(m => m.Status == OutboxMessageStatus.DeadLetter)
-    );
-
     /// <summary>The DbContext used for all LINQ-to-SQL query and update operations.</summary>
     private readonly TContext _context;
 
     /// <summary>The time provider used to generate consistent update timestamps.</summary>
     private readonly TimeProvider _timeProvider;
+
+    /// <summary>
+    /// Provider-specific strategy that handles how read and write operations are executed
+    /// (<c>ExecuteUpdateAsync</c> / compiled queries vs. plain LINQ + <c>SaveChangesAsync</c>).
+    /// </summary>
+    private readonly IOutboxManagementExecutor _executor;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="EntityFrameworkOutboxManagement{TContext}"/> class.
@@ -55,6 +40,14 @@ internal sealed class EntityFrameworkOutboxManagement<TContext> : IOutboxManagem
 
         _context = context;
         _timeProvider = timeProvider;
+        _executor = context.Database.ProviderName switch
+        {
+            // InMemory does not support ExecuteUpdate/ExecuteDelete at all.
+            ProviderName.InMemory => new TrackingOutboxManagementExecutor<TContext>(context),
+            // Oracle MySQL cannot apply value converters in ExecuteUpdateAsync parameters.
+            ProviderName.OracleMySql => new TrackingOutboxManagementExecutor<TContext>(context),
+            _ => new BulkOutboxManagementExecutor<TContext>(context),
+        };
     }
 
     /// <inheritdoc />
@@ -67,70 +60,29 @@ internal sealed class EntityFrameworkOutboxManagement<TContext> : IOutboxManagem
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pageSize);
         ArgumentOutOfRangeException.ThrowIfNegative(page);
 
-        var result = new List<OutboxMessage>(pageSize);
-        await foreach (
-            var message in DeadLetterPageQuery(_context, page * pageSize, pageSize)
-                .WithCancellation(cancellationToken)
-                .ConfigureAwait(false)
-        )
-        {
-            result.Add(message);
-        }
-
-        return result;
-    }
-
-    /// <inheritdoc />
-    public Task<OutboxMessage?> GetDeadLetterMessageAsync(Guid messageId, CancellationToken cancellationToken = default)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        return DeadLetterByIdQuery(_context, messageId);
-    }
-
-    /// <inheritdoc />
-    public Task<long> GetDeadLetterCountAsync(CancellationToken cancellationToken = default)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        return DeadLetterCountQuery(_context);
-    }
-
-    /// <inheritdoc />
-    public async Task<bool> ReplayMessageAsync(Guid messageId, CancellationToken cancellationToken = default)
-    {
-        var now = _timeProvider.GetUtcNow();
-
-        var updated = await _context
-            .OutboxMessages.Where(m => m.Id == messageId && m.Status == OutboxMessageStatus.DeadLetter)
-            .ExecuteUpdateAsync(
-                m =>
-                    m.SetProperty(m => m.Status, OutboxMessageStatus.Pending)
-                        .SetProperty(m => m.RetryCount, 0)
-                        .SetProperty(m => m.Error, (string?)null)
-                        .SetProperty(m => m.UpdatedAt, now),
-                cancellationToken
-            )
-            .ConfigureAwait(false);
-
-        return updated > 0;
-    }
-
-    /// <inheritdoc />
-    public async Task<int> ReplayAllDeadLetterAsync(CancellationToken cancellationToken = default)
-    {
-        var now = _timeProvider.GetUtcNow();
-
-        return await _context
-            .OutboxMessages.Where(m => m.Status == OutboxMessageStatus.DeadLetter)
-            .ExecuteUpdateAsync(
-                m =>
-                    m.SetProperty(m => m.Status, OutboxMessageStatus.Pending)
-                        .SetProperty(m => m.RetryCount, 0)
-                        .SetProperty(m => m.Error, (string?)null)
-                        .SetProperty(m => m.UpdatedAt, now),
-                cancellationToken
-            )
+        return await _executor
+            .GetDeadLetterMessages(page * pageSize, pageSize)
+            .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
     }
+
+    /// <inheritdoc />
+    public Task<OutboxMessage?> GetDeadLetterMessageAsync(
+        Guid messageId,
+        CancellationToken cancellationToken = default
+    ) => _executor.GetDeadLetterMessageAsync(messageId, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<long> GetDeadLetterCountAsync(CancellationToken cancellationToken = default) =>
+        _context.OutboxMessages.LongCountAsync(m => m.Status == OutboxMessageStatus.DeadLetter, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<bool> ReplayMessageAsync(Guid messageId, CancellationToken cancellationToken = default) =>
+        _executor.ReplayByIdAsync(messageId, _timeProvider.GetUtcNow(), cancellationToken);
+
+    /// <inheritdoc />
+    public Task<int> ReplayAllDeadLetterAsync(CancellationToken cancellationToken = default) =>
+        _executor.ReplayAllAsync(_timeProvider.GetUtcNow(), cancellationToken);
 
     /// <inheritdoc />
     public async Task<OutboxStatistics> GetStatisticsAsync(CancellationToken cancellationToken = default)

--- a/src/NetEvolve.Pulse.EntityFramework/Outbox/IOutboxManagementExecutor.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Outbox/IOutboxManagementExecutor.cs
@@ -1,0 +1,46 @@
+namespace NetEvolve.Pulse.Outbox;
+
+using NetEvolve.Pulse.Extensibility.Outbox;
+
+/// <summary>
+/// Defines the provider-specific strategy for executing outbox management operations.
+/// </summary>
+internal interface IOutboxManagementExecutor
+{
+    /// <summary>
+    /// Returns a paged, non-tracking query of dead-letter messages ordered by
+    /// <see cref="OutboxMessage.UpdatedAt"/> descending.
+    /// </summary>
+    /// <param name="skip">The number of messages to skip (offset).</param>
+    /// <param name="take">The maximum number of messages to return (page size).</param>
+    /// <returns>
+    /// An <see cref="IQueryable{T}"/> that can be further composed or materialized
+    /// by the caller (e.g. via <c>ToListAsync</c>).
+    /// </returns>
+    IQueryable<OutboxMessage> GetDeadLetterMessages(int skip, int take);
+
+    /// <summary>
+    /// Returns the dead-letter message with the given identifier, or <see langword="null"/> if not found.
+    /// </summary>
+    /// <param name="id">The unique identifier of the dead-letter message to retrieve.</param>
+    /// <param name="cancellationToken">Propagates notification that the operation should be cancelled.</param>
+    /// <returns>The matching <see cref="OutboxMessage"/>, or <see langword="null"/>.</returns>
+    Task<OutboxMessage?> GetDeadLetterMessageAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Resets a single dead-letter message back to <see cref="OutboxMessageStatus.Pending"/> state.
+    /// </summary>
+    /// <param name="id">The unique identifier of the dead-letter message to replay.</param>
+    /// <param name="updatedAt">The timestamp to write into <see cref="OutboxMessage.UpdatedAt"/>.</param>
+    /// <param name="cancellationToken">Propagates notification that the operation should be cancelled.</param>
+    /// <returns><see langword="true"/> if the message was found and reset; otherwise <see langword="false"/>.</returns>
+    Task<bool> ReplayByIdAsync(Guid id, DateTimeOffset updatedAt, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Resets all dead-letter messages back to <see cref="OutboxMessageStatus.Pending"/> state.
+    /// </summary>
+    /// <param name="updatedAt">The timestamp to write into <see cref="OutboxMessage.UpdatedAt"/> for each message.</param>
+    /// <param name="cancellationToken">Propagates notification that the operation should be cancelled.</param>
+    /// <returns>The number of messages that were reset.</returns>
+    Task<int> ReplayAllAsync(DateTimeOffset updatedAt, CancellationToken cancellationToken);
+}

--- a/src/NetEvolve.Pulse.EntityFramework/Outbox/IOutboxRepositoryExecutor.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Outbox/IOutboxRepositoryExecutor.cs
@@ -7,6 +7,27 @@ using NetEvolve.Pulse.Extensibility.Outbox;
 /// </summary>
 internal interface IOutboxRepositoryExecutor : IDisposable
 {
+    /// <summary>
+    /// Atomically fetches the entities returned by <paramref name="baseQuery"/>, marks each one
+    /// with <paramref name="newStatus"/> and <paramref name="updatedAt"/>, and returns the
+    /// updated messages.
+    /// </summary>
+    /// <remarks>
+    /// This is the core "fetch-and-lock" primitive used by the outbox processor.
+    /// Marking messages as <see cref="OutboxMessageStatus.Processing"/> before handing them to
+    /// the caller prevents concurrent workers from picking up the same batch.
+    /// </remarks>
+    /// <param name="baseQuery">
+    /// A pre-filtered, pre-ordered, and already-limited query that selects the candidate messages.
+    /// </param>
+    /// <param name="updatedAt">
+    /// The timestamp written to <see cref="OutboxMessage.UpdatedAt"/> for every updated message.
+    /// </param>
+    /// <param name="newStatus">
+    /// The status to assign to each message, typically <see cref="OutboxMessageStatus.Processing"/>.
+    /// </param>
+    /// <param name="cancellationToken">Propagates notification that the operation should be cancelled.</param>
+    /// <returns>The messages that were fetched and marked, in the order returned by the database.</returns>
     Task<OutboxMessage[]> FetchAndMarkAsync(
         IQueryable<OutboxMessage> baseQuery,
         DateTimeOffset updatedAt,
@@ -14,6 +35,39 @@ internal interface IOutboxRepositoryExecutor : IDisposable
         CancellationToken cancellationToken
     );
 
+    /// <summary>
+    /// Applies a status transition and related field updates to every message matched by
+    /// <paramref name="query"/>.
+    /// </summary>
+    /// <remarks>
+    /// Used to record the outcome of a single message (completed, failed, or dead-lettered).
+    /// <paramref name="processedAt"/> is only written when it carries a value; it is left
+    /// unchanged otherwise. <paramref name="errorMessage"/> replaces any previously stored error.
+    /// <paramref name="retryIncrement"/> is added to the current <see cref="OutboxMessage.RetryCount"/>.
+    /// </remarks>
+    /// <param name="query">
+    /// A pre-filtered query that targets only the rows to update, typically filtered by
+    /// message ID and <see cref="OutboxMessageStatus.Processing"/>.
+    /// </param>
+    /// <param name="updatedAt">Timestamp written to <see cref="OutboxMessage.UpdatedAt"/>.</param>
+    /// <param name="processedAt">
+    /// When not <see langword="null"/>, written to <see cref="OutboxMessage.ProcessedAt"/>;
+    /// the existing value is preserved when <see langword="null"/>.
+    /// </param>
+    /// <param name="nextRetryAt">
+    /// The earliest time the message may be retried; written to <see cref="OutboxMessage.NextRetryAt"/>.
+    /// Pass <see langword="null"/> to clear a previously scheduled retry.
+    /// </param>
+    /// <param name="newStatus">The target <see cref="OutboxMessageStatus"/> for the message.</param>
+    /// <param name="retryIncrement">
+    /// The non-negative value added to <see cref="OutboxMessage.RetryCount"/>. Pass <c>0</c> when
+    /// the retry counter should not change (e.g. on completion or dead-lettering).
+    /// </param>
+    /// <param name="errorMessage">
+    /// The error text to record in <see cref="OutboxMessage.Error"/>;
+    /// pass <see langword="null"/> to clear any previous error.
+    /// </param>
+    /// <param name="cancellationToken">Propagates notification that the operation should be cancelled.</param>
     Task UpdateByQueryAsync(
         IQueryable<OutboxMessage> query,
         DateTimeOffset updatedAt,
@@ -25,6 +79,37 @@ internal interface IOutboxRepositoryExecutor : IDisposable
         CancellationToken cancellationToken
     );
 
+    /// <summary>
+    /// Applies a status transition and related field updates to a batch of messages identified
+    /// by their <paramref name="ids"/>.
+    /// </summary>
+    /// <remarks>
+    /// Semantically equivalent to <see cref="UpdateByQueryAsync"/> but targets messages by ID
+    /// rather than by an arbitrary query. Used for bulk outcome reporting when the caller already
+    /// holds a collection of message identifiers.
+    /// Implementations may issue a single bulk statement or iterate per ID, depending on what the
+    /// underlying EF Core provider supports.
+    /// </remarks>
+    /// <param name="ids">The identifiers of the messages to update.</param>
+    /// <param name="updatedAt">Timestamp written to <see cref="OutboxMessage.UpdatedAt"/>.</param>
+    /// <param name="processedAt">
+    /// When not <see langword="null"/>, written to <see cref="OutboxMessage.ProcessedAt"/>;
+    /// the existing value is preserved when <see langword="null"/>.
+    /// </param>
+    /// <param name="nextRetryAt">
+    /// The earliest time the messages may be retried; written to <see cref="OutboxMessage.NextRetryAt"/>.
+    /// Pass <see langword="null"/> to clear a previously scheduled retry.
+    /// </param>
+    /// <param name="newStatus">The target <see cref="OutboxMessageStatus"/> for each message.</param>
+    /// <param name="retryIncrement">
+    /// The non-negative value added to <see cref="OutboxMessage.RetryCount"/>. Pass <c>0</c> when
+    /// the retry counter should not change.
+    /// </param>
+    /// <param name="errorMessage">
+    /// The error text to record in <see cref="OutboxMessage.Error"/>;
+    /// pass <see langword="null"/> to clear any previous error.
+    /// </param>
+    /// <param name="cancellationToken">Propagates notification that the operation should be cancelled.</param>
     Task UpdateByIdsAsync(
         IReadOnlyCollection<Guid> ids,
         DateTimeOffset updatedAt,

--- a/src/NetEvolve.Pulse.EntityFramework/Outbox/TrackingOutboxManagementExecutor.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Outbox/TrackingOutboxManagementExecutor.cs
@@ -20,6 +20,7 @@ internal sealed class TrackingOutboxManagementExecutor<TContext>(TContext contex
         context
             .OutboxMessages.Where(m => m.Status == OutboxMessageStatus.DeadLetter)
             .OrderByDescending(m => m.UpdatedAt)
+            .ThenBy(m => m.Id)
             .Skip(skip)
             .Take(take)
             .AsNoTracking();

--- a/src/NetEvolve.Pulse.EntityFramework/Outbox/TrackingOutboxManagementExecutor.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Outbox/TrackingOutboxManagementExecutor.cs
@@ -1,0 +1,88 @@
+namespace NetEvolve.Pulse.Outbox;
+
+using Microsoft.EntityFrameworkCore;
+using NetEvolve.Pulse.Extensibility.Outbox;
+
+/// <summary>
+/// <see cref="IOutboxManagementExecutor"/> implementation that persists changes through
+/// EF Core change tracking and <c>SaveChangesAsync</c>.
+/// </summary>
+/// <remarks>
+/// Used for providers that do not support <c>ExecuteUpdateAsync</c> (InMemory) or that
+/// have known value-converter limitations when building update parameters (Oracle MySQL).
+/// <para><strong>No compiled queries:</strong></para>
+/// Plain LINQ is used throughout — <see cref="EF.CompileAsyncQuery"/> is intentionally
+/// avoided because Oracle MySQL has known compatibility issues with compiled queries
+/// involving value converters and parameterised <see cref="Guid"/> predicates.
+/// </remarks>
+/// <typeparam name="TContext">The DbContext type that implements <see cref="IOutboxDbContext"/>.</typeparam>
+internal sealed class TrackingOutboxManagementExecutor<TContext>(TContext context) : IOutboxManagementExecutor
+    where TContext : DbContext, IOutboxDbContext
+{
+    /// <inheritdoc />
+    public IQueryable<OutboxMessage> GetDeadLetterMessages(int skip, int take) =>
+        context
+            .OutboxMessages.Where(m => m.Status == OutboxMessageStatus.DeadLetter)
+            .OrderByDescending(m => m.UpdatedAt)
+            .Skip(skip)
+            .Take(take)
+            .AsNoTracking();
+
+    /// <inheritdoc />
+    public Task<OutboxMessage?> GetDeadLetterMessageAsync(Guid id, CancellationToken cancellationToken) =>
+        context
+            .OutboxMessages.Where(m => m.Id == id && m.Status == OutboxMessageStatus.DeadLetter)
+            .AsNoTracking()
+            .FirstOrDefaultAsync(cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<bool> ReplayByIdAsync(Guid id, DateTimeOffset updatedAt, CancellationToken cancellationToken)
+    {
+        var entity = await context
+            .OutboxMessages.FirstOrDefaultAsync(
+                m => m.Id == id && m.Status == OutboxMessageStatus.DeadLetter,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        if (entity is null)
+        {
+            return false;
+        }
+
+        entity.Status = OutboxMessageStatus.Pending;
+        entity.RetryCount = 0;
+        entity.Error = null;
+        entity.UpdatedAt = updatedAt;
+
+        _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public async Task<int> ReplayAllAsync(DateTimeOffset updatedAt, CancellationToken cancellationToken)
+    {
+        var entities = await context
+            .OutboxMessages.Where(m => m.Status == OutboxMessageStatus.DeadLetter)
+            .ToArrayAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (entities.Length == 0)
+        {
+            return 0;
+        }
+
+        foreach (var entity in entities)
+        {
+            entity.Status = OutboxMessageStatus.Pending;
+            entity.RetryCount = 0;
+            entity.Error = null;
+            entity.UpdatedAt = updatedAt;
+        }
+
+        _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return entities.Length;
+    }
+}

--- a/src/NetEvolve.Pulse.EntityFramework/Outbox/TrackingOutboxManagementExecutor.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Outbox/TrackingOutboxManagementExecutor.cs
@@ -10,10 +10,6 @@ using NetEvolve.Pulse.Extensibility.Outbox;
 /// <remarks>
 /// Used for providers that do not support <c>ExecuteUpdateAsync</c> (InMemory) or that
 /// have known value-converter limitations when building update parameters (Oracle MySQL).
-/// <para><strong>No compiled queries:</strong></para>
-/// Plain LINQ is used throughout — <see cref="EF.CompileAsyncQuery"/> is intentionally
-/// avoided because Oracle MySQL has known compatibility issues with compiled queries
-/// involving value converters and parameterised <see cref="Guid"/> predicates.
 /// </remarks>
 /// <typeparam name="TContext">The DbContext type that implements <see cref="IOutboxDbContext"/>.</typeparam>
 internal sealed class TrackingOutboxManagementExecutor<TContext>(TContext context) : IOutboxManagementExecutor

--- a/src/NetEvolve.Pulse.EntityFramework/Outbox/TrackingOutboxRepositoryExecutorBase.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Outbox/TrackingOutboxRepositoryExecutorBase.cs
@@ -21,6 +21,10 @@ internal abstract class TrackingOutboxRepositoryExecutorBase<TContext>(TContext 
     /// <summary>The DbContext used for all tracking-based query and update operations.</summary>
     protected readonly TContext _context = context;
 
+    /// <summary>
+    /// Limits the number of concurrent write operations to prevent database contention.
+    /// Initialised to <c>maxDegreeOfParallelism</c> permits.
+    /// </summary>
     protected readonly SemaphoreSlim _semaphore = new SemaphoreSlim(maxDegreeOfParallelism, maxDegreeOfParallelism);
     private bool _disposedValue;
 

--- a/tests/NetEvolve.Pulse.Tests.Integration/Outbox/OutboxTestsBase.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Outbox/OutboxTestsBase.cs
@@ -507,6 +507,293 @@ public abstract class OutboxTestsBase(
         );
     }
 
+    [Test]
+    public async Task Should_GetDeadLetterMessages_Return_Empty_When_NoMessages(CancellationToken cancellationToken) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var management = services.GetRequiredService<IOutboxManagement>();
+
+                    var result = await management
+                        .GetDeadLetterMessagesAsync(cancellationToken: token)
+                        .ConfigureAwait(false);
+
+                    _ = await Assert.That(result).IsEmpty();
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+    [Test]
+    public async Task Should_GetDeadLetterMessages_Return_DeadLetterMessages(CancellationToken cancellationToken) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var mediator = services.GetRequiredService<IMediator>();
+                    await PublishEventsAsync(mediator, 3, x => new TestEvent { Id = $"Test{x:D3}" }, token);
+
+                    var outbox = services.GetRequiredService<IOutboxRepository>();
+                    var pending = await outbox.GetPendingAsync(50, token).ConfigureAwait(false);
+                    await outbox
+                        .MarkAsDeadLetterAsync([.. pending.Select(m => m.Id)], "Fatal error", token)
+                        .ConfigureAwait(false);
+
+                    var management = services.GetRequiredService<IOutboxManagement>();
+                    var result = await management
+                        .GetDeadLetterMessagesAsync(cancellationToken: token)
+                        .ConfigureAwait(false);
+
+                    _ = await Assert.That(result.Count).IsEqualTo(3);
+                    _ = await Assert.That(result.All(m => m.Status == OutboxMessageStatus.DeadLetter)).IsTrue();
+                },
+                cancellationToken,
+                configureServices: services =>
+                    services.Configure<OutboxProcessorOptions>(options => options.DisableProcessing = true)
+            )
+            .ConfigureAwait(false);
+
+    [Test]
+    public async Task Should_GetDeadLetterMessages_Respect_PageSize(CancellationToken cancellationToken) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var mediator = services.GetRequiredService<IMediator>();
+                    await PublishEventsAsync(mediator, 5, x => new TestEvent { Id = $"Test{x:D3}" }, token);
+
+                    var outbox = services.GetRequiredService<IOutboxRepository>();
+                    var pending = await outbox.GetPendingAsync(50, token).ConfigureAwait(false);
+                    await outbox
+                        .MarkAsDeadLetterAsync([.. pending.Select(m => m.Id)], "Fatal error", token)
+                        .ConfigureAwait(false);
+
+                    var management = services.GetRequiredService<IOutboxManagement>();
+                    var page0 = await management
+                        .GetDeadLetterMessagesAsync(pageSize: 3, page: 0, cancellationToken: token)
+                        .ConfigureAwait(false);
+                    var page1 = await management
+                        .GetDeadLetterMessagesAsync(pageSize: 3, page: 1, cancellationToken: token)
+                        .ConfigureAwait(false);
+
+                    using (Assert.Multiple())
+                    {
+                        _ = await Assert.That(page0.Count).IsEqualTo(3);
+                        _ = await Assert.That(page1.Count).IsEqualTo(2);
+                    }
+                },
+                cancellationToken,
+                configureServices: services =>
+                    services.Configure<OutboxProcessorOptions>(options => options.DisableProcessing = true)
+            )
+            .ConfigureAwait(false);
+
+    [Test]
+    public async Task Should_GetDeadLetterMessage_Return_Message_ById(CancellationToken cancellationToken) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var mediator = services.GetRequiredService<IMediator>();
+                    await mediator.PublishAsync(new TestEvent { Id = "Test001" }, token);
+
+                    var outbox = services.GetRequiredService<IOutboxRepository>();
+                    var pending = await outbox.GetPendingAsync(50, token).ConfigureAwait(false);
+                    var messageId = pending[0].Id;
+                    await outbox.MarkAsDeadLetterAsync(messageId, "Fatal error", token).ConfigureAwait(false);
+
+                    var management = services.GetRequiredService<IOutboxManagement>();
+                    var message = await management.GetDeadLetterMessageAsync(messageId, token).ConfigureAwait(false);
+
+                    using (Assert.Multiple())
+                    {
+                        _ = await Assert.That(message).IsNotNull();
+                        _ = await Assert.That(message!.Id).IsEqualTo(messageId);
+                        _ = await Assert.That(message.Status).IsEqualTo(OutboxMessageStatus.DeadLetter);
+                    }
+                },
+                cancellationToken,
+                configureServices: services =>
+                    services.Configure<OutboxProcessorOptions>(options => options.DisableProcessing = true)
+            )
+            .ConfigureAwait(false);
+
+    [Test]
+    public async Task Should_GetDeadLetterMessage_Return_Null_When_NotFound(CancellationToken cancellationToken) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var management = services.GetRequiredService<IOutboxManagement>();
+
+                    var message = await management
+                        .GetDeadLetterMessageAsync(Guid.NewGuid(), token)
+                        .ConfigureAwait(false);
+
+                    _ = await Assert.That(message).IsNull();
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+    [Test]
+    public async Task Should_GetDeadLetterCount_Return_Correct_Count(CancellationToken cancellationToken) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var mediator = services.GetRequiredService<IMediator>();
+                    await PublishEventsAsync(mediator, 3, x => new TestEvent { Id = $"Test{x:D3}" }, token);
+
+                    var outbox = services.GetRequiredService<IOutboxRepository>();
+                    var pending = await outbox.GetPendingAsync(50, token).ConfigureAwait(false);
+                    await outbox
+                        .MarkAsDeadLetterAsync([.. pending.Select(m => m.Id)], "Fatal error", token)
+                        .ConfigureAwait(false);
+
+                    var management = services.GetRequiredService<IOutboxManagement>();
+                    var count = await management.GetDeadLetterCountAsync(token).ConfigureAwait(false);
+
+                    _ = await Assert.That(count).IsEqualTo(3L);
+                },
+                cancellationToken,
+                configureServices: services =>
+                    services.Configure<OutboxProcessorOptions>(options => options.DisableProcessing = true)
+            )
+            .ConfigureAwait(false);
+
+    [Test]
+    public async Task Should_ReplayMessage_Reset_DeadLetter_To_Pending(CancellationToken cancellationToken) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var mediator = services.GetRequiredService<IMediator>();
+                    await mediator.PublishAsync(new TestEvent { Id = "Test001" }, token);
+
+                    var outbox = services.GetRequiredService<IOutboxRepository>();
+                    var pending = await outbox.GetPendingAsync(50, token).ConfigureAwait(false);
+                    var messageId = pending[0].Id;
+                    await outbox.MarkAsDeadLetterAsync(messageId, "Fatal error", token).ConfigureAwait(false);
+
+                    var management = services.GetRequiredService<IOutboxManagement>();
+                    var replayed = await management.ReplayMessageAsync(messageId, token).ConfigureAwait(false);
+
+                    var pendingCount = await outbox.GetPendingCountAsync(token).ConfigureAwait(false);
+
+                    using (Assert.Multiple())
+                    {
+                        _ = await Assert.That(replayed).IsTrue();
+                        _ = await Assert.That(pendingCount).IsEqualTo(1L);
+                    }
+                },
+                cancellationToken,
+                configureServices: services =>
+                    services.Configure<OutboxProcessorOptions>(options => options.DisableProcessing = true)
+            )
+            .ConfigureAwait(false);
+
+    [Test]
+    public async Task Should_ReplayMessage_Return_False_For_NonDeadLetter(CancellationToken cancellationToken) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var mediator = services.GetRequiredService<IMediator>();
+                    await mediator.PublishAsync(new TestEvent { Id = "Test001" }, token);
+
+                    // GetPendingAsync moves the message to Processing — not a dead-letter
+                    var outbox = services.GetRequiredService<IOutboxRepository>();
+                    var pending = await outbox.GetPendingAsync(50, token).ConfigureAwait(false);
+
+                    var management = services.GetRequiredService<IOutboxManagement>();
+                    var replayed = await management.ReplayMessageAsync(pending[0].Id, token).ConfigureAwait(false);
+
+                    _ = await Assert.That(replayed).IsFalse();
+                },
+                cancellationToken,
+                configureServices: services =>
+                    services.Configure<OutboxProcessorOptions>(options => options.DisableProcessing = true)
+            )
+            .ConfigureAwait(false);
+
+    [Test]
+    public async Task Should_ReplayAllDeadLetter_Reset_All_And_Return_Count(CancellationToken cancellationToken) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var mediator = services.GetRequiredService<IMediator>();
+                    await PublishEventsAsync(mediator, 3, x => new TestEvent { Id = $"Test{x:D3}" }, token);
+
+                    var outbox = services.GetRequiredService<IOutboxRepository>();
+                    var pending = await outbox.GetPendingAsync(50, token).ConfigureAwait(false);
+                    await outbox
+                        .MarkAsDeadLetterAsync([.. pending.Select(m => m.Id)], "Fatal error", token)
+                        .ConfigureAwait(false);
+
+                    var management = services.GetRequiredService<IOutboxManagement>();
+                    var count = await management.ReplayAllDeadLetterAsync(token).ConfigureAwait(false);
+
+                    var pendingCount = await outbox.GetPendingCountAsync(token).ConfigureAwait(false);
+
+                    using (Assert.Multiple())
+                    {
+                        _ = await Assert.That(count).IsEqualTo(3);
+                        _ = await Assert.That(pendingCount).IsEqualTo(3L);
+                    }
+                },
+                cancellationToken,
+                configureServices: services =>
+                    services.Configure<OutboxProcessorOptions>(options => options.DisableProcessing = true)
+            )
+            .ConfigureAwait(false);
+
+    [Test]
+    public async Task Should_ReplayAllDeadLetter_Return_Zero_When_Empty(CancellationToken cancellationToken) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var management = services.GetRequiredService<IOutboxManagement>();
+
+                    var count = await management.ReplayAllDeadLetterAsync(token).ConfigureAwait(false);
+
+                    _ = await Assert.That(count).IsEqualTo(0);
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+    [Test]
+    public async Task Should_GetStatistics_Return_Correct_Counts(CancellationToken cancellationToken) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var mediator = services.GetRequiredService<IMediator>();
+                    await PublishEventsAsync(mediator, 4, x => new TestEvent { Id = $"Test{x:D3}" }, token);
+
+                    var outbox = services.GetRequiredService<IOutboxRepository>();
+
+                    // Move msg0 → Completed
+                    var batch1 = await outbox.GetPendingAsync(1, token).ConfigureAwait(false);
+                    await outbox.MarkAsCompletedAsync(batch1[0].Id, token).ConfigureAwait(false);
+
+                    // Move msg1 → DeadLetter
+                    var batch2 = await outbox.GetPendingAsync(1, token).ConfigureAwait(false);
+                    await outbox.MarkAsDeadLetterAsync(batch2[0].Id, "Fatal error", token).ConfigureAwait(false);
+
+                    // msg2 and msg3 remain Pending
+                    var management = services.GetRequiredService<IOutboxManagement>();
+                    var statistics = await management.GetStatisticsAsync(token).ConfigureAwait(false);
+
+                    using (Assert.Multiple())
+                    {
+                        _ = await Assert.That(statistics.Pending).IsEqualTo(2L);
+                        _ = await Assert.That(statistics.Processing).IsEqualTo(0L);
+                        _ = await Assert.That(statistics.Completed).IsEqualTo(1L);
+                        _ = await Assert.That(statistics.Failed).IsEqualTo(0L);
+                        _ = await Assert.That(statistics.DeadLetter).IsEqualTo(1L);
+                        _ = await Assert.That(statistics.Total).IsEqualTo(4L);
+                    }
+                },
+                cancellationToken,
+                configureServices: services =>
+                    services.Configure<OutboxProcessorOptions>(options => options.DisableProcessing = true)
+            )
+            .ConfigureAwait(false);
+
     private sealed class TestEvent : IEvent
     {
         public string? CorrelationId { get; set; }

--- a/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/EntityFrameworkOutboxManagementTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/EntityFrameworkOutboxManagementTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Time.Testing;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.Pulse.Extensibility;
 using NetEvolve.Pulse.Extensibility.Outbox;
@@ -293,9 +294,6 @@ public sealed class EntityFrameworkOutboxManagementTests
     }
 
     [Test]
-    [Skip(
-        "The EF Core InMemory provider does not support ExecuteUpdateAsync (bulk updates). Covered by integration tests."
-    )]
     public async Task ReplayMessageAsync_WithExistingDeadLetterMessage_ReturnsTrueAndResetsMessage(
         CancellationToken cancellationToken
     )
@@ -337,9 +335,6 @@ public sealed class EntityFrameworkOutboxManagementTests
     }
 
     [Test]
-    [Skip(
-        "The EF Core InMemory provider does not support ExecuteUpdateAsync (bulk updates). Covered by integration tests."
-    )]
     public async Task ReplayMessageAsync_WithNonDeadLetterMessage_ReturnsFalse(CancellationToken cancellationToken)
     {
         var options = new DbContextOptionsBuilder<TestDbContext>()
@@ -369,9 +364,6 @@ public sealed class EntityFrameworkOutboxManagementTests
     }
 
     [Test]
-    [Skip(
-        "The EF Core InMemory provider does not support ExecuteUpdateAsync (bulk updates). Covered by integration tests."
-    )]
     public async Task ReplayMessageAsync_WithUnknownId_ReturnsFalse(CancellationToken cancellationToken)
     {
         var options = new DbContextOptionsBuilder<TestDbContext>()
@@ -386,9 +378,6 @@ public sealed class EntityFrameworkOutboxManagementTests
     }
 
     [Test]
-    [Skip(
-        "The EF Core InMemory provider does not support ExecuteUpdateAsync (bulk updates). Covered by integration tests."
-    )]
     public async Task ReplayAllDeadLetterAsync_EmptyDatabase_ReturnsZero(CancellationToken cancellationToken)
     {
         var options = new DbContextOptionsBuilder<TestDbContext>()
@@ -403,9 +392,6 @@ public sealed class EntityFrameworkOutboxManagementTests
     }
 
     [Test]
-    [Skip(
-        "The EF Core InMemory provider does not support ExecuteUpdateAsync (bulk updates). Covered by integration tests."
-    )]
     public async Task ReplayAllDeadLetterAsync_WithDeadLetterMessages_ResetsAllAndReturnsCount(
         CancellationToken cancellationToken
     )
@@ -525,6 +511,218 @@ public sealed class EntityFrameworkOutboxManagementTests
             _ = await Assert.That(statistics.Failed).IsEqualTo(1L);
             _ = await Assert.That(statistics.DeadLetter).IsEqualTo(2L);
             _ = await Assert.That(statistics.Total).IsEqualTo(9L);
+        }
+    }
+
+    [Test]
+    public async Task GetDeadLetterMessagesAsync_WithPage_ReturnsCorrectPage(CancellationToken cancellationToken)
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase(nameof(GetDeadLetterMessagesAsync_WithPage_ReturnsCorrectPage))
+            .Options;
+        await using var context = new TestDbContext(options);
+        var now = DateTimeOffset.UtcNow;
+        for (var i = 0; i < 5; i++)
+        {
+            _ = context.OutboxMessages.Add(
+                new OutboxMessage
+                {
+                    Id = Guid.NewGuid(),
+                    EventType = typeof(TestDbEvent),
+                    Payload = "{}",
+                    CreatedAt = now,
+                    UpdatedAt = now.AddMinutes(-i),
+                    Status = OutboxMessageStatus.DeadLetter,
+                }
+            );
+        }
+        _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        var management = new EntityFrameworkOutboxManagement<TestDbContext>(context, TimeProvider.System);
+
+        var page0 = await management
+            .GetDeadLetterMessagesAsync(pageSize: 3, page: 0, cancellationToken)
+            .ConfigureAwait(false);
+        var page1 = await management
+            .GetDeadLetterMessagesAsync(pageSize: 3, page: 1, cancellationToken)
+            .ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(page0.Count).IsEqualTo(3);
+            _ = await Assert.That(page1.Count).IsEqualTo(2);
+        }
+    }
+
+    [Test]
+    public async Task GetDeadLetterMessagesAsync_OrderedByUpdatedAtDescending(CancellationToken cancellationToken)
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase(nameof(GetDeadLetterMessagesAsync_OrderedByUpdatedAtDescending))
+            .Options;
+        await using var context = new TestDbContext(options);
+        var now = DateTimeOffset.UtcNow;
+        var oldest = now.AddHours(-2);
+        var newest = now.AddHours(1);
+
+        foreach (var updatedAt in new[] { now, oldest, newest })
+        {
+            _ = context.OutboxMessages.Add(
+                new OutboxMessage
+                {
+                    Id = Guid.NewGuid(),
+                    EventType = typeof(TestDbEvent),
+                    Payload = "{}",
+                    CreatedAt = now,
+                    UpdatedAt = updatedAt,
+                    Status = OutboxMessageStatus.DeadLetter,
+                }
+            );
+        }
+        _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        var management = new EntityFrameworkOutboxManagement<TestDbContext>(context, TimeProvider.System);
+
+        var result = await management
+            .GetDeadLetterMessagesAsync(cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(result.Count).IsEqualTo(3);
+            _ = await Assert.That(result[0].UpdatedAt).IsEqualTo(newest);
+            _ = await Assert.That(result[1].UpdatedAt).IsEqualTo(now);
+            _ = await Assert.That(result[2].UpdatedAt).IsEqualTo(oldest);
+        }
+    }
+
+    [Test]
+    public async Task ReplayMessageAsync_SetsUpdatedAtFromTimeProvider(CancellationToken cancellationToken)
+    {
+        var expectedTime = new DateTimeOffset(2025, 6, 1, 12, 0, 0, TimeSpan.Zero);
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase(nameof(ReplayMessageAsync_SetsUpdatedAtFromTimeProvider))
+            .Options;
+        await using var context = new TestDbContext(options);
+        var now = DateTimeOffset.UtcNow;
+        var messageId = Guid.NewGuid();
+        _ = context.OutboxMessages.Add(
+            new OutboxMessage
+            {
+                Id = messageId,
+                EventType = typeof(TestDbEvent),
+                Payload = "{}",
+                CreatedAt = now,
+                UpdatedAt = now,
+                RetryCount = 3,
+                Error = "Some error",
+                Status = OutboxMessageStatus.DeadLetter,
+            }
+        );
+        _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        var timeProvider = new FakeTimeProvider(expectedTime);
+        var management = new EntityFrameworkOutboxManagement<TestDbContext>(context, timeProvider);
+
+        _ = await management.ReplayMessageAsync(messageId, cancellationToken).ConfigureAwait(false);
+
+        var message = await context.OutboxMessages.FindAsync([messageId], cancellationToken).ConfigureAwait(false);
+        _ = await Assert.That(message!.UpdatedAt).IsEqualTo(expectedTime);
+    }
+
+    [Test]
+    public async Task ReplayAllDeadLetterAsync_DoesNotAffectNonDeadLetterMessages(CancellationToken cancellationToken)
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase(nameof(ReplayAllDeadLetterAsync_DoesNotAffectNonDeadLetterMessages))
+            .Options;
+        await using var context = new TestDbContext(options);
+        var now = DateTimeOffset.UtcNow;
+        var pendingId = Guid.NewGuid();
+        var failedId = Guid.NewGuid();
+
+        foreach (
+            var (id, status, retryCount) in new[]
+            {
+                (Guid.NewGuid(), OutboxMessageStatus.DeadLetter, 5),
+                (Guid.NewGuid(), OutboxMessageStatus.DeadLetter, 5),
+                (pendingId, OutboxMessageStatus.Pending, 0),
+                (failedId, OutboxMessageStatus.Failed, 2),
+            }
+        )
+        {
+            _ = context.OutboxMessages.Add(
+                new OutboxMessage
+                {
+                    Id = id,
+                    EventType = typeof(TestDbEvent),
+                    Payload = "{}",
+                    CreatedAt = now,
+                    UpdatedAt = now,
+                    RetryCount = retryCount,
+                    Status = status,
+                }
+            );
+        }
+        _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        var management = new EntityFrameworkOutboxManagement<TestDbContext>(context, TimeProvider.System);
+
+        var count = await management.ReplayAllDeadLetterAsync(cancellationToken).ConfigureAwait(false);
+
+        var pendingMessage = await context
+            .OutboxMessages.FindAsync([pendingId], cancellationToken)
+            .ConfigureAwait(false);
+        var failedMessage = await context.OutboxMessages.FindAsync([failedId], cancellationToken).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(count).IsEqualTo(2);
+            _ = await Assert.That(pendingMessage!.Status).IsEqualTo(OutboxMessageStatus.Pending);
+            _ = await Assert.That(failedMessage!.Status).IsEqualTo(OutboxMessageStatus.Failed);
+            _ = await Assert.That(failedMessage.RetryCount).IsEqualTo(2);
+        }
+    }
+
+    [Test]
+    public async Task ReplayAllDeadLetterAsync_ResetsRetryCountAndError(CancellationToken cancellationToken)
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase(nameof(ReplayAllDeadLetterAsync_ResetsRetryCountAndError))
+            .Options;
+        await using var context = new TestDbContext(options);
+        var now = DateTimeOffset.UtcNow;
+        for (var i = 0; i < 3; i++)
+        {
+            _ = context.OutboxMessages.Add(
+                new OutboxMessage
+                {
+                    Id = Guid.NewGuid(),
+                    EventType = typeof(TestDbEvent),
+                    Payload = "{}",
+                    CreatedAt = now,
+                    UpdatedAt = now,
+                    RetryCount = 5,
+                    Error = "Fatal error",
+                    Status = OutboxMessageStatus.DeadLetter,
+                }
+            );
+        }
+        _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        var management = new EntityFrameworkOutboxManagement<TestDbContext>(context, TimeProvider.System);
+
+        _ = await management.ReplayAllDeadLetterAsync(cancellationToken).ConfigureAwait(false);
+
+        var messages = await context.OutboxMessages.ToListAsync(cancellationToken).ConfigureAwait(false);
+        foreach (var message in messages)
+        {
+            using (Assert.Multiple())
+            {
+                _ = await Assert.That(message.Status).IsEqualTo(OutboxMessageStatus.Pending);
+                _ = await Assert.That(message.RetryCount).IsEqualTo(0);
+                _ = await Assert.That(message.Error).IsNull();
+            }
         }
     }
 

--- a/tests/NetEvolve.Pulse.Tests.Unit/NetEvolve.Pulse.Tests.Unit.csproj
+++ b/tests/NetEvolve.Pulse.Tests.Unit/NetEvolve.Pulse.Tests.Unit.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="NetEvolve.Extensions.TUnit" />
     <PackageReference Include="NetEvolve.Http.Correlation.AspNetCore" />
     <PackageReference Include="NetEvolve.Http.Correlation.TestGenerator" />


### PR DESCRIPTION
Refactored EntityFrameworkOutboxManagement to delegate dead-letter operations to provider-specific executors. Introduced IOutboxManagementExecutor with Bulk and Tracking implementations for optimal compatibility (e.g., ExecuteUpdateAsync for SQL Server, tracking for InMemory/Oracle MySQL). Removed compiled queries in favor of executor-based logic. Extended IOutboxOperationsExecutor docs. Added comprehensive integration tests for paging, lookup, replay, and statistics, now covering InMemory provider. Added Microsoft.Extensions.TimeProvider.Testing for deterministic time-based tests. Improves compatibility, test coverage, and maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Enhanced dead-letter message management: retrieve and paginate dead-letter messages with improved filtering and ordering capabilities
  - Added ability to replay individual or all dead-letter messages back to pending status with automatic retry count reset
  - Added outbox statistics functionality to track message counts by processing status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->