### PR TITLE
audit: phase 2 verification U01-U05 (round 01)

### DIFF
--- a/audit/README.md
+++ b/audit/README.md
@@ -1,0 +1,13 @@
+# Pulse Audit
+
+Multi-agent quality + practical-usability audit.
+
+## Loop schema
+- **Phase 1 (looped)** — Discovery scouts (1 quality + 1 usability) in worktrees form ASSUMPTIONS only. Output → `assumptions/round-NN-quality.md` and `assumptions/round-NN-usability.md`. Each round must read prior rounds and avoid duplicating earlier IDs; new assumptions in new round get a fresh prefix (`Q01b`, `U01b`, …) or new numbers continuing the series.
+- **Phase 2** — Verifiers in worktrees independently confirm/refute each assumption with file:line evidence, then write FAILING tests for every confirmed one. Output → `verification/round-NN-<id>.md` + tests under `audit/tests/` (later promoted into the real test projects per provider).
+- **Phase 3** — Builders in worktrees, 1 PR per confirmed assumption, English (US), conventional commits.
+
+## Conventions
+- All agents work in `git worktree`-isolated copies.
+- All PRs against `main`, English (US), conventional commits.
+- No code change without a confirming verifier and a failing test first.

--- a/audit/assumptions/round-01-quality.md
+++ b/audit/assumptions/round-01-quality.md
@@ -1,0 +1,80 @@
+# Phase 1 — Round 01 — Quality Discovery
+
+> Read-only assumptions. Each must be confirmed or refuted in Phase 2 with file:line evidence.
+
+## Repo Snapshot
+19 src projects: core (`NetEvolve.Pulse`), `Extensibility`, source generator, AspNetCore, EF Core, 4 ADO.NET providers (SqlServer, PostgreSql, SQLite, plus EF-backed MySql/CosmosDb/MongoDB), 3 native transports (Kafka, RabbitMQ, AzureServiceBus), 3 cross-cutting (Polly, FluentValidation, HttpCorrelation), Dapr, Redis, MySql. Core abstractions: `IMediator` (`PulseMediator` in `Internals/`), open-generic interceptors per request kind, `IEventDispatcher` strategies (Parallel/Sequential/Prioritized/RateLimited), outbox subsystem split into `IEventOutbox` + `IOutboxRepository` + `IMessageTransport` + `OutboxProcessorHostedService`. Outbox state machine driven by stored procedures/functions (`get_pending_outbox_messages` flips Pending→Processing using FOR UPDATE SKIP LOCKED), batch defaults `EnableBatchSending=false`, `EnableExponentialBackoff=false`, `MaxRetryCount=3`. TimeProvider is wired through most code; outbox processor leaks back to `DateTimeOffset.UtcNow` in two spots.
+
+## Assumptions
+
+### Q01 — Singleton hosted service consumes scoped IOutboxRepository (captive dependency)
+- Claim: `OutboxProcessorHostedService` is registered Singleton but constructor-injects `IOutboxRepository`, which is registered Scoped by SQL Server/PostgreSql/SQLite/EF extensions. No `IServiceScopeFactory.CreateScope()` is created per polling cycle.
+- Evidence: `src/NetEvolve.Pulse/Outbox/OutboxProcessorHostedService.cs:93-119` (constructor takes `IOutboxRepository`), `src/NetEvolve.Pulse/OutboxExtensions.cs:72-73` (`Singleton<IHostedService, OutboxProcessorHostedService>`), `src/NetEvolve.Pulse.SqlServer/SqlServerExtensions.cs:199-202` (`AddScoped<IOutboxRepository, SqlServerOutboxRepository>`), `src/NetEvolve.Pulse.EntityFramework/Outbox/EntityFrameworkOutboxRepository.cs:41-47` (takes `TContext`).
+- Why it matters: Captured EF `DbContext` is not thread-safe, accumulates change-tracker state forever, prevents per-poll connection reuse. ADO.NET impls mask this (fresh connections per call); EF-backed users will hit `ObjectDisposedException`/concurrency exceptions or unbounded memory growth.
+- Test idea: Register `AddEntityFrameworkOutbox<TestDb>()`, build host with `ValidateScopes=true`, assert startup throws `InvalidOperationException` for the singleton-consuming-scoped registration; or assert same `IOutboxRepository`/`DbContext` instance across two simulated polling cycles.
+
+### Q02 — Stuck "Processing" rows never recovered (broken at-least-once)
+- Claim: Outbox processor flips messages to `Status=1` (Processing) in the fetch query, but has no reaper for rows stuck in Processing if the host dies between fetch and `MarkAsCompleted/Failed/DeadLetter`. Pending-fetch and retry-fetch only look at `Status=0` and `Status=3`.
+- Evidence: `src/NetEvolve.Pulse.PostgreSql/Scripts/OutboxMessage.sql:78-105` (UPDATE…SET Status=1 inside `get_pending_outbox_messages`), `:131-162`, `:180-181`, `:202-203`; `src/NetEvolve.Pulse.SqlServer/Outbox/SqlServerOutboxRepository.cs:163-199`; `src/NetEvolve.Pulse/Outbox/OutboxProcessorHostedService.cs:236-292` (no reaper).
+- Why it matters: Breaks at-least-once guarantee on crash/OOM/SIGKILL. Rows stay Processing forever; `pulse.outbox.pending` metric will not see them.
+- Test idea: Insert one Pending row, call `GetPendingAsync`, simulate crash (skip MarkAsCompleted), restart host, assert second `GetPendingAsync` returns the stuck row (currently does not).
+
+### Q03 — OutboxProcessorHostedService bypasses TimeProvider
+- Claim: Uses `DateTimeOffset.UtcNow` directly instead of injected `TimeProvider` (which the rest of the codebase honors: `IdempotencyStore`, `OutboxEventStore`, `ActivityAndMetricsRequestInterceptor`).
+- Evidence: `src/NetEvolve.Pulse/Outbox/OutboxProcessorHostedService.cs:384` (`_options.ComputeNextRetryAt(DateTimeOffset.UtcNow, …)`), `:477` (`var now = DateTimeOffset.UtcNow;`). Compare `src/NetEvolve.Pulse/Idempotency/IdempotencyStore.cs:52` using `_timeProvider.GetUtcNow()`.
+- Why it matters: Backoff schedules computed with a fake `TimeProvider` are not honored; deterministic retry-window assertions impossible; persisted `NextRetryAt` will not match the test clock.
+- Test idea: Inject `FakeTimeProvider` fixed at 2030-01-01, force one message to fail with `EnableExponentialBackoff=true`, assert persisted `NextRetryAt = 2030-01-01 + BaseRetryDelay`.
+
+### Q04 — IdempotencyCommandInterceptor is check-then-act, not atomic
+- Claim: `ExistsAsync` → handler → `StoreAsync`. Two concurrent commands with the same key both pass `ExistsAsync` before either calls `StoreAsync` — handler executes twice.
+- Evidence: `src/NetEvolve.Pulse/Interceptors/IdempotencyCommandInterceptor.cs:68-79`; `src/NetEvolve.Pulse/Idempotency/IdempotencyStore.cs:47-64` (no atomic put-if-absent in contract).
+- Why it matters: Claims at-most-once execution but only catches sequential duplicates.
+- Test idea: Two `IIdempotentCommand`s, same key, gated handler, `Task.WhenAll`; assert handler ran once and the second call surfaced `IdempotencyConflictException`.
+
+### Q05 — ConcurrentCommandGuardInterceptor: dispose race + GetOrAdd factory leak
+- Claim: Singleton interceptor with `Dispose()` walking `_semaphores`. Mid-shutdown awaits surface `ObjectDisposedException` instead of `OperationCanceledException`. `GetOrAdd(typeof(TRequest), _ => new SemaphoreSlim(1,1))` can leak losing-race semaphores.
+- Evidence: `src/NetEvolve.Pulse/Interceptors/ConcurrentCommandGuardInterceptor.cs:45,49-68,71-84`.
+- Why it matters: ODE during shutdown masks real cancellation; rare contention leaks under heavy load.
+- Test idea: `Parallel.For` to provoke factory races and reflectively assert all created semaphores are present; await semaphore in HandleAsync, dispose on another thread, assert surfaced exception is `OperationCanceledException`.
+
+### Q06 — KafkaMessageTransport ignores CancellationToken on Flush + IsHealthy
+- Claim: `_producer.Flush(Timeout.InfiniteTimeSpan)` blocks indefinitely and ignores the passed token; `IsHealthyAsync` does sync `_adminClient.GetMetadata(TimeSpan.FromSeconds(5))` wrapped in `Task.FromResult`.
+- Evidence: `src/NetEvolve.Pulse.Kafka/Outbox/KafkaMessageTransport.cs:94`, `:63-102`, `:105-116`.
+- Why it matters: `IHostApplicationLifetime` cannot interrupt a stuck flush — graceful shutdown becomes ungraceful, increasing stuck-Processing risk (Q02).
+- Test idea: Fake `IProducer<…>` whose `Flush` blocks forever, `SendBatchAsync` with token canceling after 100 ms; assert the task completes (it will not).
+
+### Q07 — Azure Service Bus non-atomic batch when EnableBatching=false
+- Claim: `SendBatchAsync` loops `sender.SendMessageAsync` per message when batching disabled — non-atomic. `ProcessBatchSendAsync` then marks entire batch failed on any error → re-send next poll → duplicate delivery.
+- Evidence: `src/NetEvolve.Pulse.AzureServiceBus/Outbox/AzureServiceBusMessageTransport.cs:55-89`; `src/NetEvolve.Pulse/Outbox/OutboxProcessorHostedService.cs:456-500`.
+- Why it matters: Violates `IMessageTransport.SendBatchAsync` atomicity contract used by the processor.
+- Test idea: Fake `ServiceBusSender` succeeds for messages 1+2 then throws on 3, run with `EnableBatching=false`; verify broker received first two, outbox marks all three Failed (next poll → duplicates).
+
+### Q08 — RabbitMqMessageTransport channel leak on reconnect
+- Claim: `EnsureChannelAsync` overwrites stale `_channel` without disposing the previous instance — leaks an `IRabbitMqChannelAdapter` and its AMQP channel per reconnect.
+- Evidence: `src/NetEvolve.Pulse.RabbitMQ/Outbox/RabbitMqMessageTransport.cs:124-147`.
+- Why it matters: Long-running services exhaust the connection's `channel_max` budget on transient disconnects → `ChannelAllocationException`.
+- Test idea: Fake adapter that returns distinct disposable instances and flips `IsOpen=false` after each publish; send 100 messages, assert previous adapters were disposed.
+
+### Q09 — Batch mark operations are not atomic (per-row + parallel)
+- Claim: Default-interface batch methods on `IOutboxRepository` iterate via `Parallel.ForEachAsync` to single-item overloads (fresh connections, no transaction). PostgreSQL override iterates sequentially under one connection but no transaction. A transient mid-loop failure leaves some Completed, others Processing → duplicates next poll.
+- Evidence: `src/NetEvolve.Pulse.Extensibility/Outbox/IOutboxRepository.cs:59-69,113-124,142-153`; `src/NetEvolve.Pulse.PostgreSql/Outbox/PostgreSqlOutboxRepository.cs:243-265`; `src/NetEvolve.Pulse.SqlServer/Outbox/SqlServerOutboxRepository.cs:273-284`.
+- Why it matters: `ProcessBatchSendAsync` (Outbox/OutboxProcessorHostedService.cs:438-439) needs atomic `MarkAsCompletedAsync(ids[])` for at-least-once.
+- Test idea: Flaky connection failing after N successes; call `MarkAsCompletedAsync({id1,id2,id3})` failing after id1; assert all-or-none semantics (current: only id1 Completed).
+
+### Q10 — Timeout-cancel vs external-cancel confusion in ProcessMessageAsync
+- Claim: When `timeoutCts.CancelAfter` fires, `OperationCanceledException` does not satisfy `when (cancellationToken.IsCancellationRequested)` filter — falls into generic catch and gets treated as retryable failure with msg "The operation was canceled." Telemetry status remains `Ok` while DB state is Failed/DeadLetter.
+- Evidence: `src/NetEvolve.Pulse/Outbox/OutboxProcessorHostedService.cs:331-401`; `src/NetEvolve.Pulse/Interceptors/ActivityAndMetricsRequestInterceptor.cs:105-143`.
+- Why it matters: "Processed-but-failed" rows with success logs → operator confusion.
+- Test idea: `ProcessingTimeout=50ms`, transport sleeps 200ms; assert row Status=Failed, RetryCount=1, `pulse.outbox.failed.total` advanced, and `ExecuteAsync` did not fault.
+
+### Q11 — Race in batch failure classification reads EventTypeOverrides three times
+- Claim: `ProcessBatchSendAsync` invokes `_options.GetEffectiveMaxRetryCount(m.EventType)` independently in three LINQ predicates — `EventTypeOverrides` is a public `ConcurrentDictionary` and can mutate between reads, causing dead-letter log lines to disagree with mark-as-failed DB writes.
+- Evidence: `src/NetEvolve.Pulse/Outbox/OutboxProcessorHostedService.cs:465-518`; `src/NetEvolve.Pulse/Outbox/OutboxProcessorOptions.cs:118-119`.
+- Why it matters: Inconsistent telemetry vs DB state when overrides tuned at runtime.
+- Test idea: Custom repo whose `MarkAsFailedAsync(ids[])` delays 50ms; another thread mutates `EventTypeOverrides[typeof(MyEvent)].MaxRetryCount=1`; assert dead-letter log count ≠ DB dead-letter row count.
+
+### Q12 (lower confidence) — Interceptor pipeline ordering is implicit
+- Claim: Pipeline ordering is registration-order driven via `Reverse().ToArray()` + wrap-from-innermost-out. No priority hook; users cannot predict whether timeout wraps idempotency or vice versa without inspecting registration order.
+- Evidence: `src/NetEvolve.Pulse/Internals/PulseMediator.cs:232,243-249`; `src/NetEvolve.Pulse/IdempotencyExtensions.cs:61-63`; `src/NetEvolve.Pulse/ConcurrentCommandGuardExtensions.cs:50-52`.
+- Why it matters: Determines whether timeout fires inside or outside concurrency guard, and whether idempotency conflicts are caught by Polly retry. Fragile, load-bearing on registration order.
+- Test idea: Register `AddTimeout()` then `AddIdempotency()` and verify which exception escapes; swap order and observe change.

