### PR TITLE
refactor: use IPayloadSerializer abstraction

### DIFF
--- a/src/NetEvolve.Pulse.Dapr/OutBox/DaprMessageTransport.cs
+++ b/src/NetEvolve.Pulse.Dapr/OutBox/DaprMessageTransport.cs
@@ -3,6 +3,7 @@
 using System.Text.Json;
 using Dapr.Client;
 using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.Extensibility;
 using NetEvolve.Pulse.Extensibility.Outbox;
 
 /// <summary>
@@ -29,25 +30,32 @@ internal sealed class DaprMessageTransport : IMessageTransport
     /// <summary>The topic name resolver used to determine the Dapr topic name from an outbox message.</summary>
     private readonly ITopicNameResolver _topicNameResolver;
 
+    /// <summary>The payload serializer used to serialize and deserialize outbox message payloads.</summary>
+    private readonly IPayloadSerializer _payloadSerializer;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="DaprMessageTransport"/> class.
     /// </summary>
     /// <param name="daprClient">The Dapr client for publishing events.</param>
     /// <param name="topicNameResolver">The topic name resolver for determining topic names from outbox messages.</param>
     /// <param name="options">The transport options.</param>
+    /// <param name="payloadSerializer">The payload serializer for deserializing outbox message payloads.</param>
     public DaprMessageTransport(
         DaprClient daprClient,
         ITopicNameResolver topicNameResolver,
-        IOptions<DaprMessageTransportOptions> options
+        IOptions<DaprMessageTransportOptions> options,
+        IPayloadSerializer payloadSerializer
     )
     {
         ArgumentNullException.ThrowIfNull(daprClient);
         ArgumentNullException.ThrowIfNull(topicNameResolver);
         ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(payloadSerializer);
 
         _daprClient = daprClient;
         _topicNameResolver = topicNameResolver;
         _options = options.Value;
+        _payloadSerializer = payloadSerializer;
     }
 
     /// <inheritdoc />
@@ -56,7 +64,7 @@ internal sealed class DaprMessageTransport : IMessageTransport
         ArgumentNullException.ThrowIfNull(message);
 
         var topicName = _topicNameResolver.Resolve(message);
-        var payload = JsonSerializer.Deserialize<JsonElement>(message.Payload);
+        var payload = _payloadSerializer.Deserialize<JsonElement>(message.Payload);
 
         await _daprClient
             .PublishEventAsync(_options.PubSubName, topicName, payload, cancellationToken)

--- a/src/NetEvolve.Pulse.Dapr/OutBox/DaprMessageTransport.cs
+++ b/src/NetEvolve.Pulse.Dapr/OutBox/DaprMessageTransport.cs
@@ -1,6 +1,5 @@
 ﻿namespace NetEvolve.Pulse.Outbox;
 
-using System.Text.Json;
 using Dapr.Client;
 using Microsoft.Extensions.Options;
 using NetEvolve.Pulse.Extensibility;
@@ -64,7 +63,7 @@ internal sealed class DaprMessageTransport : IMessageTransport
         ArgumentNullException.ThrowIfNull(message);
 
         var topicName = _topicNameResolver.Resolve(message);
-        var payload = _payloadSerializer.Deserialize<JsonElement>(message.Payload);
+        var payload = _payloadSerializer.Deserialize<object>(message.Payload);
 
         await _daprClient
             .PublishEventAsync(_options.PubSubName, topicName, payload, cancellationToken)

--- a/src/NetEvolve.Pulse.Extensibility/Caching/QueryCachingOptions.cs
+++ b/src/NetEvolve.Pulse.Extensibility/Caching/QueryCachingOptions.cs
@@ -1,7 +1,5 @@
 ﻿namespace NetEvolve.Pulse.Extensibility.Caching;
 
-using System.Text.Json;
-
 /// <summary>
 /// Configuration options for the distributed query caching interceptor.
 /// </summary>
