### PR TITLE
chore: Rename OutboxOperationsExecutor to OutboxRepositoryExecutor

### DIFF
--- a/src/NetEvolve.Pulse.EntityFramework/Outbox/BulkOutboxRepositoryExecutor.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Outbox/BulkOutboxRepositoryExecutor.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using NetEvolve.Pulse.Extensibility.Outbox;
 
 /// <summary>
-/// <see cref="IOutboxOperationsExecutor"/> implementation that issues a single bulk
+/// <see cref="IOutboxRepositoryExecutor"/> implementation that issues a single bulk
 /// <c>ExecuteUpdateAsync</c> / <c>ExecuteDeleteAsync</c> statement per operation.
 /// </summary>
 /// <remarks>
@@ -13,8 +13,8 @@ using NetEvolve.Pulse.Extensibility.Outbox;
 /// (SQL Server, PostgreSQL, SQLite, and others).
 /// </remarks>
 /// <typeparam name="TContext">The DbContext type that implements <see cref="IOutboxDbContext"/>.</typeparam>
-internal sealed class BulkOutboxOperationsExecutor<TContext>(TContext context, int maxDegreeOfParallelism)
-    : IOutboxOperationsExecutor
+internal sealed class BulkOutboxRepositoryExecutor<TContext>(TContext context, int maxDegreeOfParallelism)
+    : IOutboxRepositoryExecutor
     where TContext : DbContext, IOutboxDbContext
 {
     private readonly SemaphoreSlim _semaphore = new(maxDegreeOfParallelism, maxDegreeOfParallelism);

--- a/src/NetEvolve.Pulse.EntityFramework/Outbox/EntityFrameworkOutboxRepository.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Outbox/EntityFrameworkOutboxRepository.cs
@@ -30,7 +30,7 @@ internal sealed class EntityFrameworkOutboxRepository<TContext> : IOutboxReposit
     /// Provider-specific strategy that handles how entities are persisted
     /// (change-tracking + <c>SaveChangesAsync</c> vs. bulk <c>ExecuteUpdate</c> / <c>ExecuteDelete</c>).
     /// </summary>
-    private readonly IOutboxOperationsExecutor _executor;
+    private readonly IOutboxRepositoryExecutor _executor;
     private bool _disposedValue;
 
     /// <summary>
@@ -48,12 +48,12 @@ internal sealed class EntityFrameworkOutboxRepository<TContext> : IOutboxReposit
         _executor = context.Database.ProviderName switch
         {
             // InMemory does not support ExecuteUpdate/ExecuteDelete at all.
-            ProviderName.InMemory => new InMemoryOutboxOperationsExecutor<TContext>(context, 1),
+            ProviderName.InMemory => new InMemoryOutboxRepositoryExecutor<TContext>(context, 1),
             // Oracle MySQL cannot apply value converters in ExecuteUpdateAsync parameters and
             // cannot translate a parameterised Guid collection into a SQL IN clause.
-            ProviderName.OracleMySql => new MySqlOutboxOperationsExecutor<TContext>(context, 1),
-            ProviderName.Npgsql => new BulkOutboxOperationsExecutor<TContext>(context, 1),
-            _ => new BulkOutboxOperationsExecutor<TContext>(context, Environment.ProcessorCount - 1),
+            ProviderName.OracleMySql => new MySqlOutboxRepositoryExecutor<TContext>(context, 1),
+            ProviderName.Npgsql => new BulkOutboxRepositoryExecutor<TContext>(context, 1),
+            _ => new BulkOutboxRepositoryExecutor<TContext>(context, Environment.ProcessorCount - 1),
         };
     }
 

--- a/src/NetEvolve.Pulse.EntityFramework/Outbox/IOutboxRepositoryExecutor.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Outbox/IOutboxRepositoryExecutor.cs
@@ -5,7 +5,7 @@ using NetEvolve.Pulse.Extensibility.Outbox;
 /// <summary>
 /// Defines the provider-specific strategy for executing outbox entity operations.
 /// </summary>
