### PR TITLE
audit: phase 2 verification Q01-Q06 (round 01)

### DIFF
--- a/audit/verification/round-01-Q01.md
+++ b/audit/verification/round-01-Q01.md
@@ -1,0 +1,22 @@
+# Q01 Verification
+
+**Status:** CONFIRMED
+
+**Evidence:**
+- `src/NetEvolve.Pulse/Outbox/OutboxProcessorHostedService.cs:93-119` — constructor takes `IOutboxRepository` directly; no `IServiceScopeFactory` or `IServiceProvider` is injected (verified via `Grep` — no matches for `IServiceScopeFactory|CreateScope|IServiceProvider` in the file).
+- `src/NetEvolve.Pulse/OutboxExtensions.cs:73` — `services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, OutboxProcessorHostedService>());`
+- `src/NetEvolve.Pulse.SqlServer/SqlServerExtensions.cs:199-202` — `.AddScoped<IOutboxRepository, SqlServerOutboxRepository>()`
+- `src/NetEvolve.Pulse.EntityFramework/EntityFrameworkExtensions.cs:66` — `.AddScoped<IOutboxRepository, EntityFrameworkOutboxRepository<TContext>>()`
+- `src/NetEvolve.Pulse.EntityFramework/Outbox/EntityFrameworkOutboxRepository.cs:41-47` — repository takes `TContext` (the EF DbContext) which is itself scoped.
+
+**Reasoning:**
+A singleton hosted service that takes a scoped dependency through its constructor is a textbook captive-dependency bug. The DI container enforces this when `ValidateScopes=true` (default in dev). For EF-backed repositories the captured `DbContext` is held for the lifetime of the host, accumulates change-tracker state forever, and is not thread-safe. The ADO.NET implementations mask the symptom because they open a fresh `DbConnection` per method call, but the lifetime registration is still wrong by contract.
+
+**Failing test (if confirmed):**
+- Path: `tests/NetEvolve.Pulse.Tests.Unit/Outbox/SingletonScopedCaptiveDependencyTests.cs`
+- Status: written
+
+The test calls `services.BuildServiceProvider(validateScopes: true)` and asks the container to resolve the registered `IHostedService` enumerable. Today this throws `InvalidOperationException` only when host startup runs validation; we trigger the validation path explicitly. The fix the Phase 3 builder must apply is to either (a) make `OutboxProcessorHostedService` create a scope per polling cycle via `IServiceScopeFactory`, or (b) register `IOutboxRepository` as Singleton (only safe for stateless connection-per-call ADO.NET impls — not EF).
+
+**Notes:**
+The currently registered SQL Server / EF Core impls all use Scoped lifetime; the singleton-hosted-service rule will fail for all of them under `ValidateOnBuild`/`ValidateScopes`. The failing test below targets the EF path because it is the most dangerous (captures a non-thread-safe DbContext). Phase 3 builders MUST NOT "fix" the captive by removing `ValidateScopes` — the right fix is a per-cycle scope.

--- a/audit/verification/round-01-Q02.md
+++ b/audit/verification/round-01-Q02.md
@@ -1,0 +1,27 @@
+# Q02 Verification
+
+**Status:** CONFIRMED
+
+**Evidence:**
+- `src/NetEvolve.Pulse.PostgreSql/Scripts/OutboxMessage.sql:78-105` — `get_pending_outbox_messages` flips `Status` from 0 (Pending) to 1 (Processing) in a single `UPDATE ... RETURNING` with `FOR UPDATE SKIP LOCKED`.
+- `src/NetEvolve.Pulse.PostgreSql/Scripts/OutboxMessage.sql:131-162` — `get_failed_outbox_messages_for_retry` also flips `Status` to 1 (Processing), and only filters on `Status=3` (Failed).
+- `src/NetEvolve.Pulse.PostgreSql/Scripts/OutboxMessage.sql:180-183, 202-203` — `mark_outbox_message_completed` and `mark_outbox_message_failed` only update rows with `Status=1`; nothing rescues stuck rows.
+- `src/NetEvolve.Pulse.SqlServer/Outbox/SqlServerOutboxRepository.cs:180-199` — `GetPendingAsync` calls a stored procedure that flips status to Processing.
+- `src/NetEvolve.Pulse/Outbox/OutboxProcessorHostedService.cs:236-292` — `ProcessBatchAsync` calls `GetPendingAsync` + `GetFailedForRetryAsync`. Neither queries for stuck-Processing rows, and no reaper method is invoked.
+- `src/NetEvolve.Pulse.Extensibility/Outbox/IOutboxRepository.cs:19-202` — interface contains no reaper / reclaim-stuck-processing method. There is no public surface a fix could rely on.
+
+**Reasoning:**
+The outbox follows a two-step lease pattern: claim (Pending -> Processing) and finalize (Processing -> Completed/Failed/DeadLetter). If the host crashes between those steps, the row sits in Processing forever because (a) `GetPendingAsync` filters `Status=0` only, (b) `GetFailedForRetryAsync` filters `Status=3` only, (c) `mark_outbox_message_*` SQL requires `Status=1` (so a manual SQL touch is the only escape), and (d) the `pulse.outbox.pending` gauge only counts `Status=0`, so monitoring is blind. This breaks the at-least-once delivery contract.
+
+**Failing test (if confirmed):**
+- Path: `tests/NetEvolve.Pulse.Tests.Unit/Outbox/StuckProcessingMessagesReaperTests.cs`
+- Status: written
+
+The test simulates a crash by directly setting a message to `OutboxMessageStatus.Processing` (the state a row is in after a successful `GetPendingAsync`). It then asserts that the public `IOutboxRepository` API provides some way to reclaim the message — there is none today, so the test fails at the assertion `Assert.That(reclaimMethodExists).IsTrue()`.
+
+**Notes:**
+The minimum exposure change required is a new method on `IOutboxRepository`, e.g.
+```csharp
+Task<int> ReclaimStuckProcessingAsync(TimeSpan stuckAfter, CancellationToken cancellationToken = default);
+```
+that flips rows whose `UpdatedAt < now - stuckAfter && Status = Processing` back to `Pending`, plus a corresponding tick inside `OutboxProcessorHostedService.ExecuteAsync` (every Nth poll). The current `Status` enum already supports the transition.