@@ -11,17 +9,6 @@ using System.Text.Json;
 /// <seealso cref="ICacheableQuery{TResponse}"/>
 public sealed class QueryCachingOptions
 {
-    /// <summary>
-    /// Gets or sets the <see cref="System.Text.Json.JsonSerializerOptions"/> used when
-    /// serializing responses to the cache and deserializing them back.
-    /// </summary>
-    /// <remarks>
-    /// Defaults to <see cref="JsonSerializerOptions.Default"/>.
-    /// Provide custom options when your response types require non-default converters,
-    /// naming policies, or other serialization settings.
-    /// </remarks>
-    public JsonSerializerOptions JsonSerializerOptions { get; set; } = JsonSerializerOptions.Default;
-
     /// <summary>
     /// Gets or sets how the <see cref="ICacheableQuery{TResponse}.Expiry"/> value is interpreted
     /// when storing entries in the distributed cache.

--- a/src/NetEvolve.Pulse/Interceptors/DistributedCacheQueryInterceptor.cs
+++ b/src/NetEvolve.Pulse/Interceptors/DistributedCacheQueryInterceptor.cs
@@ -18,7 +18,8 @@ using NetEvolve.Pulse.Extensibility.Caching;
 /// When a cached entry is found for the query's <see cref="ICacheableQuery{TResponse}.CacheKey"/>,
 /// the handler is skipped and the deserialized response is returned directly.
 /// <para><strong>Cache Miss:</strong></para>
-/// When no cached entry exists, the handler is invoked and the response is serialized to JSON
+/// When no cached entry exists, the handler is invoked and the response is serialized using the
+/// configured <see cref="IPayloadSerializer"/> of <see cref="DistributedCacheQueryInterceptor{TQuery, TResponse}"/>
 /// and stored in the cache before being returned to the caller.
 /// <para><strong>No Cache Registered:</strong></para>
 /// When <see cref="IDistributedCache"/> is not registered in the DI container, the interceptor
@@ -88,16 +89,21 @@ internal sealed class DistributedCacheQueryInterceptor<TQuery, TResponse> : IQue
         var cachedBytes = await cache.GetAsync(cacheKey, cancellationToken).ConfigureAwait(false);
         if (cachedBytes is not null)
         {
-            return _payloadSerializer.Deserialize<TResponse>(cachedBytes)!;
+            var cached = _payloadSerializer.Deserialize<TResponse>(cachedBytes);
+            if (cached is not null)
+            {
+                return cached;
+            }
         }
 
         var response = await handler(request, cancellationToken).ConfigureAwait(false);
 
-        var serialized = _payloadSerializer.SerializeToBytes(response);
-
-        var entryOptions = GetCacheEntryOptions(cacheableQuery);
-
-        await cache.SetAsync(cacheKey, serialized, entryOptions, cancellationToken).ConfigureAwait(false);
+        if (response is not null)
+        {
+            var serialized = _payloadSerializer.SerializeToBytes(response);
+            var entryOptions = GetCacheEntryOptions(cacheableQuery);
+            await cache.SetAsync(cacheKey, serialized, entryOptions, cancellationToken).ConfigureAwait(false);
+        }
 
         return response;
     }

--- a/src/NetEvolve.Pulse/Interceptors/DistributedCacheQueryInterceptor.cs
+++ b/src/NetEvolve.Pulse/Interceptors/DistributedCacheQueryInterceptor.cs
@@ -94,6 +94,8 @@ internal sealed class DistributedCacheQueryInterceptor<TQuery, TResponse> : IQue
             {
                 return cached;
             }
+
+            await cache.RemoveAsync(cacheKey, cancellationToken).ConfigureAwait(false);
         }
 
         var response = await handler(request, cancellationToken).ConfigureAwait(false);

--- a/src/NetEvolve.Pulse/Interceptors/DistributedCacheQueryInterceptor.cs
+++ b/src/NetEvolve.Pulse/Interceptors/DistributedCacheQueryInterceptor.cs
@@ -1,6 +1,5 @@
 ﻿namespace NetEvolve.Pulse.Interceptors;
 
-using System.Text.Json;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -30,9 +29,9 @@ using NetEvolve.Pulse.Extensibility.Caching;
 /// If both are <see langword="null"/> the entry is stored without an explicit expiration.
 /// The resolved expiry is applied as absolute or sliding based on <see cref="QueryCachingOptions.ExpirationMode"/>.
 /// <para><strong>Serialization:</strong></para>
