### PR TITLE
test: Increase SlowMessageTransport delay to reduce test flakiness

### DIFF
--- a/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorHostedServiceTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorHostedServiceTests.cs
@@ -424,7 +424,7 @@ public sealed class OutboxProcessorHostedServiceTests
     public async Task ExecuteAsync_WithPerEventTypeProcessingTimeout_UsesOverride(CancellationToken cancellationToken)
     {
         using var repository = new InMemoryOutboxRepository();
-        var transport = new SlowMessageTransport(delay: TimeSpan.FromMilliseconds(200));
+        var transport = new SlowMessageTransport(delay: TimeSpan.FromSeconds(5)); // Much larger than the override timeout to avoid timer-jitter flakiness
         var options = Options.Create(
             new OutboxProcessorOptions
             {


### PR DESCRIPTION
The delay in ExecuteAsync_WithPerEventTypeProcessingTimeout_UsesOverride was raised from 200ms to 5s to ensure it exceeds the override timeout, minimizing timer-jitter and improving test reliability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for processing timeout validation by adjusting timing parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->