--- a/audit/assumptions/round-01-usability.md
+++ b/audit/assumptions/round-01-usability.md
@@ -1,0 +1,98 @@
+# Phase 1 — Round 01 — Usability Discovery
+
+> Read-only assumptions. Each must be confirmed or refuted in Phase 2 with file:line evidence.
+
+## Repo Snapshot
+~19 src projects (core, source-gen, ASP.NET Core, FluentValidation, HttpCorrelation, Polly, persistence + transport providers). Multi-targets `net8.0;net9.0;net10.0`. Heavy XML docs and per-project READMEs. C# 14 `extension(...)` member syntax pervasively. Central versioning via `Directory.Packages.props`. NuGet metadata per-csproj. No `PackageIcon`/`PackageReadmeFile` anywhere. `SystemTextJsonPayloadSerializer` default and unconditional.
+
+## Assumptions
+
+### U01 — README "Quick Use" snippet does not compile / does not dispatch
+- Claim: Root README snippet declares record/handler types at file scope after top-level statements and never builds the provider or dispatches anything. Compile error guaranteed.
+- Evidence: `README.md:118-136`; counter-example `src/NetEvolve.Pulse/README.md:42-72`.
+- Why it matters: First-impression sample. Copy-paste = immediate compile failure.
+- Test idea: Paste the README:118-136 snippet verbatim into a new console project; build on net8/net9/net10.
+
+### U02 — README mis-describes QueryCachingOptions API
+- Claim: README claims `QueryCachingOptions` exposes `JsonSerializerOptions`; the type actually only has `ExpirationMode` and `DefaultExpiry`. Serialization is controlled via `IPayloadSerializer` and `IOptions<JsonSerializerOptions>` globally.
+- Evidence: `README.md:59`; `src/NetEvolve.Pulse/README.md:152-162`; type at `src/NetEvolve.Pulse.Extensibility/Caching/QueryCachingOptions.cs:10-59`.
+- Why it matters: Doc'd code does not compile.
+- Test idea: Compile `src/NetEvolve.Pulse/README.md:155-162` snippet → CS0117.
+
+### U03 — XML doc references non-existent NuGet package
+- Claim: `AssemblyScanningExtensions` XML doc recommends `NetEvolve.Pulse.Generators`; actual package is `NetEvolve.Pulse.SourceGeneration`. Typo-squat risk on NuGet.
+- Evidence: `src/NetEvolve.Pulse/AssemblyScanningExtensions.cs:15`.
+- Why it matters: Users `dotnet add package` something that doesn't exist.
+- Test idea: Verify package name vs csproj `<PackageId>`.
+
+### U04 — Default JSON serializer breaks AOT silently
+- Claim: `SystemTextJsonPayloadSerializer` uses reflection-mode `JsonSerializer.Serialize<T>` / `Deserialize<T>` with no `[RequiresUnreferencedCode]` / `[RequiresDynamicCode]` annotations. Conflicts with the library's AOT-friendly positioning (`HandlerRegistrationExtensions` advertises AOT compatibility).
+- Evidence: `src/NetEvolve.Pulse/Serialization/SystemTextJsonPayloadSerializer.cs:32-44`; AOT claim `src/NetEvolve.Pulse/HandlerRegistrationExtensions.cs:9,15-17`.
+- Why it matters: AOT users get runtime failures or silent metadata loss without compile-time warnings.
+- Test idea: AOT publish a console app using `AddPulse() + AddQueryCaching()`; verify no IL2026/IL3050 warnings even though reflection happens.
+
+### U05 — Critical options classes have no IValidateOptions
+- Claim: `OutboxProcessorOptions` accepts `BatchSize<=0`, `PollingInterval<=TimeSpan.Zero`, `BackoffMultiplier<=0`, `ProcessingTimeout=TimeSpan.Zero`. `AzureServiceBusTransportOptions` validation runs inline at first resolution, not at startup. Only `LoggingInterceptorOptions` has a registered validator.
+- Evidence: `src/NetEvolve.Pulse/Outbox/OutboxProcessorOptions.cs:10-99`; `src/NetEvolve.Pulse.AzureServiceBus/AzureServiceBusExtensions.cs:75-86`; only validator: `src/NetEvolve.Pulse/Interceptors/LoggingInterceptorOptionsValidator.cs`.
+- Why it matters: Misconfig fails deep inside processor at runtime instead of failing fast at startup. No `ValidateOnStart()` wired up.
+- Test idea: Configure `BatchSize=0, PollingInterval=Zero`, build host; verify host starts cleanly.
+
+### U06 — Aggressive retry defaults
+- Claim: `MaxRetryCount=3`, `EnableExponentialBackoff=false`, `EnableBatchSending=false`. New user calling `AddOutbox()` gets 3 quick retries with no backoff (gated only by polling interval) → dead-letter on transient failures.
+- Evidence: `src/NetEvolve.Pulse/Outbox/OutboxProcessorOptions.cs:28,40,47`.
+- Why it matters: Headline reliability feature configured for foot-gun.
+- Test idea: Processor with no overrides + transport that fails 3× then succeeds → message dead-lettered.
+
+### U07 — Transport extension methods do not enforce AddOutbox
+- Claim: `UseAzureServiceBusTransport`, `UseKafkaTransport`, `UseRabbitMqTransport`, `UseMessageTransport<T>` silently replace any existing `IMessageTransport` but do NOT register `IOutboxRepository` or `OutboxProcessorHostedService`. Users following per-package READMEs may get half-wired systems.
+- Evidence: `src/NetEvolve.Pulse.AzureServiceBus/README.md:32-45`; `src/NetEvolve.Pulse.AzureServiceBus/AzureServiceBusExtensions.cs:26-60`; `src/NetEvolve.Pulse.Kafka/KafkaExtensions.cs:44-59`; counter-example `src/NetEvolve.Pulse.SqlServer/SqlServerExtensions.cs:194-204`.
+- Why it matters: Missing-service exceptions at publish, or silently no-op outbox.
+- Test idea: Take ASB README:32-45 quick-start verbatim, build provider, call `mediator.PublishAsync(...)`; observe DI failure or silent no-op.
+
+### U08 — SQL Server schema script not delivered via PackageReference
+- Claim: `OutboxOptions.Schema` defaults to `"pulse"`. SQL Server README says "execute the schema script from `Scripts/OutboxMessage.sql`" — script is shipped via NuGet `content\Scripts` (legacy content mechanism that does not flow to PackageReference consumers).
+- Evidence: `src/NetEvolve.Pulse/Outbox/OutboxOptions.cs:18`; `src/NetEvolve.Pulse.SqlServer/NetEvolve.Pulse.SqlServer.csproj:18-19`; `src/NetEvolve.Pulse.SqlServer/SqlServerExtensions.cs:23-25`.
+- Why it matters: First publish throws "Invalid object name 'pulse.OutboxMessage'"; documented remediation does not deliver the file.
+- Test idea: Add `<PackageReference Include="NetEvolve.Pulse.SqlServer" />`, build, search consumer output for `OutboxMessage.sql` → absent.
+
+### U09 — MapStreamQuery uses raw JsonSerializer, ignoring IPayloadSerializer/options
+- Claim: `EndpointRouteBuilderExtensions.MapStreamQuery<TQuery,TResponse>` calls `JsonSerializer.Serialize(item)` / `SerializeToUtf8Bytes(item)` with no options — does not honor configured `JsonSerializerOptions` or `IPayloadSerializer`.
+- Evidence: `src/NetEvolve.Pulse.AspNetCore/EndpointRouteBuilderExtensions.cs:226,248`.
+- Why it matters: `MapQuery` and `MapStreamQuery` serialize the same DTO differently (camelCase vs PascalCase); blocks AOT for stream endpoints.
+- Test idea: Configure camelCase policy; add `MapQuery` and `MapStreamQuery` for same DTO; compare response property casing.
+
+### U10 — KafkaMessageTransport ignores CancellationToken (also Q06)
+- Claim: `_producer.Flush(Timeout.InfiniteTimeSpan)` ignores token; `SendBatchAsync` declared with `CancellationToken` but never observes it.
+- Evidence: `src/NetEvolve.Pulse.Kafka/Outbox/KafkaMessageTransport.cs:94`; `src/NetEvolve.Pulse/Outbox/OutboxProcessorHostedService.cs:432-435`.
+- Why it matters: Stuck broker leaks processor thread; `ProcessingTimeout` does not bound batch sending.
+- Test idea: Unreachable broker, send batch, cancel token; assert task completes within `ProcessingTimeout`.
+
+### U11 — Transport extensions silently overwrite previous registration
+- Claim: `Use*Transport` methods linear-scan and `Remove()` any existing `IMessageTransport`. No warning if a transport is overwritten by a later call.
+- Evidence: `src/NetEvolve.Pulse.AzureServiceBus/AzureServiceBusExtensions.cs:51-58`; `src/NetEvolve.Pulse.Kafka/KafkaExtensions.cs:50-57`; `src/NetEvolve.Pulse.RabbitMQ/RabbitMqExtensions.cs:53-60`; `src/NetEvolve.Pulse/OutboxExtensions.cs:94-101`.
+- Why it matters: Silent last-write-wins on foundational service makes misconfig undebuggable.
+- Test idea: Register both ASB and Kafka in any order; resolve `IMessageTransport`; assert exactly one is registered and no diagnostic emitted.
+
+### U12 — IMediator registered Scoped, BackgroundService example violates DI lifetime
+- Claim: `IMediator` is Scoped, but XML doc example shows `IMediatorSendOnly` injected directly into a `BackgroundService`. With `ValidateScopes=true` (dev default), host startup fails.
+- Evidence: `src/NetEvolve.Pulse/ServiceCollectionExtensions.cs:110-111`; example at `src/NetEvolve.Pulse.Extensibility/IMediatorSendOnly.cs:20-34`.
+- Why it matters: Copy-paste example throws `InvalidOperationException` at startup.
+- Test idea: Implement the example verbatim against `Host.CreateApplicationBuilder()`; observe scope validation failure.
+
+### U13 — NuGet metadata missing icon + embedded README
+- Claim: No `PackageIcon` / `PackageReadmeFile` set anywhere. `Directory.Build.props` defines only `Title`, `RepositoryUrl`, `PackageProjectUrl`, `PackageReleaseNotes`, `PackageTags`.
+- Evidence: `Directory.Build.props:1-12`; `logo.png` at repo root unused; grep across repo finds no `PackageIcon`/`PackageReadmeFile`.
+- Why it matters: NuGet listing shows generic placeholder, no README on package page.
+- Test idea: `dotnet pack`; inspect resulting `.nupkg` `.nuspec` for `<icon>`/`<readme>` elements.
+
+### U14 — C# 14 extension blocks lock source build to .NET 10 SDK
+- Claim: `extension(TReceiver)` member blocks used across 7+ files; multi-target is `net8.0;net9.0;net10.0` but `LangVersion` is not explicitly set.
+- Evidence: `src/NetEvolve.Pulse/AssemblyScanningExtensions.cs:51`; `src/NetEvolve.Pulse.SqlServer/Outbox/SqlServerOutboxOptionsExtensions.cs`; `src/NetEvolve.Pulse.PostgreSql/Outbox/PostgreSqlOutboxOptionsExtensions.cs`; et al.
+- Why it matters: Source builds with .NET 8 or .NET 9 SDK fail; CI on older SDKs breaks; cryptic CS1003/CS8400 errors for contributors.
+- Test idea: `global.json` pinning to .NET 8 SDK, then `dotnet build` of `Pulse.slnx`.
+
+### U15 — Missing handler gives generic DI exception, no scanning helper
+- Claim: `services.AddPulse()` with no further calls and no `[PulseHandler]` source-gen attributes throws a generic `"no service of type ICommandHandler<...>"` at first dispatch. Compared to MediatR's `RegisterServicesFromAssemblyContaining<Program>()` one-liner, Pulse requires source-gen, manual `Add*Handler`, or AOT-incompatible `AddHandlersFromCallingAssembly()`.
+- Evidence: `src/NetEvolve.Pulse/ServiceCollectionExtensions.cs:88-114`; error message inherited from `GetRequiredService`.
+- Why it matters: #1 first-time error with no actionable remediation in the message.
+- Test idea: `services.AddPulse(); …GetRequiredService<IMediator>().SendAsync(new SomeCommand())`; verify error message and that it does not mention scanning or `AddCommandHandler<>`.