-/// Responses are serialized using <c>System.Text.Json</c> with the options supplied via
-/// <see cref="QueryCachingOptions.JsonSerializerOptions"/>. Defaults to
-/// <see cref="JsonSerializerOptions.Default"/> when no custom options are configured.
+/// Responses are serialized and deserialized using the registered <see cref="IPayloadSerializer"/>.
+/// Register a custom implementation before building the service container to override the default
+/// <c>System.Text.Json</c>-based serializer.
 /// </remarks>
 /// <seealso cref="ICacheableQuery{TResponse}"/>
 /// <seealso cref="QueryCachingOptions"/>
@@ -41,16 +40,27 @@ internal sealed class DistributedCacheQueryInterceptor<TQuery, TResponse> : IQue
 {
     private readonly IServiceProvider _serviceProvider;
     private readonly QueryCachingOptions _options;
+    private readonly IPayloadSerializer _payloadSerializer;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DistributedCacheQueryInterceptor{TQuery, TResponse}"/> class.
     /// </summary>
     /// <param name="serviceProvider">The service provider used to resolve <see cref="IDistributedCache"/>.</param>
     /// <param name="options">The caching options.</param>
-    public DistributedCacheQueryInterceptor(IServiceProvider serviceProvider, IOptions<QueryCachingOptions> options)
+    /// <param name="payloadSerializer">The payload serializer for cache value serialization.</param>
+    public DistributedCacheQueryInterceptor(
+        IServiceProvider serviceProvider,
+        IOptions<QueryCachingOptions> options,
+        IPayloadSerializer payloadSerializer
+    )
     {
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(payloadSerializer);
+
         _serviceProvider = serviceProvider;
         _options = options.Value;
+        _payloadSerializer = payloadSerializer;
     }
 
     /// <inheritdoc />
@@ -74,17 +84,16 @@ internal sealed class DistributedCacheQueryInterceptor<TQuery, TResponse> : IQue
         }
 
         var cacheKey = cacheableQuery.CacheKey;
-        var jsonOptions = _options.JsonSerializerOptions;
 
         var cachedBytes = await cache.GetAsync(cacheKey, cancellationToken).ConfigureAwait(false);
         if (cachedBytes is not null)
         {
-            return JsonSerializer.Deserialize<TResponse>(cachedBytes, jsonOptions)!;
+            return _payloadSerializer.Deserialize<TResponse>(cachedBytes)!;
         }
 
         var response = await handler(request, cancellationToken).ConfigureAwait(false);
 
-        var serialized = JsonSerializer.SerializeToUtf8Bytes(response, jsonOptions);
+        var serialized = _payloadSerializer.SerializeToBytes(response);
 
         var entryOptions = GetCacheEntryOptions(cacheableQuery);
 

--- a/src/NetEvolve.Pulse/Serialization/SystemTextJsonPayloadSerializer.cs
+++ b/src/NetEvolve.Pulse/Serialization/SystemTextJsonPayloadSerializer.cs
@@ -1,6 +1,5 @@
 namespace NetEvolve.Pulse.Serialization;
 
-using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Options;
 using NetEvolve.Pulse.Extensibility;

--- a/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/TestAnalyzerConfigOptionsProvider.cs
+++ b/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/TestAnalyzerConfigOptionsProvider.cs
@@ -1,7 +1,5 @@
 ﻿namespace NetEvolve.Pulse.SourceGeneration.Tests.Unit;
 
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 

--- a/tests/NetEvolve.Pulse.Tests.Integration/Internals/MySqlContainerFixture.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Internals/MySqlContainerFixture.cs
@@ -1,7 +1,6 @@
 ﻿namespace NetEvolve.Pulse.Tests.Integration.Internals;
 
 using Microsoft.Extensions.Logging.Abstractions;
-using MySql.Data.MySqlClient;
 using Testcontainers.MySql;
 using TUnit.Core.Interfaces;
 

--- a/tests/NetEvolve.Pulse.Tests.Unit/Dapr/DaprMessageTransportTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Dapr/DaprMessageTransportTests.cs
@@ -1,18 +1,26 @@
 ﻿namespace NetEvolve.Pulse.Tests.Unit.Dapr;
 
 using System;
