### PR TITLE
test: stabilize per-event processing timeout override test

### DIFF
--- a/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorHostedServiceTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorHostedServiceTests.cs
@@ -448,12 +448,18 @@ public sealed class OutboxProcessorHostedServiceTests
         await repository.AddAsync(message, cancellationToken).ConfigureAwait(false);
 
         await service.StartAsync(cancellationToken).ConfigureAwait(false);
-        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(TimeSpan.FromSeconds(15));
         await repository.WaitForMarkingsAsync(1, timeoutCts.Token).ConfigureAwait(false);
         await service.StopAsync(cancellationToken).ConfigureAwait(false);
 
-        // The message should not have been sent successfully
-        _ = await Assert.That(transport.SentMessages).IsEmpty();
+        using (Assert.Multiple())
+        {
+            // The message should not have been sent successfully
+            _ = await Assert.That(transport.SentMessages).IsEmpty();
+            // MaxRetryCount=1 means the first timeout should move directly to dead-letter.
+            _ = await Assert.That(repository.DeadLetterMessageIds).Contains(message.Id);
+        }
     }
 
     [Test]


### PR DESCRIPTION
### Motivation
- The per-event processing timeout test was flaky under CI due to tight fixed timeouts and global test runner load, so it needs a more robust waiting strategy and stronger assertions to avoid timing-dependent failures.

### Description
- In `tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorHostedServiceTests.cs` the `ExecuteAsync_WithPerEventTypeProcessingTimeout_UsesOverride` test now uses a cancellation token linked to the test `cancellationToken` and increases the wait budget from `5s` to `15s`, and the final assertions are wrapped in `Assert.Multiple()` and now also assert the message was moved to the `DeadLetter` collection.

### Testing
- Attempted to run the targeted test with `dotnet test --solution Pulse.slnx --filter "ExecuteAsync_WithPerEventTypeProcessingTimeout_UsesOverride"`, but `dotnet` is not available in this environment so the test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dd51ea8fd4832a8b2d03f6eb320684)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for outbox processor timeout handling and dead letter message validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->