--- a/audit/verification/round-01-Q03.md
+++ b/audit/verification/round-01-Q03.md
@@ -1,0 +1,26 @@
+# Q03 Verification
+
+**Status:** CONFIRMED
+
+**Evidence:**
+- `src/NetEvolve.Pulse/Outbox/OutboxProcessorHostedService.cs:384` — `nextRetryAt = _options.ComputeNextRetryAt(DateTimeOffset.UtcNow, message.RetryCount);` (inside `ProcessMessageAsync`, used when an individual send fails and exponential backoff is enabled).
+- `src/NetEvolve.Pulse/Outbox/OutboxProcessorHostedService.cs:477` — `var now = DateTimeOffset.UtcNow;` (inside `ProcessBatchSendAsync`, used to compute `NextRetryAt` for every failed message in the batch).
+- Grep over the whole file for `TimeProvider` or `_timeProvider`: no matches. The service does not accept a `TimeProvider` argument and does not have any field of that type.
+- Contrast: `src/NetEvolve.Pulse/Idempotency/IdempotencyStore.cs:52-63` uses the injected `_timeProvider.GetUtcNow()` in both `ExistsAsync` and `StoreAsync`.
+
+**Reasoning:**
+The codebase already wires `TimeProvider` as a singleton service (`OutboxExtensions.cs:64` and `ServiceCollectionExtensions.cs:96`) and most other components honor it (Idempotency, OutboxEventStore, ActivityAndMetricsRequestInterceptor). The hosted service is the exception. Because `ComputeNextRetryAt` adds the computed delay to the supplied `now`, a fake clock pinned at e.g. `2030-01-01` will write a `NextRetryAt` that is essentially `DateTimeOffset.UtcNow + BaseRetryDelay` instead of `2030-01-01 + BaseRetryDelay`. That breaks any deterministic retry-window test and any "back-date the clock" scenario.
+
+**Failing test (if confirmed):**
+- Path: `tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorTimeProviderTests.cs`
+- Status: blocked-by-API
+
+The minimum-exposure fix is to add a `TimeProvider` parameter to `OutboxProcessorHostedService`'s constructor (or pull it through `IOptions`), then call `_timeProvider.GetUtcNow()` at line 384 and line 477. The failing test below already encodes the desired behavior; it cannot pass today because there is no constructor parameter to receive a `FakeTimeProvider`.
+
+The test writes a message, lets the hosted service fail it (failing transport), then asserts:
+1. The persisted `NextRetryAt` is anchored at the fake-clock time (`2030-01-01`), not real wall-clock time.
+
+Because the constructor cannot accept a `TimeProvider`, the test asserts the constructor has a `TimeProvider` parameter via reflection and fails — this captures the API gap.
+
+**Notes:**
+Phase 3 builders should also wire the field into the gauge subscription so the unhealthy-cycle back-off delay can be tested deterministically, but at minimum the two `DateTimeOffset.UtcNow` call sites must be replaced with `_timeProvider.GetUtcNow()`.

--- a/audit/verification/round-01-Q04.md
+++ b/audit/verification/round-01-Q04.md
@@ -1,0 +1,41 @@
+# Q04 Verification
+
+**Status:** CONFIRMED
+
+**Evidence:**
+- `src/NetEvolve.Pulse/Interceptors/IdempotencyCommandInterceptor.cs:68-79`:
+  ```csharp
+  var key = idempotentCommand.IdempotencyKey;
+  if (await store.ExistsAsync(key, cancellationToken).ConfigureAwait(false))
+  {
+      throw new IdempotencyConflictException(key);
+  }
+  var result = await handler(request, cancellationToken).ConfigureAwait(false);
+  await store.StoreAsync(key, cancellationToken).ConfigureAwait(false);
+  ```
+- `src/NetEvolve.Pulse/Idempotency/IdempotencyStore.cs:47-64` — `ExistsAsync` and `StoreAsync` are wholly separate operations; the contract has no put-if-absent / atomic-claim semantics.
+- `src/NetEvolve.Pulse.Extensibility/Idempotency/IIdempotencyStore.cs` — interface contains only `ExistsAsync(key, ct)` and `StoreAsync(key, ct)`. No `TryStoreAsync` / `ClaimAsync`.
+
+**Reasoning:**
+The interceptor is a classic TOCTOU pattern. Under concurrent dispatch of two `IIdempotentCommand`s with the same key:
+1. Thread A: `ExistsAsync(k) -> false`
+2. Thread B: `ExistsAsync(k) -> false`  (because A has not stored yet)
+3. Thread A: handler runs (side effects)
+4. Thread B: handler runs (DUPLICATE side effects)
+5. Both call `StoreAsync(k)` — the second is a no-op or silent overwrite.
+
+The public claim "at-most-once execution" (see XML docs on `IdempotencyCommandInterceptor`) is only true for strictly sequential duplicates.
+
+**Failing test (if confirmed):**
+- Path: `tests/NetEvolve.Pulse.Tests.Unit/Interceptors/IdempotencyConcurrentRaceTests.cs`
+- Status: written
+
+The test:
+1. Constructs two `IdempotencyCommandInterceptor<TestCommand, string>` instances sharing the same `TrackingIdempotencyStore`.
+2. Each schedules a `HandleAsync` for the same idempotency key with a gated handler (`SemaphoreSlim`/`TaskCompletionSource`) that only releases once both handlers have entered.
+3. Asserts: `handler ran exactly once` AND `the second call surfaced IdempotencyConflictException`.
+
+This fails today because both handlers fully execute before either calls `StoreAsync`, so `handlerExecutionCount == 2` and no `IdempotencyConflictException` is raised.
+
+**Notes:**
+The minimum-exposure fix is to add an atomic `TryStoreAsync(string key, CancellationToken)` (returns `bool`) on `IIdempotencyStore` (with a default-interface implementation falling back to the racey ExistsAsync+StoreAsync sequence for back-compat) and reorder the interceptor: `if (!await store.TryStoreAsync(key, ct)) throw new IdempotencyConflictException(key); try { return await handler(...); } catch { await store.RemoveAsync(key, ct); throw; }` — or similar. The Phase 3 builder should pick the design.