+using System.Text.Json;
 using System.Threading.Tasks;
 using global::Dapr.Client;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility;
 using NetEvolve.Pulse.Extensibility.Outbox;
 using NetEvolve.Pulse.Outbox;
+using NetEvolve.Pulse.Serialization;
 using TUnit.Assertions.Extensions;
 using TUnit.Core;
 
 [TestGroup("Dapr")]
 public sealed class DaprMessageTransportTests
 {
+#pragma warning disable CA1859 // property intentionally typed as IPayloadSerializer for test flexibility
+    private static IPayloadSerializer DefaultSerializer =>
+        new SystemTextJsonPayloadSerializer(Options.Create(JsonSerializerOptions.Default));
+#pragma warning restore CA1859
+
     [Test]
     public async Task Constructor_When_daprClient_is_null_throws_ArgumentNullException() =>
         _ = await Assert
@@ -20,7 +28,8 @@ public sealed class DaprMessageTransportTests
                 new DaprMessageTransport(
                     null!,
                     new FakeTopicNameResolver(),
-                    Options.Create(new DaprMessageTransportOptions())
+                    Options.Create(new DaprMessageTransportOptions()),
+                    DefaultSerializer
                 )
             )
             .Throws<ArgumentNullException>();
@@ -31,7 +40,14 @@ public sealed class DaprMessageTransportTests
         using var daprClient = new DaprClientBuilder().Build();
 
         _ = await Assert
-            .That(() => new DaprMessageTransport(daprClient, null!, Options.Create(new DaprMessageTransportOptions())))
+            .That(() =>
+                new DaprMessageTransport(
+                    daprClient,
+                    null!,
+                    Options.Create(new DaprMessageTransportOptions()),
+                    DefaultSerializer
+                )
+            )
             .Throws<ArgumentNullException>();
     }
 
@@ -41,7 +57,24 @@ public sealed class DaprMessageTransportTests
         using var daprClient = new DaprClientBuilder().Build();
 
         _ = await Assert
-            .That(() => new DaprMessageTransport(daprClient, new FakeTopicNameResolver(), null!))
+            .That(() => new DaprMessageTransport(daprClient, new FakeTopicNameResolver(), null!, DefaultSerializer))
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Constructor_When_payloadSerializer_is_null_throws_ArgumentNullException()
+    {
+        using var daprClient = new DaprClientBuilder().Build();
+
+        _ = await Assert
+            .That(() =>
+                new DaprMessageTransport(
+                    daprClient,
+                    new FakeTopicNameResolver(),
+                    Options.Create(new DaprMessageTransportOptions()),
+                    null!
+                )
+            )
             .Throws<ArgumentNullException>();
     }
 
@@ -52,7 +85,8 @@ public sealed class DaprMessageTransportTests
         var transport = new DaprMessageTransport(
             daprClient,
             new FakeTopicNameResolver(),
-            Options.Create(new DaprMessageTransportOptions())
+            Options.Create(new DaprMessageTransportOptions()),
+            DefaultSerializer
         );
 
         _ = await Assert.That(transport).IsNotNull();
@@ -65,7 +99,8 @@ public sealed class DaprMessageTransportTests
         var transport = new DaprMessageTransport(
             daprClient,
             new FakeTopicNameResolver(),
-            Options.Create(new DaprMessageTransportOptions())
+            Options.Create(new DaprMessageTransportOptions()),
+            DefaultSerializer
         );
 
         _ = await Assert.ThrowsAsync<ArgumentNullException>(() => transport.SendAsync(null!, cancellationToken));
@@ -78,10 +113,11 @@ public sealed class DaprMessageTransportTests
         var transport = new DaprMessageTransport(
             daprClient,
             new FakeTopicNameResolver(),
-            Options.Create(new DaprMessageTransportOptions())
+            Options.Create(new DaprMessageTransportOptions()),
+            DefaultSerializer
         );
 
