### PR TITLE
perf(azureservicebus): cache ServiceBusSender instances per entity

### DIFF
--- a/src/NetEvolve.Pulse.AzureServiceBus/Outbox/AzureServiceBusMessageTransport.cs
+++ b/src/NetEvolve.Pulse.AzureServiceBus/Outbox/AzureServiceBusMessageTransport.cs
@@ -1,5 +1,6 @@
 ﻿namespace NetEvolve.Pulse.Outbox;
 
+using System.Collections.Concurrent;
 using System.Globalization;
 using Azure.Messaging.ServiceBus;
 using Microsoft.Extensions.Options;
@@ -15,6 +16,7 @@ public sealed class AzureServiceBusMessageTransport : IMessageTransport, IAsyncD
     private readonly ServiceBusClient _client;
     private readonly ITopicNameResolver _topicNameResolver;
     private readonly AzureServiceBusTransportOptions _options;
+    private readonly ConcurrentDictionary<string, ServiceBusSender> _senders = new(StringComparer.Ordinal);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AzureServiceBusMessageTransport"/> class.
@@ -43,12 +45,9 @@ public sealed class AzureServiceBusMessageTransport : IMessageTransport, IAsyncD
         ArgumentNullException.ThrowIfNull(message);
 
         var topicName = _topicNameResolver.Resolve(message);
-        var sender = _client.CreateSender(topicName);
-        await using (sender.ConfigureAwait(false))
-        {
-            var serviceBusMessage = CreateServiceBusMessage(message);
-            await sender.SendMessageAsync(serviceBusMessage, cancellationToken).ConfigureAwait(false);
-        }
+        var sender = GetSender(topicName);
+        var serviceBusMessage = CreateServiceBusMessage(message);
+        await sender.SendMessageAsync(serviceBusMessage, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -63,14 +62,11 @@ public sealed class AzureServiceBusMessageTransport : IMessageTransport, IAsyncD
         {
             foreach (var group in messagesByTopic)
             {
-                var sender = _client.CreateSender(group.Key);
-                await using (sender.ConfigureAwait(false))
+                var sender = GetSender(group.Key);
+                foreach (var message in group)
                 {
-                    foreach (var message in group)
-                    {
-                        var serviceBusMessage = CreateServiceBusMessage(message);
-                        await sender.SendMessageAsync(serviceBusMessage, cancellationToken).ConfigureAwait(false);
-                    }
+                    var serviceBusMessage = CreateServiceBusMessage(message);
+                    await sender.SendMessageAsync(serviceBusMessage, cancellationToken).ConfigureAwait(false);
                 }
             }
 
@@ -79,14 +75,14 @@ public sealed class AzureServiceBusMessageTransport : IMessageTransport, IAsyncD
 
         foreach (var group in messagesByTopic)
         {
-            var sender = _client.CreateSender(group.Key);
-            await using (sender.ConfigureAwait(false))
-            {
-                var serviceBusMessages = group.Select(CreateServiceBusMessage).ToList();
-                await sender.SendMessagesAsync(serviceBusMessages, cancellationToken).ConfigureAwait(false);
-            }
+            var sender = GetSender(group.Key);
+            var serviceBusMessages = group.Select(CreateServiceBusMessage).ToList();
+            await sender.SendMessagesAsync(serviceBusMessages, cancellationToken).ConfigureAwait(false);
         }
     }
+
+    private ServiceBusSender GetSender(string topicName) =>
+        _senders.GetOrAdd(topicName, static (name, client) => client.CreateSender(name), _client);
 
     /// <inheritdoc />
     public Task<bool> IsHealthyAsync(CancellationToken cancellationToken = default)
@@ -133,5 +129,15 @@ public sealed class AzureServiceBusMessageTransport : IMessageTransport, IAsyncD
     }
 
     /// <inheritdoc />
-    public ValueTask DisposeAsync() => ValueTask.CompletedTask; // Do not dispose injected dependencies
+    public async ValueTask DisposeAsync()
+    {
+        // Dispose only the senders owned by this transport; the injected client is managed externally.
+        foreach (var topicName in _senders.Keys)
+        {
+            if (_senders.TryRemove(topicName, out var sender))
+            {
+                await sender.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+    }
 }

--- a/tests/NetEvolve.Pulse.Tests.Unit/AzureServiceBus/AzureServiceBusMessageTransportTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/AzureServiceBus/AzureServiceBusMessageTransportTests.cs
@@ -249,6 +249,79 @@ public sealed class AzureServiceBusMessageTransportTests
         }
     }
 