--- a/audit/repros/u01/Program.cs
+++ b/audit/repros/u01/Program.cs
@@ -1,0 +1,21 @@
+// Verbatim copy of README.md lines 118-136 (the "Quick Use" snippet).
+// Do not modify — this file exists to prove the snippet compiles or fails as the audit claims.
+
+using Microsoft.Extensions.DependencyInjection;
+using NetEvolve.Pulse;
+using NetEvolve.Pulse.Extensibility;
+
+var services = new ServiceCollection();
+
+services.AddPulse(config => config.AddActivityAndMetrics());
+services.AddScoped<ICommandHandler<CreateOrder, OrderCreated>, CreateOrderHandler>();
+
+public record CreateOrder(string Sku) : ICommand<OrderCreated>;
+
+public record OrderCreated(Guid OrderId);
+
+public sealed class CreateOrderHandler : ICommandHandler<CreateOrder, OrderCreated>
+{
+    public Task<OrderCreated> HandleAsync(CreateOrder command, CancellationToken cancellationToken) =>
+        Task.FromResult(new OrderCreated(Guid.NewGuid()));
+}

--- a/audit/repros/u01/U01Repro.csproj
+++ b/audit/repros/u01/U01Repro.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>U01Repro</RootNamespace>
+    <Description>Audit U01 — README Quick Use snippet compile probe.</Description>
+    <!-- Intentionally not part of the solution -->
+    <IsPackable>false</IsPackable>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <NoWarn>$(NoWarn);CA1050;CA1515;CA2007;CS1591;S3903;NED0003</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\NetEvolve.Pulse\NetEvolve.Pulse.csproj" />
+    <ProjectReference Include="..\..\..\src\NetEvolve.Pulse.Extensibility\NetEvolve.Pulse.Extensibility.csproj" />
+  </ItemGroup>
+</Project>

