### PR TITLE
tests: Add ConcurrentCommandGuardExtensions and improve exclusivity

### DIFF
--- a/src/NetEvolve.Pulse.AspNetCore/EndpointRouteBuilderExtensions.cs
+++ b/src/NetEvolve.Pulse.AspNetCore/EndpointRouteBuilderExtensions.cs
@@ -153,7 +153,7 @@ public static class EndpointRouteBuilderExtensions
     /// Server-Sent Events (SSE) or newline-delimited JSON (NDJSON), depending on the
     /// <c>Accept</c> request header. When the <c>Accept</c> header contains
     /// <c>application/x-ndjson</c>, each item is serialized to JSON and written as a
-    /// line followed by a newline character using <see cref="TypedResults.Stream(System.Func{System.IO.Stream,System.Threading.Tasks.Task},string?,string?,System.Nullable{System.DateTimeOffset},Microsoft.Net.Http.Headers.EntityTagHeaderValue?)"/>.
+    /// line followed by a newline character using <see cref="TypedResults.Stream(Func{Stream,Task},string?,string?,DateTimeOffset?,Microsoft.Net.Http.Headers.EntityTagHeaderValue?)"/>.
     /// Otherwise, items are streamed as SSE with <c>Content-Type: text/event-stream</c>.
     /// </summary>
     /// <typeparam name="TQuery">
@@ -219,7 +219,7 @@ public static class EndpointRouteBuilderExtensions
                 }
 
 #if NET10_0_OR_GREATER
