### PR TITLE
fix(aspnetcore): only swallow OperationCanceledException on client disconnect

### DIFF
--- a/src/NetEvolve.Pulse.AspNetCore/EndpointRouteBuilderExtensions.cs
+++ b/src/NetEvolve.Pulse.AspNetCore/EndpointRouteBuilderExtensions.cs
@@ -230,7 +230,7 @@ public static class EndpointRouteBuilderExtensions
                     await outputStream.FlushAsync(cancellationToken).ConfigureAwait(false);
                 }
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
                 // Client disconnected cleanly; do not re-throw.
             }
@@ -253,7 +253,7 @@ public static class EndpointRouteBuilderExtensions
                     await outputStream.FlushAsync(cancellationToken).ConfigureAwait(false);
                 }
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
                 // Client disconnected cleanly; do not re-throw.
             }

--- a/tests/NetEvolve.Pulse.Tests.Unit/AspNetCore/EndpointRouteBuilderExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/AspNetCore/EndpointRouteBuilderExtensionsTests.cs
@@ -338,6 +338,27 @@ public sealed class EndpointRouteBuilderExtensionsTests
             .Throws<InvalidOperationException>();
     }
 
+    // MapStreamQuery — cancellation not caused by client disconnect
+
+    [Test]
+    public async Task MapStreamQuery_WhenForeignCancellationThrown_PropagatesAsError(
+        CancellationToken cancellationToken
+    )
+    {
+        using var host = await CreateForeignCancellationTestHostAsync(cancellationToken).ConfigureAwait(false);
+        var client = host.GetTestClient();
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/x-ndjson"));
+
+        // The handler throws an OperationCanceledException tied to an unrelated token while the
+        // client stays connected (the request token is never canceled). This must not be treated
+        // as a clean client disconnect; it must propagate as an error.
+        _ = await Assert
+            .That(async () =>
+                await client.GetAsync(new Uri("/stream", UriKind.Relative), cancellationToken).ConfigureAwait(false)
+            )
+            .Throws<OperationCanceledException>();
+    }
+
     // MapStreamQuery — client disconnect
 
     [Test]
@@ -406,6 +427,32 @@ public sealed class EndpointRouteBuilderExtensionsTests
                     _ = services.AddRouting();
                     _ = services.AddSingleton<IStreamQueryHandler<TestStreamQuery, string>>(
                         new ThrowingStreamQueryHandler()
+                    );
+                    _ = services.AddPulse(_ => { });
+                });
+                _ = webBuilder.Configure(app =>
+                {
+                    _ = app.UseRouting();
+                    _ = app.UseEndpoints(endpoints => endpoints.MapStreamQuery<TestStreamQuery, string>("/stream"));
+                });
+            })
+            .Build();
+
+        await host.StartAsync(cancellationToken).ConfigureAwait(false);
+        return host;
+    }
+
+    private static async Task<IHost> CreateForeignCancellationTestHostAsync(CancellationToken cancellationToken)
+    {
+        var host = new HostBuilder()
+            .ConfigureWebHost(webBuilder =>
+            {
+                _ = webBuilder.UseTestServer();
+                _ = webBuilder.ConfigureServices(services =>
+                {
+                    _ = services.AddRouting();
+                    _ = services.AddSingleton<IStreamQueryHandler<TestStreamQuery, string>>(
+                        new ForeignCancellationStreamQueryHandler()
                     );
                     _ = services.AddPulse(_ => { });
                 });
@@ -497,6 +544,20 @@ public sealed class EndpointRouteBuilderExtensionsTests
         )
         {
             await Task.FromException(new InvalidOperationException("Handler failure.")).ConfigureAwait(false);
+            yield break;
+        }
+    }
+
+    private sealed class ForeignCancellationStreamQueryHandler : IStreamQueryHandler<TestStreamQuery, string>
+    {
+        public async IAsyncEnumerable<string> HandleAsync(
+            TestStreamQuery request,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default
+        )
+        {
+            using var foreignCts = new CancellationTokenSource();
+            await foreignCts.CancelAsync().ConfigureAwait(false);
+            foreignCts.Token.ThrowIfCancellationRequested();
             yield break;
         }
     }


### PR DESCRIPTION
Both stream writers caught every OperationCanceledException as a clean
disconnect, silently truncating the response when a foreign cancellation
(e.g. an internal timeout) was thrown instead. Guard the catch with a
filter on cancellationToken.IsCancellationRequested so unrelated
cancellations propagate as errors.