--- a/audit/repros/u02/Program.cs
+++ b/audit/repros/u02/Program.cs
@@ -1,0 +1,24 @@
+// Verbatim copy of src/NetEvolve.Pulse/README.md lines 152-162 (Distributed Query Caching snippet).
+// This file exists to prove the snippet does not compile (U02 audit assumption).
+
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using NetEvolve.Pulse;
+using NetEvolve.Pulse.Extensibility.Caching;
+
+var services = new ServiceCollection();
+
+// 1. Register an IDistributedCache implementation
+services.AddDistributedMemoryCache(); // or Redis, SQL Server, etc.
+
+// 2. Enable the caching interceptor (with optional options)
+services.AddPulse(config =>
+    config.AddQueryCaching(options =>
+    {
+        // Choose between absolute (default) and sliding expiration
+        options.ExpirationMode = CacheExpirationMode.Sliding;
+
+        // Supply custom JsonSerializerOptions for cache serialization
+        options.JsonSerializerOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+    })
+);

--- a/audit/repros/u02/U02Repro.csproj
+++ b/audit/repros/u02/U02Repro.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>U02Repro</RootNamespace>
+    <Description>Audit U02 — QueryCachingOptions JsonSerializerOptions compile probe.</Description>
+    <IsPackable>false</IsPackable>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <NoWarn>$(NoWarn);CA1050;CA1515;CA2007;CS1591;S3903;NED0003</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\NetEvolve.Pulse\NetEvolve.Pulse.csproj" />
+    <ProjectReference Include="..\..\..\src\NetEvolve.Pulse.Extensibility\NetEvolve.Pulse.Extensibility.csproj" />
+  </ItemGroup>
+</Project>