-internal interface IOutboxOperationsExecutor : IDisposable
+internal interface IOutboxRepositoryExecutor : IDisposable
 {
     Task<OutboxMessage[]> FetchAndMarkAsync(
         IQueryable<OutboxMessage> baseQuery,

--- a/src/NetEvolve.Pulse.EntityFramework/Outbox/InMemoryOutboxRepositoryExecutor.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Outbox/InMemoryOutboxRepositoryExecutor.cs
@@ -4,18 +4,18 @@ using Microsoft.EntityFrameworkCore;
 using NetEvolve.Pulse.Extensibility.Outbox;
 
 /// <summary>
-/// <see cref="IOutboxOperationsExecutor"/> implementation for the EF Core InMemory provider.
+/// <see cref="IOutboxRepositoryExecutor"/> implementation for the EF Core InMemory provider.
 /// </summary>
 /// <remarks>
 /// The InMemory provider evaluates all LINQ in process, so any query — including those with
 /// <c>Contains</c> over a <see cref="Guid"/> collection — works without type-mapping issues.
 /// <c>ExecuteUpdate</c> / <c>ExecuteDelete</c> are not supported; all mutations go through
 /// change tracking and <c>SaveChangesAsync</c> (inherited from
-/// <see cref="TrackingOutboxOperationsExecutorBase{TContext}"/>).
+/// <see cref="TrackingOutboxRepositoryExecutorBase{TContext}"/>).
 /// </remarks>
 /// <typeparam name="TContext">The DbContext type that implements <see cref="IOutboxDbContext"/>.</typeparam>
-internal sealed class InMemoryOutboxOperationsExecutor<TContext>(TContext context, int maxDegreeOfParallelism)
-    : TrackingOutboxOperationsExecutorBase<TContext>(context, maxDegreeOfParallelism)
+internal sealed class InMemoryOutboxRepositoryExecutor<TContext>(TContext context, int maxDegreeOfParallelism)
+    : TrackingOutboxRepositoryExecutorBase<TContext>(context, maxDegreeOfParallelism)
     where TContext : DbContext, IOutboxDbContext
 {
     /// <inheritdoc />

--- a/src/NetEvolve.Pulse.EntityFramework/Outbox/MySqlOutboxRepositoryExecutor.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Outbox/MySqlOutboxRepositoryExecutor.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using NetEvolve.Pulse.Extensibility.Outbox;
 
 /// <summary>
-/// <see cref="IOutboxOperationsExecutor"/> implementation for the Oracle MySQL EF Core provider
+/// <see cref="IOutboxRepositoryExecutor"/> implementation for the Oracle MySQL EF Core provider
 /// (<c>MySql.EntityFrameworkCore</c>).
 /// </summary>
 /// <remarks>
@@ -21,14 +21,14 @@ using NetEvolve.Pulse.Extensibility.Outbox;
 ///   </item>
 /// </list>
 /// All mutations go through change tracking and <c>SaveChangesAsync</c> (inherited from
-/// <see cref="TrackingOutboxOperationsExecutorBase{TContext}"/>). Only
+/// <see cref="TrackingOutboxRepositoryExecutorBase{TContext}"/>). Only
 /// <see cref="UpdateByIdsAsync"/> is overridden: it uses <c>FindAsync</c> per ID to avoid the
 /// broken <c>Guid IN</c> clause, while still benefiting from the <see cref="DbContext"/> Local
 /// cache for entities already loaded by <c>FetchAndMarkAsync</c>.
 /// </remarks>
 /// <typeparam name="TContext">The DbContext type that implements <see cref="IOutboxDbContext"/>.</typeparam>
-internal sealed class MySqlOutboxOperationsExecutor<TContext>(TContext context, int maxDegreeOfParallelism)
-    : TrackingOutboxOperationsExecutorBase<TContext>(context, maxDegreeOfParallelism)
+internal sealed class MySqlOutboxRepositoryExecutor<TContext>(TContext context, int maxDegreeOfParallelism)
+    : TrackingOutboxRepositoryExecutorBase<TContext>(context, maxDegreeOfParallelism)
     where TContext : DbContext, IOutboxDbContext
 {
     /// <inheritdoc />

--- a/src/NetEvolve.Pulse.EntityFramework/Outbox/TrackingOutboxRepositoryExecutorBase.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Outbox/TrackingOutboxRepositoryExecutorBase.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using NetEvolve.Pulse.Extensibility.Outbox;
 
 /// <summary>
-/// Base class for <see cref="IOutboxOperationsExecutor"/> implementations that persist changes
+/// Base class for <see cref="IOutboxRepositoryExecutor"/> implementations that persist changes
 /// through EF Core change tracking and <c>SaveChangesAsync</c>.
 /// </summary>
 /// <remarks>
@@ -14,8 +14,8 @@ using NetEvolve.Pulse.Extensibility.Outbox;
 /// Derived classes only need to implement <see cref="UpdateByIdsAsync"/>, which varies by provider.
 /// </remarks>
 /// <typeparam name="TContext">The DbContext type that implements <see cref="IOutboxDbContext"/>.</typeparam>
-internal abstract class TrackingOutboxOperationsExecutorBase<TContext>(TContext context, int maxDegreeOfParallelism)
-    : IOutboxOperationsExecutor
+internal abstract class TrackingOutboxRepositoryExecutorBase<TContext>(TContext context, int maxDegreeOfParallelism)
+    : IOutboxRepositoryExecutor
     where TContext : DbContext, IOutboxDbContext
 {
     /// <summary>The DbContext used for all tracking-based query and update operations.</summary>


### PR DESCRIPTION
Refactor all related interfaces, classes, and references from IOutboxOperationsExecutor to IOutboxRepositoryExecutor. Update class names (Bulk, InMemory, MySql, Tracking) and comments for consistency and clarity, better reflecting their role as repository executors. No functional changes introduced.