-        // Without a running Dapr sidecar, CheckHealthAsync returns false (connection refused → false, not throw)
+        // Without a running Dapr sidecar, CheckHealthAsync returns false
         var result = await transport.IsHealthyAsync(cancellationToken).ConfigureAwait(false);
 
         _ = await Assert.That(result).IsTypeOf<bool>();

--- a/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/DistributedCacheQueryInterceptorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/DistributedCacheQueryInterceptorTests.cs
@@ -505,6 +505,12 @@ public class DistributedCacheQueryInterceptorTests
             {
                 _ = await Assert.That(result).IsEqualTo("fallback-value");
                 _ = await Assert.That(handlerCallCount).IsEqualTo(1);
+
+                // Stale null bytes must have been evicted and replaced with the fresh handler value
+                var afterBytes = await cache.GetAsync("null-cached-key", cancellationToken).ConfigureAwait(false);
+                _ = await Assert.That(afterBytes).IsNotNull();
+                var afterValue = DefaultSerializer.Deserialize<string>(afterBytes!);
+                _ = await Assert.That(afterValue).IsEqualTo("fallback-value");
             }
         }
     }

--- a/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/DistributedCacheQueryInterceptorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/DistributedCacheQueryInterceptorTests.cs
@@ -8,12 +8,54 @@ using NetEvolve.Extensions.TUnit;
 using NetEvolve.Pulse.Extensibility;
 using NetEvolve.Pulse.Extensibility.Caching;
 using NetEvolve.Pulse.Interceptors;
