### PR TITLE
fix(caching): add in-process single-flight protection for cache misses

### DIFF
--- a/src/NetEvolve.Pulse/Interceptors/DistributedCacheQueryInterceptor.cs
+++ b/src/NetEvolve.Pulse/Interceptors/DistributedCacheQueryInterceptor.cs
@@ -21,6 +21,11 @@ using NetEvolve.Pulse.Extensibility.Caching;
 /// When no cached entry exists, the handler is invoked and the response is serialized using the
 /// configured <see cref="IPayloadSerializer"/> of <see cref="DistributedCacheQueryInterceptor{TQuery, TResponse}"/>
 /// and stored in the cache before being returned to the caller.
+/// <para><strong>Stampede Protection:</strong></para>
+/// Concurrent in-process misses for the same cache key are coordinated through striped per-key locks:
+/// only one caller executes the handler while the others wait and are served from the freshly populated
+/// cache. Keys may share a stripe, so unrelated misses can occasionally serialize. Cross-process
+/// stampede protection (e.g. a distributed lock) is out of scope for this interceptor.
 /// <para><strong>No Cache Registered:</strong></para>
 /// When <see cref="IDistributedCache"/> is not registered in the DI container, the interceptor
 /// falls through to the handler without error.
@@ -39,6 +44,12 @@ using NetEvolve.Pulse.Extensibility.Caching;
 internal sealed class DistributedCacheQueryInterceptor<TQuery, TResponse> : IQueryInterceptor<TQuery, TResponse>
     where TQuery : IQuery<TResponse>
 {
+    /// <summary>
+    /// Striped per-key locks providing in-process single-flight execution on cache misses.
+    /// Static so the protection spans all (scoped) interceptor instances of this closed generic type.
+    /// </summary>
+    private static readonly SemaphoreSlim[] KeyLocks = CreateKeyLocks();
+
     private readonly IServiceProvider _serviceProvider;
     private readonly QueryCachingOptions _options;
     private readonly IPayloadSerializer _payloadSerializer;
@@ -98,17 +109,63 @@ internal sealed class DistributedCacheQueryInterceptor<TQuery, TResponse> : IQue
             await cache.RemoveAsync(cacheKey, cancellationToken).ConfigureAwait(false);
         }
 
-        var response = await handler(request, cancellationToken).ConfigureAwait(false);
-
-        if (response is not null)
+        var keyLock = KeyLocks[GetKeyLockIndex(cacheKey)];
+        await keyLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
         {
-            var serialized = _payloadSerializer.SerializeToBytes(response);
-            var entryOptions = GetCacheEntryOptions(cacheableQuery);
-            await cache.SetAsync(cacheKey, serialized, entryOptions, cancellationToken).ConfigureAwait(false);
+            // Re-check after acquiring the lock: a concurrent in-process caller may have
+            // populated the cache while this caller was waiting.
+            cachedBytes = await cache.GetAsync(cacheKey, cancellationToken).ConfigureAwait(false);
+            if (cachedBytes is not null)
+            {
+                var cached = _payloadSerializer.Deserialize<TResponse>(cachedBytes);
+                if (cached is not null)
+                {
+                    return cached;
+                }
+
+                await cache.RemoveAsync(cacheKey, cancellationToken).ConfigureAwait(false);
+            }
+
+            var response = await handler(request, cancellationToken).ConfigureAwait(false);
+
+            if (response is not null)
+            {
+                var serialized = _payloadSerializer.SerializeToBytes(response);
+                var entryOptions = GetCacheEntryOptions(cacheableQuery);
+                await cache.SetAsync(cacheKey, serialized, entryOptions, cancellationToken).ConfigureAwait(false);
+            }
+
+            return response;
+        }
+        finally
+        {
+            _ = keyLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Creates the fixed set of stripe locks used for in-process single-flight coordination.
+    /// </summary>
+    /// <returns>An array of single-count <see cref="SemaphoreSlim"/> instances.</returns>
+    private static SemaphoreSlim[] CreateKeyLocks()
+    {
+        var locks = new SemaphoreSlim[32];
+        for (var i = 0; i < locks.Length; i++)
+        {
+            locks[i] = new SemaphoreSlim(1, 1);
         }
 
-        return response;
+        return locks;
     }
+
+    /// <summary>
+    /// Maps a cache key to its stripe lock index.
+    /// </summary>
+    /// <param name="cacheKey">The cache key to map.</param>
+    /// <returns>The index of the stripe lock responsible for the key.</returns>
+    private static uint GetKeyLockIndex(string cacheKey) =>
+        (uint)StringComparer.Ordinal.GetHashCode(cacheKey) % (uint)KeyLocks.Length;
 
     /// <summary>
     /// Determines the appropriate cache entry options based on the query's expiry and the configured expiration mode.

--- a/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/DistributedCacheQueryInterceptorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/DistributedCacheQueryInterceptorTests.cs
@@ -523,6 +523,64 @@ public class DistributedCacheQueryInterceptorTests
         public string? CorrelationId { get; set; }
     }
 