-                return TypedResults.ServerSentEvents<TResponse>(items);
+                return TypedResults.ServerSentEvents(items);
 #else
                 return TypedResults.Stream(
                     async outputStream =>

--- a/src/NetEvolve.Pulse.EntityFramework/Configurations/MySqlOutboxMessageConfiguration.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Configurations/MySqlOutboxMessageConfiguration.cs
@@ -21,7 +21,7 @@ using NetEvolve.Pulse.Outbox;
 /// <para><strong>Why binary(16) and bigint:</strong></para>
 /// The Oracle MySQL provider does not produce a valid type mapping for
 /// <see cref="Guid"/>→<c>char(36)</c> SQL parameter binding (returns <see langword="null"/>,
-/// causing a <see cref="System.NullReferenceException"/> in
+/// causing a <see cref="NullReferenceException"/> in
 /// <c>TypeMappedRelationalParameter.AddDbParameter</c>).
 /// Using <c>binary(16)</c> with an explicit <c>byte[]</c> converter provides a working
 /// binding. Similarly, the provider lacks a proper <see cref="DateTimeOffset"/> SQL type

--- a/src/NetEvolve.Pulse.EntityFramework/EntityFrameworkIdempotencyExtensions.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/EntityFrameworkIdempotencyExtensions.cs
@@ -62,7 +62,7 @@ public static class EntityFrameworkIdempotencyExtensions
 
         var services = configurator.Services;
 
-        _ = services.Configure<IdempotencyKeyOptions>(configureOptions ?? (_ => { }));
+        _ = services.Configure(configureOptions ?? (_ => { }));
 
         services.TryAddSingleton(TimeProvider.System);
 

--- a/src/NetEvolve.Pulse.EntityFramework/ModelBuilderExtensions.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/ModelBuilderExtensions.cs
@@ -51,7 +51,7 @@ public static class ModelBuilderExtensions
     /// </summary>
     /// <typeparam name="TContext">The DbContext type, used to resolve registered <see cref="OutboxOptions"/>.</typeparam>
     /// <param name="context">The DbContext instance used to resolve <see cref="IOptions{TOptions}"/> of <see cref="OutboxOptions"/>.</param>
-    /// <param name="providerName">The EF Core provider name read from <see cref="Microsoft.EntityFrameworkCore.Infrastructure.DatabaseFacade.ProviderName"/>.</param>
+    /// <param name="providerName">The EF Core provider name read from <see cref="DatabaseFacade.ProviderName"/>.</param>
     /// <returns>A provider-specific <see cref="IEntityTypeConfiguration{TEntity}"/> for <see cref="OutboxMessage"/>.</returns>
     /// <exception cref="NotSupportedException">Thrown when <paramref name="providerName"/> is not a supported EF Core provider.</exception>
     private static IEntityTypeConfiguration<OutboxMessage> GetOutboxConfiguration<TContext>(
@@ -92,7 +92,7 @@ public static class ModelBuilderExtensions
     /// </summary>
     /// <typeparam name="TContext">The DbContext type, used to resolve registered <see cref="IdempotencyKeyOptions"/>.</typeparam>
     /// <param name="context">The DbContext instance used to resolve <see cref="IOptions{TOptions}"/> of <see cref="IdempotencyKeyOptions"/>.</param>
-    /// <param name="providerName">The EF Core provider name read from <see cref="Microsoft.EntityFrameworkCore.Infrastructure.DatabaseFacade.ProviderName"/>.</param>
+    /// <param name="providerName">The EF Core provider name read from <see cref="DatabaseFacade.ProviderName"/>.</param>
     /// <returns>A provider-specific <see cref="IEntityTypeConfiguration{TEntity}"/> for <see cref="IdempotencyKey"/>.</returns>
     /// <exception cref="NotSupportedException">Thrown when <paramref name="providerName"/> is not a supported EF Core provider.</exception>
     private static IEntityTypeConfiguration<IdempotencyKey> GetIdempotencyKeyConfiguration<TContext>(

--- a/src/NetEvolve.Pulse.Extensibility/IExclusiveCommand`1.cs
+++ b/src/NetEvolve.Pulse.Extensibility/IExclusiveCommand`1.cs
@@ -3,7 +3,7 @@ namespace NetEvolve.Pulse.Extensibility;
 /// <summary>
 /// Marks a command as requiring exclusive (non-concurrent) execution within the same process.
 /// When registered with <c>ConcurrentCommandGuardInterceptor</c>, only one instance of the
-/// same command type runs at a time, enforced via a <see cref="System.Threading.SemaphoreSlim"/>(1,1).
+/// same command type runs at a time, enforced via a <see cref="SemaphoreSlim"/>(1,1).
 /// </summary>
 /// <typeparam name="TResponse">The type of response returned after executing the command.</typeparam>
 /// <remarks>

--- a/src/NetEvolve.Pulse.MySql/MySqlIdempotencyMediatorBuilderExtensions.cs
+++ b/src/NetEvolve.Pulse.MySql/MySqlIdempotencyMediatorBuilderExtensions.cs
@@ -29,13 +29,13 @@ public static class MySqlIdempotencyMediatorBuilderExtensions
     /// MySQL does not use schema namespaces. The <see cref="IdempotencyKeyOptions.Schema"/> property is
     /// ignored; tables are always created in the active database from the connection string.
     /// <para><strong>Interoperability:</strong></para>
-    /// Stores <see cref="System.DateTimeOffset"/> values as <c>BIGINT</c> (UTC ticks), matching
+    /// Stores <see cref="DateTimeOffset"/> values as <c>BIGINT</c> (UTC ticks), matching
     /// the Entity Framework MySQL provider schema.
     /// <para><strong>Registered Services:</strong></para>
     /// <list type="bullet">
     /// <item><description><see cref="IIdempotencyKeyRepository"/> as <see cref="MySqlIdempotencyKeyRepository"/> (Scoped)</description></item>
     /// <item><description><see cref="IIdempotencyStore"/> as <see cref="IdempotencyStore"/> (Scoped, via <see cref="IdempotencyExtensions.AddIdempotency"/>)</description></item>
-    /// <item><description><see cref="System.TimeProvider"/> (Singleton, if not already registered)</description></item>
+    /// <item><description><see cref="TimeProvider"/> (Singleton, if not already registered)</description></item>
     /// </list>
     /// <para><strong>Note:</strong></para>
     /// Core idempotency services are registered automatically; calling

--- a/src/NetEvolve.Pulse/ConcurrentCommandGuardExtensions.cs
+++ b/src/NetEvolve.Pulse/ConcurrentCommandGuardExtensions.cs
@@ -25,7 +25,7 @@ public static class ConcurrentCommandGuardExtensions
 {
     /// <summary>
     /// Registers an open-generic <see cref="ConcurrentCommandGuardInterceptor{TRequest,TResponse}"/>
-    /// as a scoped <see cref="IRequestInterceptor{TRequest,TResponse}"/> for <em>all</em>
+    /// as a singleton <see cref="IRequestInterceptor{TRequest,TResponse}"/> for <em>all</em>
     /// <see cref="IExclusiveCommand{TResponse}"/> implementations discovered at runtime.
     /// </summary>
     /// <param name="configurator">The <see cref="IMediatorBuilder"/> to configure. Must not be <see langword="null"/>.</param>

--- a/src/NetEvolve.Pulse/ConcurrentCommandGuardExtensions.cs
+++ b/src/NetEvolve.Pulse/ConcurrentCommandGuardExtensions.cs
@@ -1,0 +1,135 @@
+namespace NetEvolve.Pulse;
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Interceptors;
+
+/// <summary>
+/// Provides extension methods on <see cref="IMediatorBuilder"/> for registering the
+/// <see cref="ConcurrentCommandGuardInterceptor{TRequest,TResponse}"/>,
+/// which enforces exclusive (non-concurrent) in-process execution for commands that implement
+/// <see cref="IExclusiveCommand{TResponse}"/>.
+/// </summary>
+/// <remarks>
+/// <para><strong>Behavior:</strong></para>
+/// The interceptor acquires a per-command-type <see cref="SemaphoreSlim"/>(1,1)
+/// before delegating to the handler, ensuring at most one concurrent execution per command type.
+/// The semaphore is always released in a <see langword="finally"/> block, even if the handler throws.
+/// <para><strong>Scope:</strong></para>
+/// Exclusivity is in-process only. For distributed exclusivity across multiple instances,
+/// a distributed lock (e.g., Redis, SQL) is required.
+/// </remarks>
+public static class ConcurrentCommandGuardExtensions
+{
+    /// <summary>
+    /// Registers an open-generic <see cref="ConcurrentCommandGuardInterceptor{TRequest,TResponse}"/>
+    /// as a scoped <see cref="IRequestInterceptor{TRequest,TResponse}"/> for <em>all</em>
+    /// <see cref="IExclusiveCommand{TResponse}"/> implementations discovered at runtime.
+    /// </summary>
+    /// <param name="configurator">The <see cref="IMediatorBuilder"/> to configure. Must not be <see langword="null"/>.</param>
+    /// <returns>The same <paramref name="configurator"/> instance, enabling fluent chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configurator"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para><strong>Registration:</strong></para>
+    /// Uses <see cref="ServiceCollectionDescriptorExtensions.TryAddEnumerable(IServiceCollection, ServiceDescriptor)"/>
+    /// with a <see cref="ServiceLifetime.Singleton"/> lifetime to avoid duplicate registrations.
+    /// <para><strong>Lifetime:</strong></para>
+    /// The interceptor is registered as <see cref="ServiceLifetime.Singleton"/>,
+    /// sharing one instance (and its per-command-type semaphore dictionary) for the full application lifetime.
+    /// </remarks>
+    /// <seealso cref="AddConcurrentCommandGuard{TRequest,TResponse}(IMediatorBuilder)"/>
+    /// <seealso cref="AddConcurrentCommandGuard{TRequest}(IMediatorBuilder)"/>
+    public static IMediatorBuilder AddConcurrentCommandGuard(this IMediatorBuilder configurator)
+    {
+        ArgumentNullException.ThrowIfNull(configurator);
+
+        var services = configurator.Services;
+
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton(typeof(IRequestInterceptor<,>), typeof(ConcurrentCommandGuardInterceptor<,>))
+        );
+
+        return configurator;
+    }
+
+    /// <summary>
+    /// Registers a closed-generic <see cref="ConcurrentCommandGuardInterceptor{TRequest,TResponse}"/>
+    /// as a singleton <see cref="IRequestInterceptor{TRequest,TResponse}"/> for the specific
+    /// <typeparamref name="TRequest"/> / <typeparamref name="TResponse"/> pair.
+    /// </summary>
+    /// <typeparam name="TRequest">
+    /// The command type to guard. Must implement <see cref="IExclusiveCommand{TResponse}"/>.
+    /// </typeparam>
+    /// <typeparam name="TResponse">The type of response produced by <typeparamref name="TRequest"/>.</typeparam>
+    /// <param name="configurator">The <see cref="IMediatorBuilder"/> to configure. Must not be <see langword="null"/>.</param>
+    /// <returns>The same <paramref name="configurator"/> instance, enabling fluent chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configurator"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para><strong>Registration:</strong></para>
+    /// Uses a two-step registration to guarantee a single shared interceptor instance:
+    /// <list type="number">
+    /// <item>
+    /// <description>
+    /// The open-generic <see cref="ConcurrentCommandGuardInterceptor{TRequest,TResponse}"/> is registered
+    /// as a singleton mapped to itself via
+    /// <see cref="ServiceCollectionDescriptorExtensions.TryAdd(IServiceCollection, ServiceDescriptor)"/>,
+    /// ensuring at most one concrete instance per closed command type for the application lifetime.
+    /// </description>
+    /// </item>
+    /// <item>
+    /// <description>
+    /// <see cref="IRequestInterceptor{TRequest,TResponse}"/> is registered with a singleton factory
+    /// via <see cref="ServiceCollectionDescriptorExtensions.TryAddSingleton{TService}(IServiceCollection, Func{IServiceProvider,TService})"/>
+    /// that delegates to the concrete interceptor, so both the open-generic overload
+    /// (<see cref="AddConcurrentCommandGuard(IMediatorBuilder)"/>) and this typed overload resolve
+    /// to the <em>same</em> underlying instance and semaphore dictionary.
+    /// </description>
+    /// </item>
+    /// </list>
+    /// <para><strong>Lifetime:</strong></para>
+    /// Both registrations use <see cref="ServiceLifetime.Singleton"/>, sharing one interceptor
+    /// instance (and its semaphore dictionary) for the full application lifetime.
+    /// </remarks>
+    /// <seealso cref="AddConcurrentCommandGuard(IMediatorBuilder)"/>
+    /// <seealso cref="AddConcurrentCommandGuard{TRequest}(IMediatorBuilder)"/>
+    public static IMediatorBuilder AddConcurrentCommandGuard<TRequest, TResponse>(this IMediatorBuilder configurator)
+        where TRequest : IExclusiveCommand<TResponse>
+    {
+        ArgumentNullException.ThrowIfNull(configurator);
+
+        var services = configurator.Services;
+
+        services.TryAdd(ServiceDescriptor.Singleton(typeof(ConcurrentCommandGuardInterceptor<,>)));
+        services.TryAddSingleton<IRequestInterceptor<TRequest, TResponse>>(sp =>
+            sp.GetRequiredService<ConcurrentCommandGuardInterceptor<TRequest, TResponse>>()
+        );
+
+        return configurator;
+    }
+
+    /// <summary>
+    /// Registers a closed-generic <see cref="ConcurrentCommandGuardInterceptor{TRequest,TResponse}"/>
+    /// as a singleton <see cref="IRequestInterceptor{TRequest,TResponse}"/> for the specific
+    /// <typeparamref name="TRequest"/> whose response is <see cref="Extensibility.Void"/>.
+    /// </summary>
+    /// <typeparam name="TRequest">
+    /// The void command type to guard. Must implement <see cref="IExclusiveCommand"/>, which is
+    /// equivalent to <see cref="IExclusiveCommand{TResponse}"/> with <c>TResponse = <see cref="Extensibility.Void"/></c>.
+    /// </typeparam>
+    /// <param name="configurator">The <see cref="IMediatorBuilder"/> to configure. Must not be <see langword="null"/>.</param>
+    /// <returns>The same <paramref name="configurator"/> instance, enabling fluent chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configurator"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// This is a convenience overload of
+    /// <see cref="AddConcurrentCommandGuard{TRequest,TResponse}(IMediatorBuilder)"/>
+    /// that fixes <c>TResponse</c> to <see cref="Extensibility.Void"/>, simplifying registration
+    /// for commands that do not produce a meaningful return value.
+    /// </remarks>
+    /// <seealso cref="AddConcurrentCommandGuard(IMediatorBuilder)"/>
+    /// <seealso cref="AddConcurrentCommandGuard{TRequest,TResponse}(IMediatorBuilder)"/>
+    public static IMediatorBuilder AddConcurrentCommandGuard<TRequest>(this IMediatorBuilder configurator)
+        where TRequest : IExclusiveCommand<Extensibility.Void> =>
+        configurator.AddConcurrentCommandGuard<TRequest, Extensibility.Void>();
+}

--- a/src/NetEvolve.Pulse/Interceptors/ConcurrentCommandGuardInterceptor.cs
+++ b/src/NetEvolve.Pulse/Interceptors/ConcurrentCommandGuardInterceptor.cs
@@ -1,4 +1,4 @@
-namespace NetEvolve.Pulse.Interceptors;
+﻿namespace NetEvolve.Pulse.Interceptors;
 
 using System;
 using System.Collections.Concurrent;
@@ -43,7 +43,7 @@ internal sealed class ConcurrentCommandGuardInterceptor<TRequest, TResponse>
     where TRequest : IExclusiveCommand<TResponse>
 {
     private readonly ConcurrentDictionary<Type, SemaphoreSlim> _semaphores = new();
-    private bool _disposedValue;
+    private bool _disposed;
 
     /// <inheritdoc />
     public async Task<TResponse> HandleAsync(
@@ -67,28 +67,19 @@ internal sealed class ConcurrentCommandGuardInterceptor<TRequest, TResponse>
         }
     }
 
-    private void Dispose(bool disposing)
-    {
-        if (!_disposedValue)
-        {
-            if (disposing)
-            {
-                // Dispose managed state (managed objects)
-                foreach (var semaphore in _semaphores.Values)
-                {
-                    semaphore.Dispose();
-                }
-                _semaphores.Clear();
-            }
-
-            _disposedValue = true;
-        }
-    }
-
     /// <inheritdoc />
     public void Dispose()
     {
-        Dispose(disposing: true);
-        GC.SuppressFinalize(this);
+        if (_disposed)
+        {
+            return;
+        }
+
+        foreach (var semaphore in _semaphores.Values)
+        {
+            semaphore.Dispose();
+        }
+        _semaphores.Clear();
+        _disposed = true;
     }
 }

--- a/src/NetEvolve.Pulse/Interceptors/ConcurrentCommandGuardInterceptor.cs
+++ b/src/NetEvolve.Pulse/Interceptors/ConcurrentCommandGuardInterceptor.cs
@@ -7,34 +7,43 @@ using System.Threading.Tasks;
 using NetEvolve.Pulse.Extensibility;
 
 /// <summary>
-/// Request interceptor that enforces exclusive (non-concurrent) execution for commands implementing
+/// Command interceptor that enforces exclusive (non-concurrent) execution for commands implementing
 /// <see cref="IExclusiveCommand{TResponse}"/> by acquiring a per-command-type
 /// <see cref="SemaphoreSlim"/>(1,1) before delegating to the handler.
 /// </summary>
-/// <typeparam name="TRequest">The type of request being intercepted.</typeparam>
-/// <typeparam name="TResponse">The type of response produced by the request.</typeparam>
+/// <typeparam name="TRequest">
+/// The type of command being intercepted. Must implement <see cref="IExclusiveCommand{TResponse}"/>.
+/// </typeparam>
+/// <typeparam name="TResponse">The type of response produced by the command.</typeparam>
 /// <remarks>
 /// <para><strong>Behavior:</strong></para>
 /// <list type="number">
-/// <item><description>If the request does not implement <see cref="IExclusiveCommand{TResponse}"/>, the interceptor passes through with zero overhead.</description></item>
-/// <item><description>If the request implements <see cref="IExclusiveCommand{TResponse}"/>, the interceptor acquires a <see cref="SemaphoreSlim"/>(1,1) keyed on the concrete request type before invoking the handler, ensuring at most one concurrent execution per command type.</description></item>
+/// <item><description>The interceptor acquires a <see cref="SemaphoreSlim"/>(1,1) keyed on the concrete request type before invoking the handler, ensuring at most one concurrent execution per command type.</description></item>
 /// <item><description>The semaphore is released in a <see langword="finally"/> block, even if the handler throws.</description></item>
 /// </list>
 /// <para><strong>Scope:</strong></para>
 /// Exclusivity is in-process only. For distributed exclusivity across multiple instances, a distributed lock is required.
 /// <para><strong>Memory:</strong></para>
-/// One <see cref="SemaphoreSlim"/> instance is retained per distinct exclusive command type for the lifetime of the
-/// application. This is acceptable for a bounded set of command types (the typical use case), but long-running
-/// applications that dynamically generate many unique command types should be aware of this retention.
+/// One <see cref="SemaphoreSlim"/> instance is created per distinct command type and held in an instance-level
+/// dictionary for the lifetime of the interceptor. When registered as a singleton (the typical case), this
+/// equals the application lifetime. For a bounded set of command types this is acceptable, but applications
+/// that dynamically generate many unique command types should be aware of this retention.
+/// <para><strong>Disposal:</strong></para>
+/// Implements <see cref="IDisposable"/> to release all internally held <see cref="SemaphoreSlim"/> instances.
+/// When registered as a singleton via <c>AddConcurrentCommandGuard&lt;TRequest, TResponse&gt;()</c>, disposal
+/// is managed by the DI container at application shutdown.
 /// <para><strong>Registration:</strong></para>
 /// Use <c>AddConcurrentCommandGuard()</c> on the <see cref="IMediatorBuilder"/> to register this interceptor.
 /// </remarks>
 /// <seealso cref="IExclusiveCommand{TResponse}"/>
 /// <seealso cref="IExclusiveCommand"/>
-internal sealed class ConcurrentCommandGuardInterceptor<TRequest, TResponse> : IRequestInterceptor<TRequest, TResponse>
-    where TRequest : IRequest<TResponse>
+internal sealed class ConcurrentCommandGuardInterceptor<TRequest, TResponse>
+    : ICommandInterceptor<TRequest, TResponse>,
+        IDisposable
+    where TRequest : IExclusiveCommand<TResponse>
 {
-    private static readonly ConcurrentDictionary<Type, SemaphoreSlim> _semaphores = new();
+    private readonly ConcurrentDictionary<Type, SemaphoreSlim> _semaphores = new();
+    private bool _disposedValue;
 
     /// <inheritdoc />
     public async Task<TResponse> HandleAsync(
@@ -44,11 +53,6 @@ internal sealed class ConcurrentCommandGuardInterceptor<TRequest, TResponse> : I
     )
     {
         ArgumentNullException.ThrowIfNull(handler);
-
-        if (request is not IExclusiveCommand<TResponse>)
-        {
-            return await handler(request, cancellationToken).ConfigureAwait(false);
-        }
 
         var semaphore = _semaphores.GetOrAdd(typeof(TRequest), _ => new SemaphoreSlim(1, 1));
 
@@ -61,5 +65,30 @@ internal sealed class ConcurrentCommandGuardInterceptor<TRequest, TResponse> : I
         {
             _ = semaphore.Release();
         }
+    }
+
+    private void Dispose(bool disposing)
+    {
+        if (!_disposedValue)
+        {
+            if (disposing)
+            {
+                // Dispose managed state (managed objects)
+                foreach (var semaphore in _semaphores.Values)
+                {
+                    semaphore.Dispose();
+                }
+                _semaphores.Clear();
+            }
+
+            _disposedValue = true;
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
     }
 }

--- a/tests/NetEvolve.Pulse.Tests.Integration/Idempotency/IdempotencyTestsBase.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Idempotency/IdempotencyTestsBase.cs
@@ -274,7 +274,7 @@ public abstract class IdempotencyTestsBase(
                 cancellationToken,
                 configureServices: services =>
                     services.AddSingleton<
-                        ICommandHandler<TestIdempotentVoidCommand, Extensibility.Void>,
+                        ICommandHandler<TestIdempotentVoidCommand, Void>,
                         TestIdempotentVoidCommandHandler
                     >()
             )
@@ -285,10 +285,9 @@ public abstract class IdempotencyTestsBase(
         public string? CorrelationId { get; set; }
     }
 
-    private sealed class TestIdempotentVoidCommandHandler
-        : ICommandHandler<TestIdempotentVoidCommand, Extensibility.Void>
+    private sealed class TestIdempotentVoidCommandHandler : ICommandHandler<TestIdempotentVoidCommand, Void>
     {
-        public Task<Extensibility.Void> HandleAsync(
+        public Task<Void> HandleAsync(
             TestIdempotentVoidCommand command,
             CancellationToken cancellationToken = default
         ) => Task.FromResult(Extensibility.Void.Completed);

--- a/tests/NetEvolve.Pulse.Tests.Unit/ConcurrentCommandGuardExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/ConcurrentCommandGuardExtensionsTests.cs
@@ -1,4 +1,4 @@
-namespace NetEvolve.Pulse.Tests.Unit;
+﻿namespace NetEvolve.Pulse.Tests.Unit;
 
 using System;
 using System.Linq;
@@ -16,7 +16,7 @@ using TUnit.Core;
 public sealed class ConcurrentCommandGuardExtensionsTests
 {
     [Test]
-    public async Task AddConcurrentCommandGuard_WithNullConfigurator_ThrowsArgumentNullException()
+    public void AddConcurrentCommandGuard_WithNullConfigurator_ThrowsArgumentNullException()
     {
         IMediatorBuilder? configurator = null;
 
@@ -65,7 +65,7 @@ public sealed class ConcurrentCommandGuardExtensionsTests
     }
 
     [Test]
-    public async Task AddConcurrentCommandGuard_TypedWithNullConfigurator_ThrowsArgumentNullException()
+    public void AddConcurrentCommandGuard_TypedWithNullConfigurator_ThrowsArgumentNullException()
     {
         IMediatorBuilder? configurator = null;
 
@@ -116,7 +116,7 @@ public sealed class ConcurrentCommandGuardExtensionsTests
     }
 
     [Test]
-    public async Task AddConcurrentCommandGuard_VoidWithNullConfigurator_ThrowsArgumentNullException()
+    public void AddConcurrentCommandGuard_VoidWithNullConfigurator_ThrowsArgumentNullException()
     {
         IMediatorBuilder? configurator = null;
 

--- a/tests/NetEvolve.Pulse.Tests.Unit/ConcurrentCommandGuardExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/ConcurrentCommandGuardExtensionsTests.cs
@@ -1,0 +1,211 @@
+namespace NetEvolve.Pulse.Tests.Unit;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Interceptors;
+using NetEvolve.Pulse.Internals;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
+
+[TestGroup("ConcurrentCommandGuard")]
+public sealed class ConcurrentCommandGuardExtensionsTests
+{
+    [Test]
+    public async Task AddConcurrentCommandGuard_WithNullConfigurator_ThrowsArgumentNullException()
+    {
+        IMediatorBuilder? configurator = null;
+
+        _ = Assert.Throws<ArgumentNullException>("configurator", () => configurator!.AddConcurrentCommandGuard());
+    }
+
+    [Test]
+    public async Task AddConcurrentCommandGuard_RegistersOpenGenericInterceptor()
+    {
+        var services = new ServiceCollection();
+        var configurator = new MediatorBuilder(services);
+
+        var result = configurator.AddConcurrentCommandGuard();
+
+        _ = await Assert.That(result).IsSameReferenceAs(configurator);
+
+        var descriptor = services.FirstOrDefault(d =>
+            d.ServiceType == typeof(IRequestInterceptor<,>)
+            && d.ImplementationType == typeof(ConcurrentCommandGuardInterceptor<,>)
+        );
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor).IsNotNull();
+            _ = await Assert.That(descriptor!.Lifetime).IsEqualTo(ServiceLifetime.Singleton);
+        }
+    }
+
+    [Test]
+    public async Task AddConcurrentCommandGuard_CalledMultipleTimes_DoesNotDuplicateInterceptors()
+    {
+        var services = new ServiceCollection();
+        var configurator = new MediatorBuilder(services);
+
+        _ = configurator.AddConcurrentCommandGuard();
+        _ = configurator.AddConcurrentCommandGuard();
+
+        var descriptors = services
+            .Where(d =>
+                d.ServiceType == typeof(IRequestInterceptor<,>)
+                && d.ImplementationType == typeof(ConcurrentCommandGuardInterceptor<,>)
+            )
+            .ToList();
+
+        _ = await Assert.That(descriptors).HasSingleItem();
+    }
+
+    [Test]
+    public async Task AddConcurrentCommandGuard_TypedWithNullConfigurator_ThrowsArgumentNullException()
+    {
+        IMediatorBuilder? configurator = null;
+
+        _ = Assert.Throws<ArgumentNullException>(
+            "configurator",
+            () => configurator!.AddConcurrentCommandGuard<ExclusiveCommand, string>()
+        );
+    }
+
+    [Test]
+    public async Task AddConcurrentCommandGuard_Typed_RegistersAsSingleton()
+    {
+        var services = new ServiceCollection();
+        var configurator = new MediatorBuilder(services);
+
+        var result = configurator.AddConcurrentCommandGuard<ExclusiveCommand, string>();
+
+        _ = await Assert.That(result).IsSameReferenceAs(configurator);
+
+        var descriptor = services.FirstOrDefault(d =>
+            d.ServiceType == typeof(IRequestInterceptor<ExclusiveCommand, string>) && d.ImplementationFactory != null
+        );
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor).IsNotNull();
+            _ = await Assert.That(descriptor!.Lifetime).IsEqualTo(ServiceLifetime.Singleton);
+        }
+    }
+
+    [Test]
+    public async Task AddConcurrentCommandGuard_Typed_CalledMultipleTimes_DoesNotDuplicateInterceptors()
+    {
+        var services = new ServiceCollection();
+        var configurator = new MediatorBuilder(services);
+
+        _ = configurator.AddConcurrentCommandGuard<ExclusiveCommand, string>();
+        _ = configurator.AddConcurrentCommandGuard<ExclusiveCommand, string>();
+
+        var descriptors = services
+            .Where(d =>
+                d.ServiceType == typeof(IRequestInterceptor<ExclusiveCommand, string>)
+                && d.ImplementationFactory != null
+            )
+            .ToList();
+
+        _ = await Assert.That(descriptors).HasSingleItem();
+    }
+
+    [Test]
+    public async Task AddConcurrentCommandGuard_VoidWithNullConfigurator_ThrowsArgumentNullException()
+    {
+        IMediatorBuilder? configurator = null;
+
+        _ = Assert.Throws<ArgumentNullException>(
+            "configurator",
+            () => configurator!.AddConcurrentCommandGuard<ExclusiveVoidCommand>()
+        );
+    }
+
+    [Test]
+    public async Task AddConcurrentCommandGuard_Void_RegistersAsSingleton()
+    {
+        var services = new ServiceCollection();
+        var configurator = new MediatorBuilder(services);
+
+        var result = configurator.AddConcurrentCommandGuard<ExclusiveVoidCommand>();
+
+        _ = await Assert.That(result).IsSameReferenceAs(configurator);
+
+        var descriptor = services.FirstOrDefault(d =>
+            d.ServiceType == typeof(IRequestInterceptor<ExclusiveVoidCommand, Extensibility.Void>)
+            && d.ImplementationFactory != null
+        );
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor).IsNotNull();
+            _ = await Assert.That(descriptor!.Lifetime).IsEqualTo(ServiceLifetime.Singleton);
+        }
+    }
+
+    [Test]
+    public async Task AddConcurrentCommandGuard_Void_CalledMultipleTimes_DoesNotDuplicateInterceptors()
+    {
+        var services = new ServiceCollection();
+        var configurator = new MediatorBuilder(services);
+
+        _ = configurator.AddConcurrentCommandGuard<ExclusiveVoidCommand>();
+        _ = configurator.AddConcurrentCommandGuard<ExclusiveVoidCommand>();
+
+        var descriptors = services
+            .Where(d =>
+                d.ServiceType == typeof(IRequestInterceptor<ExclusiveVoidCommand, Extensibility.Void>)
+                && d.ImplementationFactory != null
+            )
+            .ToList();
+
+        _ = await Assert.That(descriptors).HasSingleItem();
+    }
+
+    [Test]
+    public async Task AddConcurrentCommandGuard_Typed_CombinedWithOpenGeneric_DoesNotDuplicateInterfaceRegistrations()
+    {
+        var services = new ServiceCollection();
+        var configurator = new MediatorBuilder(services);
+
+        _ = configurator.AddConcurrentCommandGuard();
+        _ = configurator.AddConcurrentCommandGuard<ExclusiveCommand, string>();
+
+        // Open-generic overload: IRequestInterceptor<,> → ConcurrentCommandGuardInterceptor<,>
+        var openGenericDescriptors = services
+            .Where(d =>
+                d.ServiceType == typeof(IRequestInterceptor<,>)
+                && d.ImplementationType == typeof(ConcurrentCommandGuardInterceptor<,>)
+            )
+            .ToList();
+
+        // Typed overload: IRequestInterceptor<ExclusiveCommand, string> → factory
+        var closedGenericDescriptors = services
+            .Where(d =>
+                d.ServiceType == typeof(IRequestInterceptor<ExclusiveCommand, string>)
+                && d.ImplementationFactory != null
+            )
+            .ToList();
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(openGenericDescriptors).HasSingleItem();
+            _ = await Assert.That(closedGenericDescriptors).HasSingleItem();
+        }
+    }
+
+    private sealed record ExclusiveCommand : IExclusiveCommand<string>
+    {
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed record ExclusiveVoidCommand : IExclusiveCommand
+    {
+        public string? CorrelationId { get; set; }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/ConcurrentCommandGuardInterceptorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/ConcurrentCommandGuardInterceptorTests.cs
@@ -16,7 +16,7 @@ public sealed class ConcurrentCommandGuardInterceptorTests
     [Test]
     public async Task HandleAsync_NullHandler_ThrowsArgumentNullException(CancellationToken cancellationToken)
     {
-        var interceptor = new ConcurrentCommandGuardInterceptor<ExclusiveCommand, string>();
+        using var interceptor = new ConcurrentCommandGuardInterceptor<ExclusiveCommand, string>();
         var command = new ExclusiveCommand();
 
         _ = await Assert
@@ -25,35 +25,9 @@ public sealed class ConcurrentCommandGuardInterceptorTests
     }
 
     [Test]
-    public async Task HandleAsync_NonExclusiveCommand_PassesThroughDirectly(CancellationToken cancellationToken)
-    {
-        var interceptor = new ConcurrentCommandGuardInterceptor<NonExclusiveCommand, string>();
-        var command = new NonExclusiveCommand();
-        var handlerCalled = false;
-
-        var result = await interceptor
-            .HandleAsync(
-                command,
-                (_, _) =>
-                {
-                    handlerCalled = true;
-                    return Task.FromResult("response");
-                },
-                cancellationToken
-            )
-            .ConfigureAwait(false);
-
-        using (Assert.Multiple())
-        {
-            _ = await Assert.That(result).IsEqualTo("response");
-            _ = await Assert.That(handlerCalled).IsTrue();
-        }
-    }
-
-    [Test]
     public async Task HandleAsync_ExclusiveCommand_ExecutesHandler(CancellationToken cancellationToken)
     {
-        var interceptor = new ConcurrentCommandGuardInterceptor<ExclusiveCommand, string>();
+        using var interceptor = new ConcurrentCommandGuardInterceptor<ExclusiveCommand, string>();
         var command = new ExclusiveCommand();
         var handlerCalled = false;
 
@@ -79,7 +53,7 @@ public sealed class ConcurrentCommandGuardInterceptorTests
     [Test]
     public async Task HandleAsync_ExclusiveCommand_HandlerThrows_SemaphoreReleased(CancellationToken cancellationToken)
     {
-        var interceptor = new ConcurrentCommandGuardInterceptor<ExclusiveCommand2, string>();
+        using var interceptor = new ConcurrentCommandGuardInterceptor<ExclusiveCommand2, string>();
         var command = new ExclusiveCommand2();
 
         _ = await Assert
@@ -106,7 +80,7 @@ public sealed class ConcurrentCommandGuardInterceptorTests
     [Test]
     public async Task HandleAsync_ExclusiveVoidCommand_ExecutesHandler(CancellationToken cancellationToken)
     {
-        var interceptor = new ConcurrentCommandGuardInterceptor<ExclusiveVoidCommand, Extensibility.Void>();
+        using var interceptor = new ConcurrentCommandGuardInterceptor<ExclusiveVoidCommand, Extensibility.Void>();
         var command = new ExclusiveVoidCommand();
         var handlerCalled = false;
 
@@ -132,7 +106,7 @@ public sealed class ConcurrentCommandGuardInterceptorTests
     [Test]
     public async Task HandleAsync_ExclusiveCommand_SerializesExecution(CancellationToken cancellationToken)
     {
-        var interceptor = new ConcurrentCommandGuardInterceptor<ExclusiveCommand3, int>();
+        using var interceptor = new ConcurrentCommandGuardInterceptor<ExclusiveCommand3, int>();
         var maxConcurrent = 0;
         var currentConcurrent = 0;
         var tasks = new Task<int>[5];
@@ -181,11 +155,6 @@ public sealed class ConcurrentCommandGuardInterceptorTests
     }
 
     private sealed record ExclusiveVoidCommand : IExclusiveCommand
-    {
-        public string? CorrelationId { get; set; }
-    }
-
-    private sealed record NonExclusiveCommand : ICommand<string>
     {
         public string? CorrelationId { get; set; }
     }


### PR DESCRIPTION
Introduce extension methods for registering ConcurrentCommandGuardInterceptor with IMediatorBuilder, supporting open-generic, closed-generic, and void command overloads. Refactor the interceptor to implement IDisposable for proper SemaphoreSlim disposal and restrict it to IExclusiveCommand<TResponse> only. Update and expand tests to cover registration and deduplication scenarios. Apply minor doc and type improvements, and ensure consistent usage of Extensibility.Void.

Resolves #256

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added concurrent command guard extension methods for registering exclusive command execution support in the mediator builder.

* **Refactor**
  * Improved concurrent command guard interceptor with refined resource management and instance-level lifecycle handling.
  * Simplified dependency injection registration configuration.

* **Documentation**
  * Updated XML documentation references for improved code clarity and consistency.

* **Tests**
  * Added comprehensive unit test coverage for concurrent command guard registration.
  * Enhanced integration and unit tests with proper resource disposal patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->