### PR TITLE
perf(aspnetcore): hoist NDJSON newline delimiter to a static buffer

### DIFF
--- a/src/NetEvolve.Pulse.AspNetCore/EndpointRouteBuilderExtensions.cs
+++ b/src/NetEvolve.Pulse.AspNetCore/EndpointRouteBuilderExtensions.cs
@@ -19,6 +19,8 @@ public static class EndpointRouteBuilderExtensions
 {
     private const string NdjsonContentType = "application/x-ndjson";
 
+    private static readonly byte[] NdjsonNewLine = [(byte)'\n'];
+
     /// <summary>
     /// Maps a command to an HTTP endpoint. The command is bound from the request body,
     /// dispatched via <see cref="IMediatorSendOnly.SendAsync{TCommand, TResponse}"/>, and the result
@@ -260,7 +262,7 @@ public static class EndpointRouteBuilderExtensions
                 {
                     var json = JsonSerializer.SerializeToUtf8Bytes(item);
                     await outputStream.WriteAsync(json, cancellationToken).ConfigureAwait(false);
-                    await outputStream.WriteAsync(new byte[] { (byte)'\n' }, cancellationToken).ConfigureAwait(false);
+                    await outputStream.WriteAsync(NdjsonNewLine, cancellationToken).ConfigureAwait(false);
                     await outputStream.FlushAsync(cancellationToken).ConfigureAwait(false);
                 }
             }

--- a/tests/NetEvolve.Pulse.Tests.Unit/AspNetCore/EndpointRouteBuilderExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/AspNetCore/EndpointRouteBuilderExtensionsTests.cs
@@ -281,6 +281,26 @@ public sealed class EndpointRouteBuilderExtensionsTests
         _ = await Assert.That(body).Contains("\"beta\"\n");
     }
 
+    // MapStreamQuery — NDJSON newline delimiter
+
+    [Test]
+    public async Task MapStreamQuery_WithMultipleItems_WritesExactlyOneNewlinePerItem(
+        CancellationToken cancellationToken
+    )
+    {
+        using var host = await CreateTestHostAsync(["alpha", "beta"], cancellationToken).ConfigureAwait(false);
+        var client = host.GetTestClient();
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/x-ndjson"));
+
+        using var response = await client
+            .GetAsync(new Uri("/stream", UriKind.Relative), cancellationToken)
+            .ConfigureAwait(false);
+
+        var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(body).IsEqualTo("\"alpha\"\n\"beta\"\n");
+    }
+
     // INVARIANT: Media types are case-insensitive per RFC 7231 §3.1.1.1, so a request
     // sending the upper-cased / mixed-case ndjson media type must be treated as ndjson.
     [Test]


### PR DESCRIPTION
The NDJSON stream writer allocated a fresh byte[1] for the newline
delimiter on every streamed item, adding avoidable Gen0 pressure on
long-running streams. Reuse a single static readonly buffer instead.