+    [Test]
+    public async Task HandleAsync_ConcurrentCacheMisses_ExecutesHandlerOnlyOnce(CancellationToken cancellationToken)
+    {
+        var services = new ServiceCollection();
+        _ = services.AddDistributedMemoryCache();
+        var provider = services.BuildServiceProvider();
+        await using (provider.ConfigureAwait(false))
+        {
+            // Two interceptor instances mirror the scoped registration: each request gets its own
+            // instance, so stampede protection must work across instances.
+            var interceptor1 = new DistributedCacheQueryInterceptor<CacheableQuery, string>(
+                provider,
+                DefaultOptions,
+                DefaultSerializer
+            );
+            var interceptor2 = new DistributedCacheQueryInterceptor<CacheableQuery, string>(
+                provider,
+                DefaultOptions,
+                DefaultSerializer
+            );
+            var query = new CacheableQuery("stampede-key");
+
+            var executionCount = 0;
+            using var handlerEntered = new SemaphoreSlim(0, int.MaxValue);
+            var releaseHandler = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            async Task<string> Handler(CacheableQuery request, CancellationToken token)
+            {
+                _ = Interlocked.Increment(ref executionCount);
+                _ = handlerEntered.Release();
+#pragma warning disable VSTHRD003 // TaskCompletionSource gate is signaled by the test, not started here
+                await releaseHandler.Task.ConfigureAwait(false);
+#pragma warning restore VSTHRD003
+                return "value";
+            }
+
+            var firstCall = interceptor1.HandleAsync(query, Handler, cancellationToken);
+            await handlerEntered.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+            // A second identical query misses the cache while the first handler is still running.
+            var secondCall = interceptor2.HandleAsync(query, Handler, cancellationToken);
+
+            // Without single-flight protection the second caller enters the handler almost
+            // immediately; give it ample time so the defect is observed reliably.
+            _ = await handlerEntered.WaitAsync(TimeSpan.FromSeconds(1), cancellationToken).ConfigureAwait(false);
+
+            releaseHandler.SetResult();
+            var results = await Task.WhenAll(firstCall, secondCall).ConfigureAwait(false);
+
+            using (Assert.Multiple())
+            {
+                _ = await Assert.That(results[0]).IsEqualTo("value");
+                _ = await Assert.That(results[1]).IsEqualTo("value");
+                _ = await Assert.That(executionCount).IsEqualTo(1);
+            }
+        }
+    }
+
     private sealed record CacheableQuery(string Key) : ICacheableQuery<string>
     {
         public string? CausationId { get; set; }


### PR DESCRIPTION
Concurrent identical cacheable queries that missed the cache all executed
the handler, producing the thundering-herd load spike the cache exists to
prevent. Misses now coordinate through striped per-key semaphores shared
across scoped interceptor instances, with a re-check after lock
acquisition; cross-process stampede protection remains out of scope and is
documented as such.