### PR TITLE
fix(aspnetcore): parse Accept header media types for NDJSON negotiation

### DIFF
--- a/src/NetEvolve.Pulse.AspNetCore/EndpointRouteBuilderExtensions.cs
+++ b/src/NetEvolve.Pulse.AspNetCore/EndpointRouteBuilderExtensions.cs
@@ -7,6 +7,8 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Net.Http.Headers;
 using NetEvolve.Pulse.Extensibility;
 
 /// <summary>
@@ -191,9 +193,11 @@ public static class EndpointRouteBuilderExtensions
             {
                 var items = mediator.StreamQueryAsync<TQuery, TResponse>(query, cancellationToken);
 
-                // RFC 7231 §3.1.1.1 makes media types case-insensitive; match accordingly so
-                // clients sending e.g. "Application/X-NDJSON" still receive the NDJSON variant.
-                if (request.Headers.Accept.Contains(NdjsonContentType, StringComparer.OrdinalIgnoreCase))
+                // RFC 7231 §3.1.1.1 makes media types case-insensitive, and the Accept header
+                // may contain comma-separated media types and/or q-value parameters (e.g.
+                // "application/x-ndjson;q=0.9"). Parse it properly instead of comparing whole
+                // header values.
+                if (AcceptsNdjson(request.Headers.Accept))
                 {
                     return (IResult)
                         TypedResults.Stream(
@@ -213,6 +217,13 @@ public static class EndpointRouteBuilderExtensions
             }
         );
     }
+
+    private static bool AcceptsNdjson(StringValues acceptHeader) =>
+        MediaTypeHeaderValue.TryParseList(acceptHeader, out var mediaTypes)
+        && mediaTypes is not null
+        && mediaTypes.Any(mediaType =>
+            mediaType.MediaType.Equals(NdjsonContentType, StringComparison.OrdinalIgnoreCase)
+        );
 
 #if !NET10_0_OR_GREATER
     private static Func<Stream, Task> ExecuteStreamReadServerSentEvents<TResponse>(

--- a/tests/NetEvolve.Pulse.Tests.Unit/AspNetCore/EndpointRouteBuilderExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/AspNetCore/EndpointRouteBuilderExtensionsTests.cs
@@ -302,6 +302,27 @@ public sealed class EndpointRouteBuilderExtensionsTests
         _ = await Assert.That(body).Contains("\"alpha\"\n");
     }
 
+    // INVARIANT: The Accept header may carry a q-value parameter (e.g. "application/x-ndjson;q=0.9")
+    // or be part of a comma-separated list; whole-string equality must not be used to detect it.
+    [Test]
+    public async Task MapStreamQuery_WithNdjsonAcceptQValue_ReturnsNdjson(CancellationToken cancellationToken)
+    {
+        using var host = await CreateTestHostAsync(["alpha"], cancellationToken).ConfigureAwait(false);
+        var client = host.GetTestClient();
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/x-ndjson", 0.9));
+
+        using var response = await client
+            .GetAsync(new Uri("/stream", UriKind.Relative), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        _ = await Assert.That(response.Content.Headers.ContentType?.MediaType).IsEqualTo("application/x-ndjson");
+
+        var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(body).Contains("\"alpha\"\n");
+    }
+
     // MapStreamQuery — empty stream
 
     [Test]


### PR DESCRIPTION
Whole-string equality against StringValues entries missed comma-separated
Accept lists and q-value parameters (e.g. application/x-ndjson;q=0.9), so
clients negotiating NDJSON silently received SSE. Parse the header with
MediaTypeHeaderValue.TryParseList and match on MediaType instead.