### PR TITLE
perf(polly): use state-passing ExecuteAsync overload in interceptors

### DIFF
--- a/src/NetEvolve.Pulse.Polly/Interceptors/PollyEventInterceptor.cs
+++ b/src/NetEvolve.Pulse.Polly/Interceptors/PollyEventInterceptor.cs
@@ -114,7 +114,11 @@ internal sealed class PollyEventInterceptor<TEvent> : IEventInterceptor<TEvent>
         ArgumentNullException.ThrowIfNull(handler);
 
         await _pipeline
-            .ExecuteAsync(async token => await handler(message, token).ConfigureAwait(false), cancellationToken)
+            .ExecuteAsync(
+                static (state, token) => new ValueTask(state.Handler(state.Message, token)),
+                (Handler: handler, Message: message),
+                cancellationToken
+            )
             .ConfigureAwait(false);
     }
 }

--- a/src/NetEvolve.Pulse.Polly/Interceptors/PollyRequestInterceptor.cs
+++ b/src/NetEvolve.Pulse.Polly/Interceptors/PollyRequestInterceptor.cs
@@ -115,7 +115,11 @@ internal sealed class PollyRequestInterceptor<TRequest, TResponse> : IRequestInt
         ArgumentNullException.ThrowIfNull(handler);
 
         return await _pipeline
-            .ExecuteAsync(async token => await handler(request, token).ConfigureAwait(false), cancellationToken)
+            .ExecuteAsync(
+                static (state, token) => new ValueTask<TResponse>(state.Handler(state.Request, token)),
+                (Handler: handler, Request: request),
+                cancellationToken
+            )
             .ConfigureAwait(false);
     }
 }

--- a/tests/NetEvolve.Pulse.Tests.Unit/Polly/Interceptors/PollyEventInterceptorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Polly/Interceptors/PollyEventInterceptorTests.cs
@@ -129,6 +129,55 @@ public sealed class PollyEventInterceptorTests
     }
 
     [Test]
+    public async Task HandleAsync_WithRetryPolicy_PassesMessageInstanceToHandlerOnEachAttempt(
+        CancellationToken cancellationToken
+    )
+    {
+        // Arrange
+        var pipeline = new ResiliencePipelineBuilder()
+            .AddRetry(new RetryStrategyOptions { MaxRetryAttempts = 1, Delay = TimeSpan.FromMilliseconds(10) })
+            .Build();
+        var serviceProvider = CreateServiceProvider<TestEvent>(pipeline);
+        var interceptor = new PollyEventInterceptor<TestEvent>(serviceProvider);
+        var message = new TestEvent();
+
+        var callCount = 0;
+        var allSameMessageInstance = true;
+        var tokenNeverCanceled = true;
+
+        // Act
+        await interceptor
+            .HandleAsync(
+                message,
+                (msg, ct) =>
+                {
+                    callCount++;
+                    if (!ReferenceEquals(msg, message))
+                    {
+                        allSameMessageInstance = false;
+                    }
+
+                    if (ct.IsCancellationRequested)
+                    {
+                        tokenNeverCanceled = false;
+                    }
+
+                    return callCount < 2
+                        ? Task.FromException(new InvalidOperationException("Transient failure"))
+                        : Task.CompletedTask;
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        // Assert - the state-passing execution path forwards the exact event instance
+        // and a live cancellation token to the handler on every attempt
+        _ = await Assert.That(callCount).IsEqualTo(2);
+        _ = await Assert.That(allSameMessageInstance).IsTrue();
+        _ = await Assert.That(tokenNeverCanceled).IsTrue();
+    }
+
+    [Test]
     public async Task HandleAsync_WithRetryPolicy_RetriesOnFailure(CancellationToken cancellationToken)
     {
         // Arrange

--- a/tests/NetEvolve.Pulse.Tests.Unit/Polly/Interceptors/PollyRequestInterceptorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Polly/Interceptors/PollyRequestInterceptorTests.cs
@@ -123,6 +123,56 @@ public sealed class PollyRequestInterceptorTests
     }
 
     [Test]
+    public async Task HandleAsync_WithRetryPolicy_PassesRequestInstanceToHandlerOnEachAttempt(
+        CancellationToken cancellationToken
+    )
+    {
+        // Arrange
+        var pipeline = new ResiliencePipelineBuilder<string>()
+            .AddRetry(new RetryStrategyOptions<string> { MaxRetryAttempts = 1, Delay = TimeSpan.FromMilliseconds(10) })
+            .Build();
+        var serviceProvider = CreateServiceProvider<TestCommand, string>(pipeline);
+        var interceptor = new PollyRequestInterceptor<TestCommand, string>(serviceProvider);
+        var request = new TestCommand();
+
+        var callCount = 0;
+        var allSameRequestInstance = true;
+        var tokenNeverCanceled = true;
+
+        // Act
+        var result = await interceptor
+            .HandleAsync(
+                request,
+                (req, ct) =>
+                {
+                    callCount++;
+                    if (!ReferenceEquals(req, request))
+                    {
+                        allSameRequestInstance = false;
+                    }
+
+                    if (ct.IsCancellationRequested)
+                    {
+                        tokenNeverCanceled = false;
+                    }
+
+                    return callCount < 2
+                        ? Task.FromException<string>(new InvalidOperationException("Transient failure"))
+                        : Task.FromResult("success");
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        // Assert - the state-passing execution path forwards the exact request instance
+        // and a live cancellation token to the handler on every attempt
+        _ = await Assert.That(result).IsEqualTo("success");
+        _ = await Assert.That(callCount).IsEqualTo(2);
+        _ = await Assert.That(allSameRequestInstance).IsTrue();
+        _ = await Assert.That(tokenNeverCanceled).IsTrue();
+    }
+
+    [Test]
     public async Task HandleAsync_WithRetryPolicy_RetriesOnFailure(CancellationToken cancellationToken)
     {
         // Arrange


### PR DESCRIPTION
The request and event interceptors captured the handler and message in a
closure and wrapped the Task-returning handler in an extra async lambda,
allocating a display class, a delegate, and an additional async state machine
per dispatch attempt. Both now use Polly's state-passing ExecuteAsync overload
with a static lambda and tuple state, removing those per-dispatch allocations.