+using NetEvolve.Pulse.Serialization;
 using TUnit.Core;
 
 [TestGroup("Interceptors")]
 public class DistributedCacheQueryInterceptorTests
 {
     private static IOptions<QueryCachingOptions> DefaultOptions => Options.Create(new QueryCachingOptions());
+
+#pragma warning disable CA1859 // property intentionally typed as IPayloadSerializer for test flexibility
+    private static IPayloadSerializer DefaultSerializer =>
+        new SystemTextJsonPayloadSerializer(Options.Create(JsonSerializerOptions.Default));
+#pragma warning restore CA1859
+
+    [Test]
+    public async Task Constructor_When_serviceProvider_is_null_throws_ArgumentNullException() =>
+        _ = await Assert
+            .That(() =>
+                new DistributedCacheQueryInterceptor<NonCacheableQuery, string>(
+                    null!,
+                    DefaultOptions,
+                    DefaultSerializer
+                )
+            )
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Constructor_When_options_is_null_throws_ArgumentNullException() =>
+        _ = await Assert
+            .That(() =>
+                new DistributedCacheQueryInterceptor<NonCacheableQuery, string>(
+                    new ServiceCollection().BuildServiceProvider(),
+                    null!,
+                    DefaultSerializer
+                )
+            )
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Constructor_When_payloadSerializer_is_null_throws_ArgumentNullException() =>
+        _ = await Assert
+            .That(() =>
+                new DistributedCacheQueryInterceptor<NonCacheableQuery, string>(
+                    new ServiceCollection().BuildServiceProvider(),
+                    DefaultOptions,
+                    null!
+                )
+            )
+            .Throws<ArgumentNullException>();
 
     [Test]
     public async Task HandleAsync_QueryNotCacheable_AlwaysCallsHandler(CancellationToken cancellationToken)
@@ -23,7 +65,11 @@ public class DistributedCacheQueryInterceptorTests
         var provider = services.BuildServiceProvider();
         await using (provider.ConfigureAwait(false))
         {
-            var interceptor = new DistributedCacheQueryInterceptor<NonCacheableQuery, string>(provider, DefaultOptions);
+            var interceptor = new DistributedCacheQueryInterceptor<NonCacheableQuery, string>(
+                provider,
+                DefaultOptions,
+                DefaultSerializer
+            );
             var query = new NonCacheableQuery();
             var handlerCallCount = 0;
 
@@ -55,7 +101,11 @@ public class DistributedCacheQueryInterceptorTests
         var provider = services.BuildServiceProvider();
         await using (provider.ConfigureAwait(false))
         {
-            var interceptor = new DistributedCacheQueryInterceptor<CacheableQuery, string>(provider, DefaultOptions);
+            var interceptor = new DistributedCacheQueryInterceptor<CacheableQuery, string>(
+                provider,
+                DefaultOptions,
+                DefaultSerializer
+            );
             var query = new CacheableQuery("test-key");
             var handlerCallCount = 0;
 
@@ -81,7 +131,7 @@ public class DistributedCacheQueryInterceptorTests
             var cache = provider.GetRequiredService<IDistributedCache>();
             var bytes = await cache.GetAsync("test-key", cancellationToken).ConfigureAwait(false);
             _ = await Assert.That(bytes).IsNotNull();
-            var deserialised = JsonSerializer.Deserialize<string>(bytes!);
+            var deserialised = DefaultSerializer.Deserialize<string>(bytes!);
             _ = await Assert.That(deserialised).IsEqualTo("cached-value");
         }
     }
@@ -96,10 +146,14 @@ public class DistributedCacheQueryInterceptorTests
         {
             // Pre-populate the cache
             var cache = provider.GetRequiredService<IDistributedCache>();
-            var serialized = JsonSerializer.SerializeToUtf8Bytes("cached-result");
+            var serialized = DefaultSerializer.SerializeToBytes("cached-result");
             await cache.SetAsync("hit-key", serialized, cancellationToken).ConfigureAwait(false);
 
-            var interceptor = new DistributedCacheQueryInterceptor<CacheableQuery, string>(provider, DefaultOptions);
+            var interceptor = new DistributedCacheQueryInterceptor<CacheableQuery, string>(
+                provider,
+                DefaultOptions,
+                DefaultSerializer
+            );
             var query = new CacheableQuery("hit-key");
             var handlerCallCount = 0;
 
@@ -133,7 +187,8 @@ public class DistributedCacheQueryInterceptorTests
         {
             var interceptor = new DistributedCacheQueryInterceptor<CacheableQueryWithExpiry, string>(
                 provider,
-                DefaultOptions
+                DefaultOptions,
+                DefaultSerializer
             );
             var query = new CacheableQueryWithExpiry("expiry-key", TimeSpan.FromSeconds(60));
 
@@ -157,7 +212,11 @@ public class DistributedCacheQueryInterceptorTests
         var provider = services.BuildServiceProvider();
         await using (provider.ConfigureAwait(false))
         {
-            var interceptor = new DistributedCacheQueryInterceptor<CacheableQuery, string>(provider, DefaultOptions);
+            var interceptor = new DistributedCacheQueryInterceptor<CacheableQuery, string>(
+                provider,
+                DefaultOptions,
+                DefaultSerializer
+            );
             var query = new CacheableQuery("no-expiry-key");
 
             var result = await interceptor
@@ -181,7 +240,11 @@ public class DistributedCacheQueryInterceptorTests
         // Do NOT register IDistributedCache
         await using (provider.ConfigureAwait(false))
         {
-            var interceptor = new DistributedCacheQueryInterceptor<CacheableQuery, string>(provider, DefaultOptions);
+            var interceptor = new DistributedCacheQueryInterceptor<CacheableQuery, string>(
+                provider,
+                DefaultOptions,
+                DefaultSerializer
+            );
             var query = new CacheableQuery("some-key");
             var handlerCallCount = 0;
 
@@ -214,7 +277,7 @@ public class DistributedCacheQueryInterceptorTests
         await using (provider.ConfigureAwait(false))
         {
             var cache = provider.GetRequiredService<IDistributedCache>();
-            var serialized = JsonSerializer.SerializeToUtf8Bytes("stale-value");
+            var serialized = DefaultSerializer.SerializeToBytes("stale-value");
             // Store with an already-expired entry (1 ms TTL)
             await cache
                 .SetAsync(
@@ -227,7 +290,11 @@ public class DistributedCacheQueryInterceptorTests
 
             await Task.Delay(50, cancellationToken).ConfigureAwait(false); // Allow the entry to expire
 
-            var interceptor = new DistributedCacheQueryInterceptor<CacheableQuery, string>(provider, DefaultOptions);
+            var interceptor = new DistributedCacheQueryInterceptor<CacheableQuery, string>(
+                provider,
+                DefaultOptions,
+                DefaultSerializer
+            );
             var query = new CacheableQuery("expired-key");
             var handlerCallCount = 0;
 
@@ -262,7 +329,11 @@ public class DistributedCacheQueryInterceptorTests
         await using (provider.ConfigureAwait(false))
         {
             var options = Options.Create(new QueryCachingOptions { ExpirationMode = CacheExpirationMode.Sliding });
-            var interceptor = new DistributedCacheQueryInterceptor<CacheableQueryWithExpiry, string>(provider, options);
+            var interceptor = new DistributedCacheQueryInterceptor<CacheableQueryWithExpiry, string>(
+                provider,
+                options,
+                DefaultSerializer
+            );
             var query = new CacheableQueryWithExpiry("sliding-key", TimeSpan.FromSeconds(60));
 
             var result = await interceptor
@@ -279,7 +350,7 @@ public class DistributedCacheQueryInterceptorTests
     }
 
     [Test]
-    public async Task HandleAsync_CustomJsonSerializerOptions_UsedForSerializationAndDeserialization(
+    public async Task HandleAsync_SecondCall_ReturnsCachedValueWithoutCallingHandler(
         CancellationToken cancellationToken
     )
     {
@@ -288,24 +359,25 @@ public class DistributedCacheQueryInterceptorTests
         var provider = services.BuildServiceProvider();
         await using (provider.ConfigureAwait(false))
         {
-            var customJsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
-            var options = Options.Create(new QueryCachingOptions { JsonSerializerOptions = customJsonOptions });
-
-            var interceptor = new DistributedCacheQueryInterceptor<CacheableQuery, string>(provider, options);
-            var query = new CacheableQuery("custom-json-key");
+            var interceptor = new DistributedCacheQueryInterceptor<CacheableQuery, string>(
+                provider,
+                DefaultOptions,
+                DefaultSerializer
+            );
+            var query = new CacheableQuery("second-call-key");
 
             var result = await interceptor
-                .HandleAsync(query, (_, _) => Task.FromResult("custom-json-value"), cancellationToken)
+                .HandleAsync(query, (_, _) => Task.FromResult("first-value"), cancellationToken)
                 .ConfigureAwait(false);
 
-            _ = await Assert.That(result).IsEqualTo("custom-json-value");
+            _ = await Assert.That(result).IsEqualTo("first-value");
 
-            // Second call should return from cache using the same custom options
+            // Second call should return from cache without invoking the handler
             var cachedResult = await interceptor
                 .HandleAsync(query, (_, _) => Task.FromResult("should-not-be-returned"), cancellationToken)
                 .ConfigureAwait(false);
 
-            _ = await Assert.That(cachedResult).IsEqualTo("custom-json-value");
+            _ = await Assert.That(cachedResult).IsEqualTo("first-value");
         }
     }
 
@@ -318,7 +390,11 @@ public class DistributedCacheQueryInterceptorTests
         await using (provider.ConfigureAwait(false))
         {
             var options = Options.Create(new QueryCachingOptions { DefaultExpiry = TimeSpan.FromMinutes(5) });
-            var interceptor = new DistributedCacheQueryInterceptor<CacheableQuery, string>(provider, options);
+            var interceptor = new DistributedCacheQueryInterceptor<CacheableQuery, string>(
+                provider,
+                options,
+                DefaultSerializer
+            );
             var query = new CacheableQuery("default-expiry-key");
 
             var result = await interceptor
@@ -344,7 +420,11 @@ public class DistributedCacheQueryInterceptorTests
         {
             // DefaultExpiry set but query overrides with its own expiry value
             var options = Options.Create(new QueryCachingOptions { DefaultExpiry = TimeSpan.FromMilliseconds(1) });
-            var interceptor = new DistributedCacheQueryInterceptor<CacheableQueryWithExpiry, string>(provider, options);
+            var interceptor = new DistributedCacheQueryInterceptor<CacheableQueryWithExpiry, string>(
+                provider,
+                options,
+                DefaultSerializer
+            );
             var query = new CacheableQueryWithExpiry("query-expiry-key", TimeSpan.FromMinutes(10));
 
             var result = await interceptor

--- a/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/DistributedCacheQueryInterceptorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/DistributedCacheQueryInterceptorTests.cs
@@ -1,4 +1,4 @@
-namespace NetEvolve.Pulse.Tests.Unit.Interceptors;
+﻿namespace NetEvolve.Pulse.Tests.Unit.Interceptors;
 
 using System.Text.Json;
 using Microsoft.Extensions.Caching.Distributed;
@@ -437,6 +437,75 @@ public class DistributedCacheQueryInterceptorTests
             var cache = provider.GetRequiredService<IDistributedCache>();
             var bytes = await cache.GetAsync("query-expiry-key", cancellationToken).ConfigureAwait(false);
             _ = await Assert.That(bytes).IsNotNull();
+        }
+    }
+
+    [Test]
+    public async Task HandleAsync_NullResponse_SkipsCaching(CancellationToken cancellationToken)
+    {
+        var services = new ServiceCollection();
+        _ = services.AddDistributedMemoryCache();
+        var provider = services.BuildServiceProvider();
+        await using (provider.ConfigureAwait(false))
+        {
+            var interceptor = new DistributedCacheQueryInterceptor<CacheableQuery, string>(
+                provider,
+                DefaultOptions,
+                DefaultSerializer
+            );
+            var query = new CacheableQuery("null-response-key");
+
+            var result = await interceptor
+                .HandleAsync(query, (_, _) => Task.FromResult<string>(null!), cancellationToken)
+                .ConfigureAwait(false);
+
+            _ = await Assert.That(result).IsNull();
+
+            // Nothing should have been written to the cache
+            var cache = provider.GetRequiredService<IDistributedCache>();
+            var bytes = await cache.GetAsync("null-response-key", cancellationToken).ConfigureAwait(false);
+            _ = await Assert.That(bytes).IsNull();
+        }
+    }
+
+    [Test]
+    public async Task HandleAsync_NullDeserializedFromCache_FallsThroughToHandler(CancellationToken cancellationToken)
+    {
+        var services = new ServiceCollection();
+        _ = services.AddDistributedMemoryCache();
+        var provider = services.BuildServiceProvider();
+        await using (provider.ConfigureAwait(false))
+        {
+            // Pre-populate the cache with bytes that the serializer will deserialize as null
+            var cache = provider.GetRequiredService<IDistributedCache>();
+            var nullBytes = DefaultSerializer.SerializeToBytes<string>(null!);
+            await cache.SetAsync("null-cached-key", nullBytes, cancellationToken).ConfigureAwait(false);
+
+            var interceptor = new DistributedCacheQueryInterceptor<CacheableQuery, string>(
+                provider,
+                DefaultOptions,
+                DefaultSerializer
+            );
+            var query = new CacheableQuery("null-cached-key");
+            var handlerCallCount = 0;
+
+            var result = await interceptor
+                .HandleAsync(
+                    query,
+                    (_, _) =>
+                    {
+                        handlerCallCount++;
+                        return Task.FromResult("fallback-value");
+                    },
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+
+            using (Assert.Multiple())
+            {
+                _ = await Assert.That(result).IsEqualTo("fallback-value");
+                _ = await Assert.That(handlerCallCount).IsEqualTo(1);
+            }
         }
     }
 

--- a/tests/NetEvolve.Pulse.Tests.Unit/Serialization/SystemTextJsonPayloadSerializerTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Serialization/SystemTextJsonPayloadSerializerTests.cs
@@ -3,7 +3,6 @@ namespace NetEvolve.Pulse.Tests.Unit.Serialization;
 using System;
 using System.Text;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;


### PR DESCRIPTION
Replaced direct JsonSerializer usage with a pluggable IPayloadSerializer in DaprMessageTransport and DistributedCacheQueryInterceptor. Updated constructors to require IPayloadSerializer and added null checks. Removed QueryCachingOptions.JsonSerializerOptions and updated documentation accordingly. Adjusted all serialization logic and unit tests to use the serializer abstraction, ensuring consistent and customizable payload handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the JsonSerializerOptions property from query caching configuration.

* **Refactor**
  * Serialization now uses a pluggable serializer across caching and message transport components, improving consistency.

* **Chores**
  * Cleaned up unused import statements across tests and implementation files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->