--- a/audit/repros/u04/Program.cs
+++ b/audit/repros/u04/Program.cs
@@ -1,0 +1,36 @@
+// U04 — Default JSON serializer breaks AOT silently.
+//
+// This program references NetEvolve.Pulse from an AOT-enabled console (PublishAot=true).
+// The intent is to demonstrate that the chain `IPayloadSerializer -> SystemTextJsonPayloadSerializer
+// -> JsonSerializer.Serialize<T>` produces NO IL2026 / IL3050 warning at compile or publish time,
+// even though it uses reflection-mode serialization, because `SystemTextJsonPayloadSerializer`
+// lacks `[RequiresUnreferencedCode]` / `[RequiresDynamicCode]` annotations and does not flow them
+// to its `IPayloadSerializer` contract.
+//
+// Reproduction:
+//   dotnet publish audit/repros/u04/U04AotRepro.csproj -r win-x64 -c Release
+//
+// Expected (after Phase 3 fix):  IL2026 / IL3050 warnings on the Serialize call sites below.
+// Actual (today):                build/publish completes cleanly. Audit assumption confirmed.
+
+using Microsoft.Extensions.DependencyInjection;
+using NetEvolve.Pulse;
+using NetEvolve.Pulse.Extensibility;
+
+var services = new ServiceCollection();
+services.AddPulse();
+
+await using var provider = services.BuildServiceProvider();
+
+var serializer = provider.GetRequiredService<IPayloadSerializer>();
+
+// These two calls hit reflection-mode JsonSerializer under the hood (via
+// SystemTextJsonPayloadSerializer). On an AOT-annotated chain the analyzer should warn here.
+var payload = new DemoPayload("u04", 42);
+var s1 = serializer.Serialize(payload);
+var b1 = serializer.SerializeToBytes(payload);
+
+System.Console.WriteLine(s1);
+System.Console.WriteLine(b1.Length);
+
+public sealed record DemoPayload(string Name, int Value);

--- a/audit/repros/u04/U04AotRepro.csproj
+++ b/audit/repros/u04/U04AotRepro.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>U04AotRepro</RootNamespace>
+    <Description>Audit U04 — AOT reflection probe.</Description>
+    <IsPackable>false</IsPackable>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+
+    <!-- Force AOT analyzers so IL2026 / IL3050 fire if the chain is not annotated. -->
+    <PublishAot>true</PublishAot>
+    <IsAotCompatible>true</IsAotCompatible>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+
+    <!-- Repo defaults promote a few style/codequality rules to errors. Disable for this minimal repro. -->
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <NoWarn>$(NoWarn);CA1050;CA1515;CA2007;CS1591;S3903;NED0003</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\NetEvolve.Pulse\NetEvolve.Pulse.csproj" />
+    <ProjectReference Include="..\..\..\src\NetEvolve.Pulse.Extensibility\NetEvolve.Pulse.Extensibility.csproj" />
+  </ItemGroup>
+</Project>

