### PR TITLE
chore(deps): pin SQLitePCLRaw.lib.e_sqlite3 to 2.1.12

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,8 +20,4 @@
     <InternalsVisibleTo Include="NetEvolve.Pulse.Tests.Integration" />
     <InternalsVisibleTo Include="NetEvolve.Pulse.Tests.Unit" />
   </ItemGroup>
-
-  <ItemGroup Label="Temporary NuGet audit suppression (no fixed version yet): https://github.com/advisories/GHSA-2m69-gcr7-jv3q">
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
-  </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,6 +45,7 @@
     <PackageVersion Include="RabbitMQ.Client" Version="7.2.1" />
     <PackageVersion Include="SharpCompress" Version="0.50.0" />
     <PackageVersion Include="Snappier" Version="1.3.1" />
+    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.12" />
     <PackageVersion Include="StackExchange.Redis" Version="3.0.17" />
     <PackageVersion Include="Testcontainers" Version="4.13.0" />
     <PackageVersion Include="Testcontainers.CosmosDb" Version="4.13.0" />


### PR DESCRIPTION
## Summary
- Pin `SQLitePCLRaw.lib.e_sqlite3` (transitive via `Microsoft.Data.Sqlite`) to 2.1.12, which contains the fixed e_sqlite3 build for GHSA-2m69-gcr7-jv3q.
- Remove the now-unneeded temporary `NuGetAuditSuppress` entry for GHSA-2m69-gcr7-jv3q from `Directory.Build.props`.

Same fix as dailydevops/healthchecks#1912.

## Test plan
- [x] `dotnet restore` clean, no NU1903 warning
- [x] `dotnet list package --include-transitive` confirms `SQLitePCLRaw.lib.e_sqlite3` resolves to 2.1.12
- [x] `dotnet build` succeeds with 0 warnings