+    // ── Sender caching ────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task SendAsync_Reuses_cached_sender_for_same_topic(CancellationToken cancellationToken)
+    {
+        var fakeClient = new FakeServiceBusClient();
+        await using (fakeClient.ConfigureAwait(false))
+        {
+            var resolver = new FakeTopicNameResolver("orders");
+            var options = Options.Create(new AzureServiceBusTransportOptions());
+
+            var transport = new AzureServiceBusMessageTransport(fakeClient, resolver, options);
+            await using (transport.ConfigureAwait(false))
+            {
+                await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false);
+                await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false);
+                await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false);
+
+                using (Assert.Multiple())
+                {
+                    _ = await Assert.That(fakeClient.CreateSenderCalls["orders"]).IsEqualTo(1);
+                    _ = await Assert.That(fakeClient.GetSender("orders")!.SentMessages.Count).IsEqualTo(3);
+                    _ = await Assert.That(fakeClient.GetSender("orders")!.IsDisposed).IsFalse();
+                }
+            }
+        }
+    }
+
+    [Test]
+    public async Task SendBatchAsync_Reuses_cached_sender_across_invocations(CancellationToken cancellationToken)
+    {
+        var fakeClient = new FakeServiceBusClient();
+        await using (fakeClient.ConfigureAwait(false))
+        {
+            var resolver = new FakeTopicNameResolver("orders");
+            var options = Options.Create(new AzureServiceBusTransportOptions { EnableBatching = true });
+
+            var transport = new AzureServiceBusMessageTransport(fakeClient, resolver, options);
+            await using (transport.ConfigureAwait(false))
+            {
+                await transport
+                    .SendBatchAsync([CreateOutboxMessage(), CreateOutboxMessage()], cancellationToken)
+                    .ConfigureAwait(false);
+                await transport.SendBatchAsync([CreateOutboxMessage()], cancellationToken).ConfigureAwait(false);
+
+                using (Assert.Multiple())
+                {
+                    _ = await Assert.That(fakeClient.CreateSenderCalls["orders"]).IsEqualTo(1);
+                    _ = await Assert.That(fakeClient.GetSender("orders")!.BatchedMessages.Count).IsEqualTo(2);
+                    _ = await Assert.That(fakeClient.GetSender("orders")!.IsDisposed).IsFalse();
+                }
+            }
+        }
+    }
+
+    [Test]
+    public async Task DisposeAsync_Disposes_cached_senders(CancellationToken cancellationToken)
+    {
+        var fakeClient = new FakeServiceBusClient();
+        await using (fakeClient.ConfigureAwait(false))
+        {
+            var resolver = new FakeTopicNameResolver("orders");
+            var options = Options.Create(new AzureServiceBusTransportOptions());
+
+            var transport = new AzureServiceBusMessageTransport(fakeClient, resolver, options);
+            await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false);
+
+            await transport.DisposeAsync().ConfigureAwait(false);
+
+            _ = await Assert.That(fakeClient.GetSender("orders")!.IsDisposed).IsTrue();
+        }
+    }
+
     // ── SendBatchAsync null/empty guards ──────────────────────────────────────
 
     [Test]
@@ -567,10 +640,15 @@ public sealed class AzureServiceBusMessageTransportTests
 
         public Dictionary<string, Exception> FailuresByTopic { get; } = new(StringComparer.Ordinal);
 
+        public Dictionary<string, int> CreateSenderCalls { get; } = new(StringComparer.Ordinal);
+
         public FakeServiceBusSender? GetSender(string name) => _senders.TryGetValue(name, out var s) ? s : null;
 
         public override ServiceBusSender CreateSender(string queueOrTopicName)
         {
+            CreateSenderCalls[queueOrTopicName] = CreateSenderCalls.TryGetValue(queueOrTopicName, out var count)
+                ? count + 1
+                : 1;
             var sender = new FakeServiceBusSender();
             if (FailuresByTopic.TryGetValue(queueOrTopicName, out var failure))
             {
@@ -595,6 +673,8 @@ public sealed class AzureServiceBusMessageTransportTests
         public List<IReadOnlyList<ServiceBusMessage>> BatchedMessages { get; } = [];
 
         public Exception? FailureToRaise { get; set; }
+
+        public bool IsDisposed { get; private set; }
 
         public override Task SendMessageAsync(ServiceBusMessage message, CancellationToken cancellationToken = default)
         {
@@ -625,6 +705,10 @@ public sealed class AzureServiceBusMessageTransportTests
             "CA2215",
             Justification = "Test fake with no underlying transport; calling base would throw NullReferenceException."
         )]
-        public override ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public override ValueTask DisposeAsync()
+        {
+            IsDisposed = true;
+            return ValueTask.CompletedTask;
+        }
     }
 }


### PR DESCRIPTION
The transport created and disposed a ServiceBusSender for every send,
paying an AMQP link attach/detach round trip per message. Senders are
now cached per queue/topic in a ConcurrentDictionary, reused across
sends, and disposed with the transport, while the injected client
remains untouched.