--- a/audit/verification/round-01-U01.md
+++ b/audit/verification/round-01-U01.md
@@ -1,0 +1,26 @@
+# U01 Verification
+
+**Status:** CONFIRMED
+
+**Evidence:** `README.md:118-136` (Quick Use snippet); `src/NetEvolve.Pulse.Extensibility/ICommand`1.cs` (declares `ICommand<TResponse>` which inherits `IRequest<TResponse>` carrying `CorrelationId` / `CausationId` interface members).
+
+**Reasoning:**
+The Quick Use snippet declares `public record CreateOrder(string Sku) : ICommand<OrderCreated>;` without implementing `CorrelationId` or `CausationId` properties required by the `IRequest<TResponse>` parent of `ICommand<TResponse>`. Pasting the snippet verbatim into a real `net10.0` console project that project-references `NetEvolve.Pulse` and `NetEvolve.Pulse.Extensibility` produces two `CS0535` compile errors. The snippet additionally never calls `BuildServiceProvider()` and never dispatches anything, so even if `CS0535` were removed it would be inert as a first-impression sample.
+
+**Failing test / repro (if confirmed):**
+- Path: `audit/repros/u01/`
+- Status: written
+- Code or steps:
+```text
+cd audit/repros/u01
+dotnet build U01Repro.csproj
+
+# Result:
+# Program.cs(13,41): error CS0535: 'CreateOrder' does not implement interface member 'IRequest<OrderCreated>.CausationId'
+# Program.cs(13,41): error CS0535: 'CreateOrder' does not implement interface member 'IRequest<OrderCreated>.CorrelationId'
+```
+
+**Notes:**
+- Exact CS errors captured: `CS0535` x2 (CausationId, CorrelationId).
+- Secondary defect: snippet shows neither `BuildServiceProvider()` nor `IMediator.SendAsync(...)` — even if compile errors are fixed, sample never dispatches anything, undermining "first impression" value.
+- Counter-example at `src/NetEvolve.Pulse/README.md:42-72` does show a working dispatch pattern; root README should be aligned with it.

--- a/audit/verification/round-01-U02.md
+++ b/audit/verification/round-01-U02.md
@@ -1,0 +1,27 @@
+# U02 Verification
+
+**Status:** CONFIRMED
+
+**Evidence:** `src/NetEvolve.Pulse/README.md:152-162` references `options.JsonSerializerOptions`; `src/NetEvolve.Pulse.Extensibility/Caching/QueryCachingOptions.cs:10-59` defines only `ExpirationMode` (line 36) and `DefaultExpiry` (line 58). Root `README.md:59` likewise claims "configurable JsonSerializerOptions … via QueryCachingOptions".
+
+**Reasoning:**
+The Distributed Query Caching snippet in `src/NetEvolve.Pulse/README.md` assigns `options.JsonSerializerOptions = new JsonSerializerOptions { … }`, but the `QueryCachingOptions` type exposes no such member. Pasting the snippet verbatim into a real `net10.0` console project that project-references `NetEvolve.Pulse` and `NetEvolve.Pulse.Extensibility` produces `CS1061`. Serialization options for the cache pipeline are in fact controlled via the global `IPayloadSerializer` / `IOptions<JsonSerializerOptions>` registrations, not per-`AddQueryCaching` configuration.
+
+**Failing test / repro (if confirmed):**
+- Path: `audit/repros/u02/`
+- Status: written
+- Code or steps:
+```text
+cd audit/repros/u02
+dotnet build U02Repro.csproj
+
+# Result:
+# Program.cs(22,17): error CS1061: 'QueryCachingOptions' does not contain a definition for 'JsonSerializerOptions'
+#                                  and no accessible extension method 'JsonSerializerOptions' accepting a first argument
+#                                  of type 'QueryCachingOptions' could be found
+```
+
+**Notes:**
+- Exact CS error captured: `CS1061` x1 at Program.cs:22:17 (the `options.JsonSerializerOptions` access).
+- Phase 3 fix options: (a) add `JsonSerializerOptions` to `QueryCachingOptions` and wire it through the caching interceptor, OR (b) update both README files to point users at the global `services.Configure<JsonSerializerOptions>(…)` / custom `IPayloadSerializer` registration paths.
+- Root README:59 ("configurable JsonSerializerOptions … via QueryCachingOptions") needs the same alignment.

--- a/audit/verification/round-01-U03.md
+++ b/audit/verification/round-01-U03.md
@@ -1,0 +1,25 @@
+# U03 Verification
+
+**Status:** CONFIRMED
+
+**Evidence:** `src/NetEvolve.Pulse/AssemblyScanningExtensions.cs:15` — XML doc reads: *"…use source generator-based registration instead by referencing the `NetEvolve.Pulse.Generators` package."*; `src/NetEvolve.Pulse.SourceGeneration/NetEvolve.Pulse.SourceGeneration.csproj` (the actual source-gen project — no explicit `<PackageId>`, so PackageId == AssemblyName == `NetEvolve.Pulse.SourceGeneration`); compiled XML doc at `src/NetEvolve.Pulse/bin/Debug/net10.0/NetEvolve.Pulse.xml:31` reproduces the wrong id.
+
+**Reasoning:**
+There is no `src/NetEvolve.Pulse.Generators` project anywhere in the repo. The only source-generator project is `NetEvolve.Pulse.SourceGeneration` (csproj inherits AssemblyName from project name, so the published NuGet package id matches the folder name). A user following the XML doc and running `dotnet add package NetEvolve.Pulse.Generators` will install something that does not exist — or, worse, install a future typo-squat package once someone notices.
+
+**Failing test / repro (if confirmed):**
+- Path: `tests/NetEvolve.Pulse.Tests.Unit/Audit/U03_AssemblyScanningPackageNameTests.cs`
+- Status: written
+- Code or steps:
+```csharp
+// Reflectively loads NetEvolve.Pulse.xml next to NetEvolve.Pulse.dll and asserts the
+// T:NetEvolve.Pulse.AssemblyScanningExtensions <member> recommends "NetEvolve.Pulse.SourceGeneration"
+// (and does not mention the phantom "NetEvolve.Pulse.Generators").
+//
+// Today both assertions fail; Phase 3 must fix the XML doc.
+```
+
+**Notes:**
+- Test reads the on-disk XML via `Path.Combine(Path.GetDirectoryName(typeof(AssemblyScanningExtensions).Assembly.Location), "NetEvolve.Pulse.xml")` — the XML file is auto-copied next to the assembly via the project reference, no extra MSBuild plumbing needed.
+- Same wording appears in the compiled XML (verified at `src/NetEvolve.Pulse/bin/Debug/net10.0/NetEvolve.Pulse.xml:31`).
+- Phase 3 fix is a one-line C# XML-doc edit on `AssemblyScanningExtensions.cs:15` (`Generators` → `SourceGeneration`).

--- a/audit/verification/round-01-U04.md
+++ b/audit/verification/round-01-U04.md
@@ -1,0 +1,25 @@
+# U04 Verification
+
+**Status:** CONFIRMED
+
+**Evidence:** `src/NetEvolve.Pulse/Serialization/SystemTextJsonPayloadSerializer.cs:32-44` — every `Serialize` / `Deserialize` overload calls reflection-mode `JsonSerializer.Serialize<T>` / `Deserialize<T>` / `SerializeToUtf8Bytes<T>` with no `[RequiresUnreferencedCode]` / `[RequiresDynamicCode]` annotations on the class or any method. The `IPayloadSerializer` contract (`src/NetEvolve.Pulse.Extensibility/IPayloadSerializer.cs:35-86`) likewise has no AOT-hostility attributes, so callers see a clean signature. AOT claim at `src/NetEvolve.Pulse/HandlerRegistrationExtensions.cs:8-17` advertises "All methods in this class are AOT-compatible and trimming-safe … No reflection is used at runtime".
+
+**Reasoning:**
+A consumer project with `<PublishAot>true</PublishAot>` + `<IsAotCompatible>true</IsAotCompatible>` + `<EnableAotAnalyzer>true</EnableAotAnalyzer>` + `<EnableTrimAnalyzer>true</EnableTrimAnalyzer>` that calls `IPayloadSerializer.Serialize(payload)` / `SerializeToBytes(payload)` builds with **zero IL2026 / IL3050 warnings**, even though those calls land in `SystemTextJsonPayloadSerializer` which uses untyped reflection-mode `System.Text.Json`. The audit assumption is correct: the AOT analyzer cannot warn the caller because the chain is unannotated, and at runtime AOT consumers will silently lose unreferenced payload type metadata.
+
+**Failing test / repro (if confirmed):**
+- Path: `audit/repros/u04/`
+- Status: written
+- Code or steps:
+```text
+cd audit/repros/u04
+dotnet build U04AotRepro.csproj   # 0 Warnung(en), 0 Fehler — AOT analyzer is SILENT
+dotnet publish U04AotRepro.csproj -r win-x64 -c Release --self-contained
+# Native linker fails on machines without the C++ workload, but the trim/AOT analyzer
+# stage runs first and still emits zero IL2026/IL3050 warnings. That silence is the bug.
+```
+
+**Notes:**
+- Build output captured: `0 Warnung(en), 0 Fehler` on Debug build with `EnableTrimAnalyzer=true`.
+- Phase 3 fix: annotate `SystemTextJsonPayloadSerializer.Serialize<T>` / `Deserialize<T>` / `SerializeToBytes<T>` with `[RequiresUnreferencedCode]` and `[RequiresDynamicCode]`, and likewise propagate to `IPayloadSerializer` so callers receive the warning at their call site. Alternatively introduce a source-generator-backed serializer for AOT scenarios and have the default DI registration prefer it when `RuntimeFeature.IsDynamicCodeSupported == false`.
+- `dotnet publish -r win-x64 --self-contained` fails on this machine at the native linker step (missing C++ workload). The trim/AOT analyzer phase still runs first and emits 0 IL warnings — that's the load-bearing data point. Linker output: `error : Platform linker not found. Ensure you have all the required prerequisites …` is unrelated to the audit claim.

--- a/audit/verification/round-01-U05.md
+++ b/audit/verification/round-01-U05.md
@@ -1,0 +1,32 @@
+# U05 Verification
+
+**Status:** CONFIRMED
+
+**Evidence:** `src/NetEvolve.Pulse/Outbox/OutboxProcessorOptions.cs:10-99` (no validation attributes / no `IValidateOptions<T>` companion); `src/NetEvolve.Pulse/OutboxExtensions.cs:51-61` (`AddOutbox` calls `AddOptions<OutboxProcessorOptions>()` then `services.Configure(...)` — no `.Validate(...)`, no `.ValidateDataAnnotations()`, no `.ValidateOnStart()`); only registered validator is `src/NetEvolve.Pulse/Interceptors/LoggingInterceptorOptionsValidator.cs` (confirmed by `Grep "IValidateOptions" src/` matching only that file + the registration in `LoggingExtensions.cs`).
+
+**Reasoning:**
+`OutboxProcessorOptions` exposes a wide surface of numerically- and temporally-meaningful properties (`BatchSize`, `PollingInterval`, `BackoffMultiplier`, `ProcessingTimeout`, `BaseRetryDelay`, `MaxRetryDelay`, `MaxRetryCount`) yet none are guarded by data annotations or an `IValidateOptions<OutboxProcessorOptions>`. `AddOutbox()` does not call `ValidateOnStart()`. Consequence: `BatchSize=0` resolves cleanly, `PollingInterval=TimeSpan.Zero` resolves cleanly, etc., and the processor only fails far inside the loop or — worse — never fails at all (e.g., `BatchSize=0` simply yields no work). This is the documented fail-fast gap.
+
+**Failing test / repro (if confirmed):**
+- Path: `tests/NetEvolve.Pulse.Tests.Unit/Audit/U05_OutboxProcessorOptionsValidationTests.cs`
+- Status: written, builds, and fails as expected (4/4 failing)
+- Code or steps:
+```text
+dotnet run --no-build -c Debug -f net10.0 \
+  --project tests/NetEvolve.Pulse.Tests.Unit \
+  -- --treenode-filter "/*/*/U05_OutboxProcessorOptionsValidationTests/*"
+
+# Result:
+#   gesamt: 4
+#   fehlerhaft: 4
+# Each test reports:
+#   "Expected to throw OptionsValidationException, because AddOutbox() must register
+#    an IValidateOptions<OutboxProcessorOptions> that rejects <field>=<bad-value>."
+#    but no exception was thrown
+```
+
+**Notes:**
+- The four scenarios covered match the assumption text: `BatchSize=0`, `PollingInterval=TimeSpan.Zero`, `BackoffMultiplier=0`, `ProcessingTimeout=TimeSpan.Zero`.
+- Tests use `services.BuildServiceProvider(validateScopes: true)` and resolve `IOptions<OutboxProcessorOptions>.Value` — the standard mechanism that surfaces `OptionsValidationException` from a registered `IValidateOptions<T>` (see `LoggingInterceptorOptionsValidator` for the reference pattern).
+- Phase 3 fix: add `OutboxProcessorOptionsValidator : IValidateOptions<OutboxProcessorOptions>`, register it inside `AddOutbox()` via `services.AddSingleton<IValidateOptions<OutboxProcessorOptions>, OutboxProcessorOptionsValidator>()`, and chain `.ValidateOnStart()` on the options builder so misconfig fails the host at startup, not at first dispatch.
+- `AzureServiceBusTransportOptions` (audit text mentions it as a counter-example of "validation runs inline at first resolution") was not exercised by this round — that should be a separate U05-follow-up scenario in a later round.

--- a/tests/NetEvolve.Pulse.Tests.Unit/Audit/U03_AssemblyScanningPackageNameTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Audit/U03_AssemblyScanningPackageNameTests.cs
@@ -1,0 +1,75 @@
+namespace NetEvolve.Pulse.Tests.Unit.Audit;
+
+using System.IO;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using NetEvolve.Extensions.TUnit;
+using TUnit.Core;
+
+/// <summary>
+/// Phase 2 / Round 01 / U03 — XML doc references non-existent NuGet package.
+///
+/// The XML doc on <see cref="AssemblyScanningExtensions"/> recommends referencing
+/// "NetEvolve.Pulse.Generators" but the actual package id (driven by the project's
+/// AssemblyName / PackageId) is "NetEvolve.Pulse.SourceGeneration".
+///
+/// This test is intentionally FAILING — it asserts the XML doc contains the real
+/// package id. Phase 3 must update the XML doc and then this assertion will pass.
+/// </summary>
+[TestGroup("Audit-Round01-U03")]
+public class U03_AssemblyScanningPackageNameTests
+{
+    private const string ActualPackageId = "NetEvolve.Pulse.SourceGeneration";
+    private const string DocumentedPackageId = "NetEvolve.Pulse.Generators";
+
+    [Test]
+    public async Task AssemblyScanningExtensions_XmlDoc_References_The_Real_SourceGeneration_Package()
+    {
+        var xmlPath = GetPulseXmlDocPath();
+
+        _ = await Assert
+            .That(File.Exists(xmlPath))
+            .IsTrue()
+            .Because($"Expected XML documentation at '{xmlPath}'. Did GenerateDocumentationFile get disabled?");
+
+        var doc = XDocument.Load(xmlPath);
+        var memberId = "T:NetEvolve.Pulse.AssemblyScanningExtensions";
+        var member = doc.Descendants("member")
+            .FirstOrDefault(m =>
+                string.Equals((string?)m.Attribute("name"), memberId, System.StringComparison.Ordinal)
+            );
+
+        _ = await Assert.That(member).IsNotNull().Because($"XML doc member '{memberId}' not found in {xmlPath}.");
+
+        var memberText = member!.ToString();
+
+        // The XML doc must recommend the package that actually exists on NuGet.
+        // Currently the doc cites a phantom package id, which is the bug under audit (U03).
+        using (Assert.Multiple())
+        {
+            _ = await Assert
+                .That(memberText.Contains(ActualPackageId, System.StringComparison.Ordinal))
+                .IsTrue()
+                .Because(
+                    $"AssemblyScanningExtensions XML doc must recommend the real package id '{ActualPackageId}'. "
+                        + $"Currently it references the phantom id '{DocumentedPackageId}'."
+                );
+
+            _ = await Assert
+                .That(memberText.Contains(DocumentedPackageId, System.StringComparison.Ordinal))
+                .IsFalse()
+                .Because(
+                    $"AssemblyScanningExtensions XML doc must NOT reference the phantom package id '{DocumentedPackageId}'."
+                );
+        }
+    }
+
+    private static string GetPulseXmlDocPath()
+    {
+        // The test runs from its own bin directory. The NetEvolve.Pulse XML doc is copied next to
+        // its DLL in the test output via project reference.
+        var probe = typeof(AssemblyScanningExtensions).Assembly.Location;
+        var dir = Path.GetDirectoryName(probe)!;
+        return Path.Combine(dir, "NetEvolve.Pulse.xml");
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/Audit/U05_OutboxProcessorOptionsValidationTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Audit/U05_OutboxProcessorOptionsValidationTests.cs
@@ -1,0 +1,99 @@
+namespace NetEvolve.Pulse.Tests.Unit.Audit;
+
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+/// <summary>
+/// Phase 2 / Round 01 / U05 — Critical options classes have no IValidateOptions.
+///
+/// OutboxProcessorOptions accepts nonsensical values (BatchSize&lt;=0, PollingInterval&lt;=Zero,
+/// BackoffMultiplier&lt;=0, ProcessingTimeout=Zero) and only fails deep inside the processor
+/// at runtime. No <see cref="IValidateOptions{TOptions}"/> nor data-annotation validation is
+/// registered by <c>AddOutbox()</c>.
+///
+/// These tests are intentionally FAILING — they assert that invalid values surface as an
+/// <see cref="OptionsValidationException"/> when the options are resolved. Today the options
+/// resolve cleanly with the bad values, so the tests fail. Phase 3 must add validators and
+/// wire ValidateOnStart().
+/// </summary>
+[TestGroup("Audit-Round01-U05")]
+public class U05_OutboxProcessorOptionsValidationTests
+{
+    [Test]
+    public async Task BatchSize_Zero_ShouldFailValidation_When_OptionsResolved()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddPulse(builder => builder.AddOutbox(configureProcessorOptions: o => o.BatchSize = 0));
+        await using var provider = services.BuildServiceProvider(validateScopes: true);
+
+        var resolve = () => provider.GetRequiredService<IOptions<OutboxProcessorOptions>>().Value;
+
+        // Today: succeeds and returns OutboxProcessorOptions with BatchSize=0 (invalid).
+        // Expected after Phase 3: throws OptionsValidationException.
+        _ = await Assert
+            .That(resolve)
+            .Throws<OptionsValidationException>()
+            .Because(
+                "AddOutbox() must register an IValidateOptions<OutboxProcessorOptions> that rejects BatchSize<=0."
+            );
+    }
+
+    [Test]
+    public async Task PollingInterval_Zero_ShouldFailValidation_When_OptionsResolved()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddPulse(builder =>
+            builder.AddOutbox(configureProcessorOptions: o => o.PollingInterval = System.TimeSpan.Zero)
+        );
+        await using var provider = services.BuildServiceProvider(validateScopes: true);
+
+        var resolve = () => provider.GetRequiredService<IOptions<OutboxProcessorOptions>>().Value;
+
+        _ = await Assert
+            .That(resolve)
+            .Throws<OptionsValidationException>()
+            .Because(
+                "AddOutbox() must register an IValidateOptions<OutboxProcessorOptions> that rejects PollingInterval<=TimeSpan.Zero."
+            );
+    }
+
+    [Test]
+    public async Task BackoffMultiplier_Zero_ShouldFailValidation_When_OptionsResolved()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddPulse(builder => builder.AddOutbox(configureProcessorOptions: o => o.BackoffMultiplier = 0d));
+        await using var provider = services.BuildServiceProvider(validateScopes: true);
+
+        var resolve = () => provider.GetRequiredService<IOptions<OutboxProcessorOptions>>().Value;
+
+        _ = await Assert
+            .That(resolve)
+            .Throws<OptionsValidationException>()
+            .Because(
+                "AddOutbox() must register an IValidateOptions<OutboxProcessorOptions> that rejects BackoffMultiplier<=0."
+            );
+    }
+
+    [Test]
+    public async Task ProcessingTimeout_Zero_ShouldFailValidation_When_OptionsResolved()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddPulse(builder =>
+            builder.AddOutbox(configureProcessorOptions: o => o.ProcessingTimeout = System.TimeSpan.Zero)
+        );
+        await using var provider = services.BuildServiceProvider(validateScopes: true);
+
+        var resolve = () => provider.GetRequiredService<IOptions<OutboxProcessorOptions>>().Value;
+
+        _ = await Assert
+            .That(resolve)
+            .Throws<OptionsValidationException>()
+            .Because(
+                "AddOutbox() must register an IValidateOptions<OutboxProcessorOptions> that rejects ProcessingTimeout=TimeSpan.Zero."
+            );
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 verification for the first five usability assumptions from `audit/assumptions/round-01-usability.md`. Each was independently re-verified with file:line evidence; failing tests / repros were added but no production code was modified. Phase 3 builders will fix the underlying issues.

| ID  | Status     | Evidence                                                                 | Failing test / repro                                                                                  |
| --- | ---------- | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
| U01 | CONFIRMED  | `README.md:118-136`                                                      | `audit/repros/u01/` — `dotnet build` emits `CS0535` x2 (CausationId, CorrelationId)                   |
| U02 | CONFIRMED  | `src/NetEvolve.Pulse/README.md:152-162`; `QueryCachingOptions.cs:10-59` | `audit/repros/u02/` — `dotnet build` emits `CS1061` for `options.JsonSerializerOptions`               |
| U03 | CONFIRMED  | `src/NetEvolve.Pulse/AssemblyScanningExtensions.cs:15`                  | `tests/NetEvolve.Pulse.Tests.Unit/Audit/U03_AssemblyScanningPackageNameTests.cs` (fails 1/1)          |
| U04 | CONFIRMED  | `src/NetEvolve.Pulse/Serialization/SystemTextJsonPayloadSerializer.cs:32-44` | `audit/repros/u04/` — AOT-annotated build emits zero IL2026/IL3050 warnings                          |
| U05 | CONFIRMED  | `src/NetEvolve.Pulse/Outbox/OutboxProcessorOptions.cs:10-99`; `OutboxExtensions.cs:51-61` | `tests/NetEvolve.Pulse.Tests.Unit/Audit/U05_OutboxProcessorOptionsValidationTests.cs` (fails 4/4)     |

All assumptions confirmed: **5 CONFIRMED / 0 REFUTED / 0 NEEDS-NUANCE**.

## Test plan

- [x] `dotnet build audit/repros/u01/U01Repro.csproj` — observe `CS0535` x2.
- [x] `dotnet build audit/repros/u02/U02Repro.csproj` — observe `CS1061` x1.
- [x] `dotnet build audit/repros/u04/U04AotRepro.csproj` (AOT analyzers on) — observe **zero** `IL2026` / `IL3050` warnings.
- [x] `dotnet run --project tests/NetEvolve.Pulse.Tests.Unit -- --treenode-filter "/*/*/U03_AssemblyScanningPackageNameTests/*"` — 1/1 fails (XML doc mentions phantom `NetEvolve.Pulse.Generators`).
- [x] `dotnet run --project tests/NetEvolve.Pulse.Tests.Unit -- --treenode-filter "/*/*/U05_OutboxProcessorOptionsValidationTests/*"` — 4/4 fail (no `OptionsValidationException`).
- [x] `dotnet build tests/NetEvolve.Pulse.Tests.Unit/NetEvolve.Pulse.Tests.Unit.csproj` succeeds (new tests compile).