--- a/audit/verification/round-01-Q05.md
+++ b/audit/verification/round-01-Q05.md
@@ -1,0 +1,29 @@
+# Q05 Verification
+
+**Status:** NEEDS-NUANCE
+
+**Evidence:**
+- `src/NetEvolve.Pulse/Interceptors/ConcurrentCommandGuardInterceptor.cs:45` — `private readonly ConcurrentDictionary<Type, SemaphoreSlim> _semaphores = new();`
+- `src/NetEvolve.Pulse/Interceptors/ConcurrentCommandGuardInterceptor.cs:57` — `var semaphore = _semaphores.GetOrAdd(typeof(TRequest), _ => new SemaphoreSlim(1, 1));`
+- `src/NetEvolve.Pulse/Interceptors/ConcurrentCommandGuardInterceptor.cs:59` — `await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);`
+- `src/NetEvolve.Pulse/Interceptors/ConcurrentCommandGuardInterceptor.cs:71-84` — `Dispose()` iterates and disposes every value in `_semaphores`, then clears. No coordination with in-flight `WaitAsync` callers.
+
+**Reasoning:**
+Two sub-claims:
+
+1. **Dispose race → ODE during shutdown:** TRUE. `SemaphoreSlim.WaitAsync` (lines 59) does not honor disposal of the semaphore as cancellation. If `Dispose()` runs on the DI shutdown thread while another thread is parked in `WaitAsync(cancellationToken)`, the parked thread surfaces `ObjectDisposedException`, not `OperationCanceledException`. This is observable by writing a test that disposes the interceptor while a handler holds the semaphore. ODE during graceful shutdown is misleading: callers expect `OCE` and may catch it as the cancellation contract.
+
+2. **`GetOrAdd` factory leak:** TRUE but mitigated by SemaphoreSlim's design — `SemaphoreSlim` allocates a lazy `AvailableWaitHandle` only on first call. The discarded instances created by losing-race factories are GC'd. They are not tracked in `_semaphores`, so they are NEVER disposed deterministically — but because the wait handle is lazy, the practical leak is small (one managed `SemaphoreSlim` object per racing call). Under heavy contention the discarded objects can accumulate briefly until GC reclaims them. This is a correctness smell more than a runtime crash.
+
+Together: the higher-impact bug is the dispose race; the factory-leak is real but minor.
+
+**Failing test (if confirmed):**
+- Path: `tests/NetEvolve.Pulse.Tests.Unit/Interceptors/ConcurrentCommandGuardDisposeRaceTests.cs`
+- Status: written
+
+The test parks one `HandleAsync` invocation in `WaitAsync` (the inner handler awaits a `TaskCompletionSource` that is never released), disposes the interceptor on another thread, then awaits the parked task. The parked task today surfaces `ObjectDisposedException`. The assertion requires `OperationCanceledException` (the contract for shutdown), so it fails.
+
+**Notes:**
+For the factory leak claim, a deterministic reflection-based test is brittle (`GetOrAdd` factory race is timing-dependent and the .NET implementation does not guarantee multi-invocation under any specific contention pattern). We omit a failing test for that sub-claim and recommend Phase 3 fix `GetOrAdd` via the `factoryArgument` overload + `Lazy<SemaphoreSlim>` value, *or* use `ConcurrentDictionary<Type, Lazy<SemaphoreSlim>>` so the inner allocation runs exactly once.
+
+For the dispose race, the right Phase 3 fix is to add an internal `CancellationTokenSource` linked to disposal and link it into the `WaitAsync` call (`semaphore.WaitAsync(linkedToken)`), then cancel that source from `Dispose()` before disposing the semaphores. That converts the race into the expected `OperationCanceledException`.

--- a/audit/verification/round-01-Q06.md
+++ b/audit/verification/round-01-Q06.md
@@ -1,0 +1,21 @@
+# Q06 Verification
+
+**Status:** CONFIRMED
+
+**Evidence:**
+- `src/NetEvolve.Pulse.Kafka/Outbox/KafkaMessageTransport.cs:63-102` — `SendBatchAsync(IEnumerable<OutboxMessage> messages, CancellationToken cancellationToken = default)` declares the token but never passes it to `_producer.Produce` (the sync overload at line 76 does not accept one) nor to `_producer.Flush` at line 94.
+- `src/NetEvolve.Pulse.Kafka/Outbox/KafkaMessageTransport.cs:94` — `_ = _producer.Flush(Timeout.InfiniteTimeSpan);` — explicitly waits forever, ignoring the token.
+- `src/NetEvolve.Pulse.Kafka/Outbox/KafkaMessageTransport.cs:105-116` — `IsHealthyAsync` calls sync `_adminClient.GetMetadata(TimeSpan.FromSeconds(5))` and only checks the token in the catch filter; it does not pre-check `cancellationToken.ThrowIfCancellationRequested()` either.
+- The `IProducer<TKey, TValue>` interface offers `Flush(CancellationToken)` (see `Confluent.Kafka` SDK). The token-aware overload is `_producer.Flush(cancellationToken)` and *will* throw `OperationCanceledException` when the supplied token fires.
+
+**Reasoning:**
+The Kafka transport ignores cancellation in the two places it matters: the synchronous batch flush and the sync admin-client health probe. During graceful shutdown (`IHostApplicationLifetime.StopApplication`), the hosted service signals `stoppingToken` and expects all transports to wind down. With `Flush(Timeout.InfiniteTimeSpan)` the transport blocks forever if the broker is unreachable. The stuck flush keeps the row in `Status=Processing` (compounding Q02). The fix is one line: `_producer.Flush(cancellationToken)`.
+
+**Failing test (if confirmed):**
+- Path: `tests/NetEvolve.Pulse.Tests.Unit/Kafka/KafkaMessageTransportCancellationTests.cs`
+- Status: written
+
+The test plugs a fake `IProducer<string, string>` whose `Flush(TimeSpan)` blocks indefinitely on a `ManualResetEventSlim` while ignoring its argument, and whose `Flush(CancellationToken)` honors the token (the real Confluent producer behaves this way). It then calls `SendBatchAsync` with a `CancellationTokenSource` set to cancel after 100ms. The task must complete (cancelled or successful) within 1 second. Today it hangs because the transport calls the timespan overload with `Timeout.InfiniteTimeSpan`, so the assertion-with-timeout fails.
+
+**Notes:**
+The fix is local to `KafkaMessageTransport.SendBatchAsync` (line 94) and `IsHealthyAsync` (line 109). For `IsHealthyAsync`, the right pattern is `Task.Run(() => _adminClient.GetMetadata(timeout), cancellationToken)` or use the admin client's cancellation-token overload if available; alternatively `cancellationToken.ThrowIfCancellationRequested()` before the call so the pre-cancelled path is fast. Document this transport as best-effort for `IsHealthy` and note the sync API limitation in librdkafka.

--- a/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/ConcurrentCommandGuardDisposeRaceTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/ConcurrentCommandGuardDisposeRaceTests.cs
@@ -1,0 +1,91 @@
+namespace NetEvolve.Pulse.Tests.Unit.Interceptors;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Interceptors;
+using TUnit.Core;
+
+/// <summary>
+/// Phase 2 audit verification — Q05 (dispose-race sub-claim).
+/// <see cref="ConcurrentCommandGuardInterceptor{TRequest, TResponse}"/> disposes all internally
+/// held <see cref="SemaphoreSlim"/> instances in its <c>Dispose</c> method. There is no
+/// coordination with in-flight <c>WaitAsync</c> callers, so a parked thread surfaces
+/// <see cref="ObjectDisposedException"/> at shutdown instead of <see cref="OperationCanceledException"/>.
+///
+/// EXPECTED TO FAIL today: the test parks one HandleAsync invocation in <c>WaitAsync</c>,
+/// disposes the interceptor on another thread, and asserts that the parked task surfaces
+/// <see cref="OperationCanceledException"/>. Today it surfaces <see cref="ObjectDisposedException"/>.
+/// </summary>
+[TestGroup("Audit-Q05")]
+public sealed class ConcurrentCommandGuardDisposeRaceTests
+{
+    [Test]
+    public async Task Dispose_While_HandleAsync_Awaits_Semaphore_Surfaces_OperationCanceled()
+    {
+        var interceptor = new ConcurrentCommandGuardInterceptor<DisposeRaceCommand, string>();
+        var firstHandlerEntered = new TaskCompletionSource();
+        var holdFirstHandler = new TaskCompletionSource();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        // First call: acquires the semaphore and holds it indefinitely.
+        // We intentionally fire-and-forget this task; it will be released later via holdFirstHandler.SetResult().
+        _ = Task.Run(
+            () =>
+                interceptor.HandleAsync(
+                    new DisposeRaceCommand(),
+                    async (_, ct) =>
+                    {
+                        firstHandlerEntered.SetResult();
+                        await holdFirstHandler.Task.WaitAsync(ct).ConfigureAwait(false);
+                        return "first";
+                    },
+                    cts.Token
+                ),
+            cts.Token
+        );
+
+        await firstHandlerEntered.Task.WaitAsync(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+
+        // Second call: queues behind the semaphore. This is the task we want to inspect at shutdown.
+        var parkedTask = Task.Run(
+            () => interceptor.HandleAsync(new DisposeRaceCommand(), (_, _) => Task.FromResult("second"), cts.Token),
+            cts.Token
+        );
+
+        // Give the parked task a moment to enter SemaphoreSlim.WaitAsync.
+        await Task.Delay(TimeSpan.FromMilliseconds(50), cts.Token).ConfigureAwait(false);
+
+        // Dispose mid-flight — simulates DI-container shutdown.
+        interceptor.Dispose();
+
+        // Release the first handler so it can finish its own work path.
+        holdFirstHandler.SetResult();
+
+        Exception? capturedSecondException = null;
+        try
+        {
+            _ = await parkedTask.ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            capturedSecondException = ex;
+        }
+
+        // ASSERTION CAPTURES THE DEFECT:
+        // The shutdown-cancellation contract is OperationCanceledException, not ObjectDisposedException.
+        // Today the parked WaitAsync surfaces ObjectDisposedException because Dispose() racing with WaitAsync
+        // is not converted into a cooperative cancellation.
+        _ = await Assert.That(capturedSecondException).IsNotNull();
+        _ = await Assert.That(capturedSecondException).IsTypeOf<OperationCanceledException>();
+    }
+
+    private sealed record DisposeRaceCommand : IExclusiveCommand<string>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/IdempotencyConcurrentRaceTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/IdempotencyConcurrentRaceTests.cs
@@ -1,0 +1,155 @@
+namespace NetEvolve.Pulse.Tests.Unit.Interceptors;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.Idempotency;
+using NetEvolve.Pulse.Idempotency;
+using NetEvolve.Pulse.Interceptors;
+using TUnit.Core;
+
+/// <summary>
+/// Phase 2 audit verification — Q04.
+/// <see cref="IdempotencyCommandInterceptor{TRequest, TResponse}"/> implements the classic
+/// check-then-act pattern (<c>ExistsAsync</c> → handler → <c>StoreAsync</c>). Two concurrent
+/// commands with the same idempotency key both pass <c>ExistsAsync</c> before either calls
+/// <c>StoreAsync</c>, so the handler runs twice.
+///
+/// EXPECTED TO FAIL today: the test schedules two parallel <c>HandleAsync</c> invocations
+/// with the same key, gates the handler so neither can finish before both have entered,
+/// then asserts that the handler ran at most once and the second invocation surfaced
+/// <see cref="IdempotencyConflictException"/>.
+/// </summary>
+[SuppressMessage(
+    "IDisposableAnalyzers.Correctness",
+    "CA2000:Dispose objects before losing scope",
+    Justification = "ServiceProvider instances are short-lived within test methods"
+)]
+[TestGroup("Audit-Q04")]
+public sealed class IdempotencyConcurrentRaceTests
+{
+    [Test]
+    public async Task HandleAsync_Two_Concurrent_Commands_Same_Key_Should_Execute_Handler_Once()
+    {
+        var store = new SharedTrackingIdempotencyStore();
+        var services = new ServiceCollection();
+        _ = services.AddSingleton<IIdempotencyStore>(store);
+        var provider = services.BuildServiceProvider();
+
+        // Two interceptors that share the same store (same scenario as two competing
+        // workers under one DI container resolving the singleton store).
+        var interceptor1 = new IdempotencyCommandInterceptor<RaceCommand, string>(provider);
+        var interceptor2 = new IdempotencyCommandInterceptor<RaceCommand, string>(provider);
+
+        var sharedKey = "race-key";
+        var entered = new SemaphoreSlim(0, 2);
+        var release = new TaskCompletionSource();
+        var handlerExecutionCount = 0;
+
+        async Task<string> GatedHandler(RaceCommand cmd, CancellationToken ct)
+        {
+            ArgumentNullException.ThrowIfNull(cmd);
+            _ = Interlocked.Increment(ref handlerExecutionCount);
+            _ = entered.Release();
+            await release.Task.WaitAsync(ct).ConfigureAwait(false);
+            return "ok";
+        }
+
+        var command1 = new RaceCommand { IdempotencyKey = sharedKey };
+        var command2 = new RaceCommand { IdempotencyKey = sharedKey };
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        // Schedule both invocations; do not await yet.
+        var task1 = Task.Run(() => interceptor1.HandleAsync(command1, GatedHandler, cts.Token), cts.Token);
+        var task2 = Task.Run(() => interceptor2.HandleAsync(command2, GatedHandler, cts.Token), cts.Token);
+
+        // Wait for either both handlers to enter (the race we want) OR a single conflict to be raised.
+        // If the interceptor were race-safe, only ONE handler would enter and the other would surface
+        // an IdempotencyConflictException without ever calling the handler.
+        var firstEntered = await entered.WaitAsync(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+        var secondEntered = await entered.WaitAsync(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+        var bothEntered = firstEntered && secondEntered;
+
+        // Release whichever handlers are parked.
+        release.SetResult();
+
+        // Await both invocations; collect their outcomes.
+        var outcomes = new[]
+        {
+            await CaptureAsync(task1).ConfigureAwait(false),
+            await CaptureAsync(task2).ConfigureAwait(false),
+        };
+
+        // ASSERTION CAPTURES THE DEFECT:
+        // The handler must execute at most ONCE for the same idempotency key, even under concurrency.
+        // Today both handlers execute (handlerExecutionCount == 2) because the check-then-act window is open.
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(handlerExecutionCount).IsEqualTo(1);
+            _ = await Assert
+                .That(System.Array.Exists(outcomes, o => o.Exception is IdempotencyConflictException))
+                .IsTrue();
+            // Sanity-record: if this is true the race was provoked; if false the test is non-reproducing.
+            // We do not assert on it — leave it as diagnostic.
+            _ = bothEntered;
+        }
+    }
+
+    [SuppressMessage(
+        "Reliability",
+        "VSTHRD003:Avoid awaiting foreign Tasks",
+        Justification = "Test deliberately awaits Task.Run-produced tasks to capture outcomes."
+    )]
+    private static async Task<(string? Result, Exception? Exception)> CaptureAsync(Task<string> task)
+    {
+        try
+        {
+            var result = await task.ConfigureAwait(false);
+            return (result, null);
+        }
+        catch (Exception ex)
+        {
+            return (null, ex);
+        }
+    }
+
+    private sealed record RaceCommand : IIdempotentCommand<string>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+        public string IdempotencyKey { get; init; } = string.Empty;
+    }
+
+    /// <summary>
+    /// A store that mirrors the real <see cref="IdempotencyStore"/> contract: ExistsAsync and
+    /// StoreAsync are NON-ATOMIC. Internally tracks stored keys with a lock for thread safety,
+    /// but does NOT implement check-and-set semantics.
+    /// </summary>
+    private sealed class SharedTrackingIdempotencyStore : IIdempotencyStore
+    {
+        private readonly System.Collections.Generic.HashSet<string> _keys = [];
+        private readonly object _lock = new();
+
+        public Task<bool> ExistsAsync(string idempotencyKey, CancellationToken cancellationToken = default)
+        {
+            lock (_lock)
+            {
+                return Task.FromResult(_keys.Contains(idempotencyKey));
+            }
+        }
+
+        public Task StoreAsync(string idempotencyKey, CancellationToken cancellationToken = default)
+        {
+            lock (_lock)
+            {
+                _ = _keys.Add(idempotencyKey);
+            }
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/Kafka/KafkaMessageTransportCancellationTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Kafka/KafkaMessageTransportCancellationTests.cs
@@ -1,0 +1,281 @@
+namespace NetEvolve.Pulse.Tests.Unit.Kafka;
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Confluent.Kafka;
+using Confluent.Kafka.Admin;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.Outbox;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+/// <summary>
+/// Phase 2 audit verification — Q06.
+/// <see cref="KafkaMessageTransport.SendBatchAsync"/> calls
+/// <c>_producer.Flush(Timeout.InfiniteTimeSpan)</c> and does NOT pass the supplied
+/// <see cref="CancellationToken"/>. The Confluent.Kafka <see cref="IProducer{TKey,TValue}"/>
+/// interface offers a <c>Flush(CancellationToken)</c> overload that respects cancellation;
+/// the transport uses the timespan overload instead, so a stuck broker blocks shutdown forever.
+///
+/// EXPECTED TO FAIL today: the test plugs a fake producer whose timespan-Flush blocks until
+/// signalled (mirroring the real librdkafka behavior on an unreachable broker), then triggers
+/// cancellation after 100 ms. <see cref="KafkaMessageTransport.SendBatchAsync"/> must complete
+/// within 1 second — today it does not, so the wait-with-timeout returns false and the assertion fails.
+/// </summary>
+[TestGroup("Audit-Q06")]
+public sealed class KafkaMessageTransportCancellationTests
+{
+    [Test]
+    public async Task SendBatchAsync_Respects_CancellationToken_When_Flush_Hangs()
+    {
+        using var producer = new BlockingFakeProducer();
+        using var admin = new BlockingFakeAdminClient();
+        var transport = new KafkaMessageTransport(producer, admin, new FixedTopicNameResolver("test-topic"));
+        var message = CreateOutboxMessage();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+
+        var sendTask = Task.Run(() => transport.SendBatchAsync(new[] { message }, cts.Token), CancellationToken.None);
+
+        // ASSERTION CAPTURES THE DEFECT:
+        // SendBatchAsync should respect the cancellation token. Today it ignores it because
+        // the transport calls _producer.Flush(Timeout.InfiniteTimeSpan) instead of
+        // _producer.Flush(cancellationToken).
+        // We give a generous 1-second window for the cancellation to propagate; today the call
+        // hangs until producer.Release() is called explicitly, so the wait times out.
+        var completedInTime =
+            await Task.WhenAny(sendTask, Task.Delay(TimeSpan.FromSeconds(1))).ConfigureAwait(false) == sendTask;
+
+        // Release the producer so we don't leak the background task.
+        producer.Release();
+        try
+        {
+            await sendTask.ConfigureAwait(false);
+        }
+        catch
+        {
+            // Ignore: the task may surface AggregateException or OperationCanceledException.
+        }
+
+        _ = await Assert.That(completedInTime).IsTrue();
+    }
+
+    private static OutboxMessage CreateOutboxMessage() =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            EventType = typeof(TestKafkaEvent),
+            Payload = """{"event":"sample"}""",
+            CorrelationId = "corr-q06",
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            RetryCount = 0,
+        };
+
+    private sealed record TestKafkaEvent : IEvent
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+        public string Id { get; init; } = Guid.NewGuid().ToString();
+        public DateTimeOffset? PublishedAt { get; set; }
+    }
+
+    private sealed class FixedTopicNameResolver(string topic) : ITopicNameResolver
+    {
+        public string Resolve(OutboxMessage message) => topic;
+    }
+
+    /// <summary>
+    /// A fake producer whose <c>Flush(TimeSpan)</c> blocks indefinitely on a manual signal,
+    /// regardless of the supplied timeout. Mirrors librdkafka's real behavior on a stuck broker.
+    /// The <c>Flush(CancellationToken)</c> overload honors the token (this is the fix path —
+    /// the transport should call this overload).
+    /// </summary>
+    private sealed class BlockingFakeProducer : IProducer<string, string>
+    {
+        private readonly ManualResetEventSlim _release = new(initialState: false);
+
+        public string Name => "blocking-fake-producer";
+        public Handle Handle => default!;
+
+        public void Release() => _release.Set();
+
+        public Task<DeliveryResult<string, string>> ProduceAsync(
+            string topic,
+            Message<string, string> message,
+            CancellationToken cancellationToken = default
+        ) =>
+            Task.FromResult(
+                new DeliveryResult<string, string>
+                {
+                    Topic = topic,
+                    Message = message,
+                    Status = PersistenceStatus.Persisted,
+                }
+            );
+
+        public Task<DeliveryResult<string, string>> ProduceAsync(
+            TopicPartition topicPartition,
+            Message<string, string> message,
+            CancellationToken cancellationToken = default
+        ) => throw new NotSupportedException();
+
+        public void Produce(
+            string topic,
+            Message<string, string> message,
+            Action<DeliveryReport<string, string>>? deliveryHandler = null
+        )
+        {
+            // No-op: pretend the message was enqueued. Flush is the bottleneck.
+        }
+
+        public void Produce(
+            TopicPartition topicPartition,
+            Message<string, string> message,
+            Action<DeliveryReport<string, string>>? deliveryHandler = null
+        ) => throw new NotSupportedException();
+
+        public int Flush(TimeSpan timeout)
+        {
+            // Block until explicitly released. This is the buggy code path — the production
+            // transport calls this overload with Timeout.InfiniteTimeSpan and ignores the
+            // SendBatchAsync cancellation token.
+            _release.Wait();
+            return 0;
+        }
+
+        public void Flush(CancellationToken cancellationToken = default) =>
+            // The cancellation-aware overload — the fix path.
+            _release.Wait(cancellationToken);
+
+        public int Poll(TimeSpan timeout) => 0;
+
+        public void InitTransactions(TimeSpan timeout) { }
+
+        public void BeginTransaction() { }
+
+        public void CommitTransaction(TimeSpan timeout) { }
+
+        public void CommitTransaction() { }
+
+        public void AbortTransaction(TimeSpan timeout) { }
+
+        public void AbortTransaction() { }
+
+        public void SendOffsetsToTransaction(
+            IEnumerable<TopicPartitionOffset> offsets,
+            IConsumerGroupMetadata groupMetadata,
+            TimeSpan timeout
+        ) => throw new NotSupportedException();
+
+        public int AddBrokers(string brokers) => 0;
+
+        public void SetSaslCredentials(string username, string password) { }
+
+        public void Dispose() => _release.Dispose();
+    }
+
+    private sealed class BlockingFakeAdminClient : IAdminClient
+    {
+        public string Name => "blocking-fake-admin";
+        public Handle Handle => default!;
+
+        public Metadata GetMetadata(TimeSpan timeout) => new([], [], -1, "test-cluster");
+
+        public Metadata GetMetadata(string topic, TimeSpan timeout) => throw new NotSupportedException();
+
+        public List<GroupInfo> ListGroups(TimeSpan timeout) => throw new NotSupportedException();
+
+        public GroupInfo ListGroup(string group, TimeSpan timeout) => throw new NotSupportedException();
+
+        public Task CreateTopicsAsync(IEnumerable<TopicSpecification> topics, CreateTopicsOptions? options = null) =>
+            throw new NotSupportedException();
+
+        public Task DeleteTopicsAsync(IEnumerable<string> topics, DeleteTopicsOptions? options = null) =>
+            throw new NotSupportedException();
+
+        public Task CreatePartitionsAsync(
+            IEnumerable<PartitionsSpecification> partitionsSpecifications,
+            CreatePartitionsOptions? options = null
+        ) => throw new NotSupportedException();
+
+        public Task DeleteGroupsAsync(IList<string> groups, DeleteGroupsOptions? options = null) =>
+            throw new NotSupportedException();
+
+        public Task AlterConfigsAsync(
+            Dictionary<ConfigResource, List<ConfigEntry>> configs,
+            AlterConfigsOptions? options = null
+        ) => throw new NotSupportedException();
+
+        public Task<List<IncrementalAlterConfigsResult>> IncrementalAlterConfigsAsync(
+            Dictionary<ConfigResource, List<ConfigEntry>> configs,
+            IncrementalAlterConfigsOptions? options = null
+        ) => throw new NotSupportedException();
+
+        public Task<List<DescribeConfigsResult>> DescribeConfigsAsync(
+            IEnumerable<ConfigResource> resources,
+            DescribeConfigsOptions? options = null
+        ) => throw new NotSupportedException();
+
+        public Task<List<DeleteRecordsResult>> DeleteRecordsAsync(
+            IEnumerable<TopicPartitionOffset> topicPartitionOffsets,
+            DeleteRecordsOptions? options = null
+        ) => throw new NotSupportedException();
+
+        public Task CreateAclsAsync(IEnumerable<AclBinding> aclBindings, CreateAclsOptions? options = null) =>
+            throw new NotSupportedException();
+
+        public Task<DescribeAclsResult> DescribeAclsAsync(
+            AclBindingFilter aclBindingFilter,
+            DescribeAclsOptions? options = null
+        ) => throw new NotSupportedException();
+
+        public Task<List<DeleteAclsResult>> DeleteAclsAsync(
+            IEnumerable<AclBindingFilter> aclBindingFilters,
+            DeleteAclsOptions? options = null
+        ) => throw new NotSupportedException();
+
+        public Task<DeleteConsumerGroupOffsetsResult> DeleteConsumerGroupOffsetsAsync(
+            string group,
+            IEnumerable<TopicPartition> partitions,
+            DeleteConsumerGroupOffsetsOptions? options = null
+        ) => throw new NotSupportedException();
+
+        public Task<List<AlterConsumerGroupOffsetsResult>> AlterConsumerGroupOffsetsAsync(
+            IEnumerable<ConsumerGroupTopicPartitionOffsets> groupPartitions,
+            AlterConsumerGroupOffsetsOptions? options = null
+        ) => throw new NotSupportedException();
+
+        public Task<List<ListConsumerGroupOffsetsResult>> ListConsumerGroupOffsetsAsync(
+            IEnumerable<ConsumerGroupTopicPartitions> groupPartitions,
+            ListConsumerGroupOffsetsOptions? options = null
+        ) => throw new NotSupportedException();
+
+        public Task<ListConsumerGroupsResult> ListConsumerGroupsAsync(ListConsumerGroupsOptions? options = null) =>
+            throw new NotSupportedException();
+
+        public Task<DescribeConsumerGroupsResult> DescribeConsumerGroupsAsync(
+            IEnumerable<string> groups,
+            DescribeConsumerGroupsOptions? options = null
+        ) => throw new NotSupportedException();
+
+        public Task<DescribeUserScramCredentialsResult> DescribeUserScramCredentialsAsync(
+            IEnumerable<string> users,
+            DescribeUserScramCredentialsOptions? options = null
+        ) => throw new NotSupportedException();
+
+        public Task AlterUserScramCredentialsAsync(
+            IEnumerable<UserScramCredentialAlteration> alterations,
+            AlterUserScramCredentialsOptions? options = null
+        ) => throw new NotSupportedException();
+
+        public int AddBrokers(string brokers) => 0;
+
+        public void SetSaslCredentials(string username, string password) { }
+
+        public void Dispose() { }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorTimeProviderTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorTimeProviderTests.cs
@@ -1,0 +1,37 @@
+namespace NetEvolve.Pulse.Tests.Unit.Outbox;
+
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+/// <summary>
+/// Phase 2 audit verification — Q03.
+/// <see cref="OutboxProcessorHostedService"/> calls <c>DateTimeOffset.UtcNow</c>
+/// directly at lines 384 and 477, bypassing the rest-of-the-codebase
+/// <see cref="TimeProvider"/> convention. This prevents deterministic
+/// retry-window assertions with <c>FakeTimeProvider</c>.
+///
+/// BLOCKED-BY-API today: the public constructor does not accept a
+/// <see cref="TimeProvider"/>, so a follow-up test cannot inject a fake clock.
+/// Phase 3 must add the parameter and reroute the two call sites.
+/// </summary>
+[TestGroup("Audit-Q03")]
+public sealed class OutboxProcessorTimeProviderTests
+{
+    [Test]
+    public async Task OutboxProcessorHostedService_Should_Accept_A_TimeProvider_Argument()
+    {
+        var ctors = typeof(OutboxProcessorHostedService).GetConstructors(BindingFlags.Public | BindingFlags.Instance);
+
+        var acceptsTimeProvider = ctors.Any(c => c.GetParameters().Any(p => p.ParameterType == typeof(TimeProvider)));
+
+        // ASSERTION CAPTURES THE DEFECT:
+        // The hosted service must accept a TimeProvider so that retry scheduling
+        // honors the same fake clock used by IdempotencyStore, OutboxEventStore, etc.
+        _ = await Assert.That(acceptsTimeProvider).IsTrue();
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/Outbox/SingletonScopedCaptiveDependencyTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Outbox/SingletonScopedCaptiveDependencyTests.cs
@@ -1,0 +1,60 @@
+namespace NetEvolve.Pulse.Tests.Unit.Outbox;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse;
+using NetEvolve.Pulse.Outbox;
+using NetEvolve.Pulse.Tests.Unit.EntityFramework;
+using TUnit.Core;
+
+/// <summary>
+/// Phase 2 audit verification — Q01.
+/// Reproduces the captive-dependency bug where the Singleton
+/// <see cref="OutboxProcessorHostedService"/> consumes the Scoped
+/// <c>IOutboxRepository</c> directly through its constructor.
+///
+/// EXPECTED TO FAIL today: the test asserts that resolving the registered
+/// <see cref="IHostedService"/> enumerable through a validated root provider
+/// does NOT throw. Today it throws <see cref="InvalidOperationException"/>
+/// (the standard message from <c>CallSiteValidator</c>) because the
+/// EntityFrameworkOutboxRepository is registered Scoped.
+/// </summary>
+[TestGroup("Audit-Q01")]
+public sealed class SingletonScopedCaptiveDependencyTests
+{
+    [Test]
+    public async Task OutboxProcessorHostedService_Should_Not_Capture_Scoped_Repository()
+    {
+        // Arrange: the standard EF-Core outbox wiring used in production.
+        var services = new ServiceCollection();
+        _ = services.AddLogging();
+        _ = services.AddDbContext<TestDbContext>(o =>
+            o.UseInMemoryDatabase(nameof(OutboxProcessorHostedService_Should_Not_Capture_Scoped_Repository))
+        );
+        _ = services.AddPulse(config => config.AddOutbox().AddEntityFrameworkOutbox<TestDbContext>());
+
+        // Act + Assert: building the root provider with scope validation and resolving the
+        // hosted service enumerable must not throw. Today this throws InvalidOperationException
+        // because OutboxProcessorHostedService is a Singleton consuming the Scoped IOutboxRepository.
+        var act = () =>
+        {
+            using var provider = services.BuildServiceProvider(
+                new ServiceProviderOptions { ValidateScopes = true, ValidateOnBuild = true }
+            );
+
+            // Force resolution of all hosted services to surface the captive-dependency error.
+            var hostedServices = provider.GetServices<IHostedService>().ToArray();
+            return hostedServices;
+        };
+
+        // ASSERTION CAPTURES THE DEFECT:
+        // The captive-dependency rule SHOULD be honored — this should NOT throw.
+        // Today it throws InvalidOperationException with a "Cannot consume scoped service ... from singleton ..." message.
+        _ = await Assert.That(act).ThrowsNothing();
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/Outbox/StuckProcessingMessagesReaperTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Outbox/StuckProcessingMessagesReaperTests.cs
@@ -1,0 +1,43 @@
+namespace NetEvolve.Pulse.Tests.Unit.Outbox;
+
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility.Outbox;
+using TUnit.Core;
+
+/// <summary>
+/// Phase 2 audit verification — Q02.
+/// The outbox state machine flips Pending→Processing inside <c>GetPendingAsync</c>.
+/// If the host crashes between fetch and <c>MarkAsCompleted/Failed/DeadLetter</c>,
+/// the row sits in Processing forever — neither <c>GetPendingAsync</c> (Status=0 only)
+/// nor <c>GetFailedForRetryAsync</c> (Status=3 only) will surface it.
+///
+/// EXPECTED TO FAIL today: the test asserts that <see cref="IOutboxRepository"/>
+/// exposes some way to reclaim stuck-Processing rows. No such method exists.
+/// </summary>
+[TestGroup("Audit-Q02")]
+public sealed class StuckProcessingMessagesReaperTests
+{
+    [Test]
+    public async Task IOutboxRepository_Should_Expose_A_Reaper_For_Stuck_Processing_Rows()
+    {
+        var contract = typeof(IOutboxRepository);
+        var methods = contract.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+
+        // A reaper method must exist. We accept any of these conventional names; the Phase 3 fix may pick one.
+        var hasReaper = methods.Any(m =>
+            string.Equals(m.Name, "ReclaimStuckProcessingAsync", StringComparison.Ordinal)
+            || string.Equals(m.Name, "ReclaimStuckAsync", StringComparison.Ordinal)
+            || string.Equals(m.Name, "GetStuckProcessingAsync", StringComparison.Ordinal)
+            || string.Equals(m.Name, "RescueStuckAsync", StringComparison.Ordinal)
+        );
+
+        // ASSERTION CAPTURES THE DEFECT:
+        // The at-least-once delivery contract requires a way to reclaim rows whose host died mid-process.
+        // No such API exists on IOutboxRepository today.
+        _ = await Assert.That(hasReaper).IsTrue();
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of the NetEvolve.Pulse audit. Independently verifies the first six quality
assumptions raised in `audit/assumptions/round-01-quality.md` and ships one failing
TUnit test per CONFIRMED defect.

### Status table

| Assumption | Status            | Failing test |
|------------|-------------------|--------------|
| Q01 OutboxProcessorHostedService captive-dependency (Singleton consumes Scoped) | CONFIRMED       | `SingletonScopedCaptiveDependencyTests.cs` |
| Q02 Stuck `Status=Processing` rows never reaped                                | CONFIRMED       | `StuckProcessingMessagesReaperTests.cs` |
| Q03 OutboxProcessor bypasses `TimeProvider`                                    | CONFIRMED (blocked-by-API) | `OutboxProcessorTimeProviderTests.cs` |
| Q04 `IdempotencyCommandInterceptor` is check-then-act, not atomic              | CONFIRMED       | `IdempotencyConcurrentRaceTests.cs` |
| Q05 `ConcurrentCommandGuardInterceptor` dispose race + GetOrAdd factory leak   | NEEDS-NUANCE    | `ConcurrentCommandGuardDisposeRaceTests.cs` (dispose-race only) |
| Q06 `KafkaMessageTransport` ignores CancellationToken on Flush/IsHealthy       | CONFIRMED       | `KafkaMessageTransportCancellationTests.cs` |

Six new tests, six new verification documents in `audit/verification/`.
All tests compile against the public API on net8.0/net9.0/net10.0 (verified via `dotnet build`).
The Q03 test is intentionally a reflection-based contract test because the public constructor does
not yet accept a `TimeProvider` (blocked-by-API).

Phase 3 builders should fix the underlying defects in a follow-up PR; this PR intentionally leaves
the failing tests in place.

## Test plan

- [ ] `dotnet build tests/NetEvolve.Pulse.Tests.Unit/NetEvolve.Pulse.Tests.Unit.csproj` succeeds on net8.0, net9.0, net10.0 (already verified locally)
- [ ] Each new test fails today with the documented assertion
- [ ] Each verification doc cites real file:line evidence