### PR TITLE
fix(idempotency): reserve idempotency key before command execution

### DIFF
--- a/src/NetEvolve.Pulse.Extensibility/Idempotency/IIdempotencyStore.cs
+++ b/src/NetEvolve.Pulse.Extensibility/Idempotency/IIdempotencyStore.cs
@@ -16,9 +16,11 @@ namespace NetEvolve.Pulse.Extensibility.Idempotency;
 /// <item><description>Implementations SHOULD use distributed storage (Redis, SQL, etc.) in multi-instance deployments.</description></item>
 /// </list>
 /// <para><strong>Atomicity Note:</strong></para>
-/// The interceptor calls <see cref="ExistsAsync"/> and <see cref="StoreAsync"/> in two separate steps.
-/// If strict at-most-once semantics are required, implementations SHOULD provide an atomic
-/// check-and-set operation internally (e.g., via a database unique constraint or a Redis SET NX).
+/// The interceptor reserves the key via <see cref="TryReserveAsync"/> BEFORE the handler executes.
+/// The default implementation of <see cref="TryReserveAsync"/> composes <see cref="ExistsAsync"/> and
+/// <see cref="StoreAsync"/> and is therefore not atomic. If strict at-most-once semantics are required,
+/// implementations SHOULD override <see cref="TryReserveAsync"/> with an atomic check-and-set operation
+/// (e.g., via a database unique constraint or a Redis SET NX).
 /// </remarks>
 /// <example>
 /// <code>
@@ -60,4 +62,32 @@ public interface IIdempotencyStore
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>A task representing the asynchronous store operation.</returns>
     Task StoreAsync(string idempotencyKey, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Attempts to reserve the specified idempotency key before the corresponding command executes,
+    /// so that concurrent or subsequent submissions of the same key are rejected.
+    /// </summary>
+    /// <param name="idempotencyKey">The idempotency key to reserve. Must not be <see langword="null"/> or empty.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>
+    /// <see langword="true"/> if the key was newly reserved and the command may execute;
+    /// <see langword="false"/> if the key is already present, indicating a duplicate submission.
+    /// </returns>
+    /// <remarks>
+    /// The default implementation composes <see cref="ExistsAsync"/> and <see cref="StoreAsync"/> and
+    /// is therefore not atomic — two concurrent calls may both observe an absent key within the small
+    /// window between the two operations. Implementations backed by storage that supports an atomic
+    /// check-and-set (database unique constraint, Redis <c>SET NX</c>) SHOULD override this member to
+    /// close that window and provide strict at-most-once semantics.
+    /// </remarks>
+    async Task<bool> TryReserveAsync(string idempotencyKey, CancellationToken cancellationToken = default)
+    {
+        if (await ExistsAsync(idempotencyKey, cancellationToken).ConfigureAwait(false))
+        {
+            return false;
+        }
+
+        await StoreAsync(idempotencyKey, cancellationToken).ConfigureAwait(false);
+        return true;
+    }
 }

--- a/src/NetEvolve.Pulse/IdempotencyExtensions.cs
+++ b/src/NetEvolve.Pulse/IdempotencyExtensions.cs
@@ -16,10 +16,11 @@ using NetEvolve.Pulse.Interceptors;
 /// <para><strong>Purpose:</strong></para>
 /// The idempotency interceptor automatically enforces at-most-once execution semantics
 /// for commands that implement <see cref="IIdempotentCommand{TResponse}"/>.
-/// Before delegating to the command handler, the interceptor queries the registered
-/// <see cref="IIdempotencyStore"/>. If the idempotency key has already been stored,
-/// an <see cref="IdempotencyConflictException"/> is thrown. Otherwise the handler executes
-/// and the key is persisted afterwards.
+/// Before delegating to the command handler, the interceptor reserves the idempotency key in the
+/// registered <see cref="IIdempotencyStore"/>. If the key has already been reserved,
+/// an <see cref="IdempotencyConflictException"/> is thrown. Otherwise the handler executes; because
+/// the key is reserved before execution, concurrent duplicate submissions are rejected while the
+/// handler is still running, and a failed execution keeps its key reserved.
 /// <para><strong>Optional Dependency:</strong></para>
 /// If <see cref="IIdempotencyStore"/> is not registered in the DI container, the interceptor
 /// passes through without any store interaction and without error.

--- a/src/NetEvolve.Pulse/Interceptors/IdempotencyCommandInterceptor.cs
+++ b/src/NetEvolve.Pulse/Interceptors/IdempotencyCommandInterceptor.cs
@@ -10,8 +10,8 @@ using NetEvolve.Pulse.Idempotency;
 
 /// <summary>
 /// Request interceptor that enforces idempotency for commands implementing
-/// <see cref="IIdempotentCommand{TResponse}"/> by checking and updating an
-/// <see cref="IIdempotencyStore"/> before and after handler execution.
+/// <see cref="IIdempotentCommand{TResponse}"/> by reserving the idempotency key in an
+/// <see cref="IIdempotencyStore"/> before handler execution.
 /// </summary>
 /// <typeparam name="TRequest">The type of request being intercepted.</typeparam>
 /// <typeparam name="TResponse">The type of response produced by the request.</typeparam>
@@ -20,9 +20,16 @@ using NetEvolve.Pulse.Idempotency;
 /// <list type="number">
 /// <item><description>If the request does not implement <see cref="IIdempotentCommand{TResponse}"/>, the interceptor passes through without any store interaction.</description></item>
 /// <item><description>If <see cref="IIdempotencyStore"/> is not registered in the DI container, the interceptor passes through without any store interaction.</description></item>
-/// <item><description>If <see cref="IIdempotencyStore.ExistsAsync"/> returns <see langword="true"/>, an <see cref="IdempotencyConflictException"/> is thrown.</description></item>
-/// <item><description>Otherwise, the handler is executed and the key is stored via <see cref="IIdempotencyStore.StoreAsync"/> after successful completion.</description></item>
+/// <item><description>If <see cref="IIdempotencyStore.TryReserveAsync"/> returns <see langword="false"/> (the key is already present), an <see cref="IdempotencyConflictException"/> is thrown.</description></item>
+/// <item><description>Otherwise, the key is reserved BEFORE the handler executes, so concurrent duplicate submissions are rejected while the handler is still running.</description></item>
 /// </list>
+/// <para><strong>Semantics:</strong></para>
+/// Reservation before execution provides at-most-once semantics: a command whose handler fails
+/// keeps its key reserved, and retries with the same key are rejected with
+/// <see cref="IdempotencyConflictException"/>. Strict atomicity of the reservation itself depends on
+/// the registered <see cref="IIdempotencyStore"/> implementation of
+/// <see cref="IIdempotencyStore.TryReserveAsync"/>; the non-atomic default leaves a small window
+/// between the existence check and the store operation.
 /// <para><strong>Registration:</strong></para>
 /// Use <c>AddIdempotency()</c> on the <see cref="IMediatorBuilder"/> to register this interceptor.
 /// </remarks>
@@ -67,15 +74,11 @@ internal sealed class IdempotencyCommandInterceptor<TRequest, TResponse> : IRequ
 
         var key = idempotentCommand.IdempotencyKey;
 
-        if (await store.ExistsAsync(key, cancellationToken).ConfigureAwait(false))
+        if (!await store.TryReserveAsync(key, cancellationToken).ConfigureAwait(false))
         {
             throw new IdempotencyConflictException(key);
         }
 
-        var result = await handler(request, cancellationToken).ConfigureAwait(false);
-
-        await store.StoreAsync(key, cancellationToken).ConfigureAwait(false);
-
-        return result;
+        return await handler(request, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/IdempotencyCommandInterceptorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/IdempotencyCommandInterceptorTests.cs
@@ -200,7 +200,7 @@ public sealed class IdempotencyCommandInterceptorTests
     }
 
     [Test]
-    public async Task HandleAsync_HandlerThrows_DoesNotStoreKey(CancellationToken cancellationToken)
+    public async Task HandleAsync_HandlerThrows_KeyRemainsReserved(CancellationToken cancellationToken)
     {
         var store = new TrackingIdempotencyStore();
         var services = new ServiceCollection();
@@ -221,7 +221,11 @@ public sealed class IdempotencyCommandInterceptorTests
             )
             .Throws<InvalidOperationException>();
 
-        _ = await Assert.That(store.StoreCallCount).IsEqualTo(0);
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(store.StoreCallCount).IsEqualTo(1);
+            _ = await Assert.That(store.StoredKey).IsEqualTo("key-throw");
+        }
     }
 
     [Test]
@@ -273,7 +277,7 @@ public sealed class IdempotencyCommandInterceptorTests
     }
 
     [Test]
-    public async Task HandleAsync_VoidCommand_CallsStoreAsyncAfterExecution(CancellationToken cancellationToken)
+    public async Task HandleAsync_VoidCommand_ReservesKeyBeforeExecution(CancellationToken cancellationToken)
     {
         var store = new TrackingIdempotencyStore();
         var services = new ServiceCollection();
@@ -330,6 +334,63 @@ public sealed class IdempotencyCommandInterceptorTests
         }
     }
 
+    [Test]
+    public async Task HandleAsync_ConcurrentDuplicateKey_ExecutesHandlerAtMostOnce(CancellationToken cancellationToken)
+    {
+        var store = new RecordingIdempotencyStore();
+        var services = new ServiceCollection();
+        _ = services.AddSingleton<IIdempotencyStore>(store);
+        var provider = services.BuildServiceProvider();
+        var interceptor = new IdempotencyCommandInterceptor<TestCommand, string>(provider);
+        var command = new TestCommand { IdempotencyKey = "key-race" };
+
+        var executionCount = 0;
+        var firstHandlerEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirstHandler = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var firstCall = interceptor.HandleAsync(
+            command,
+            async (_, _) =>
+            {
+                _ = Interlocked.Increment(ref executionCount);
+                firstHandlerEntered.SetResult();
+#pragma warning disable VSTHRD003 // TaskCompletionSource gate is signaled by the test, not started here
+                await releaseFirstHandler.Task.ConfigureAwait(false);
+#pragma warning restore VSTHRD003
+                return "first";
+            },
+            cancellationToken
+        );
+
+        await firstHandlerEntered.Task.ConfigureAwait(false);
+
+        // A duplicate submission arrives while the first handler is still executing.
+        _ = await Assert
+            .That(async () =>
+                await interceptor
+                    .HandleAsync(
+                        command,
+                        (_, _) =>
+                        {
+                            _ = Interlocked.Increment(ref executionCount);
+                            return Task.FromResult("second");
+                        },
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false)
+            )
+            .Throws<IdempotencyConflictException>();
+
+        releaseFirstHandler.SetResult();
+        var firstResult = await firstCall.ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(firstResult).IsEqualTo("first");
+            _ = await Assert.That(executionCount).IsEqualTo(1);
+        }
+    }
+
     private sealed record TestCommand : IIdempotentCommand<string>
     {
         public string? CausationId { get; set; }
@@ -348,6 +409,30 @@ public sealed class IdempotencyCommandInterceptorTests
     {
         public string? CausationId { get; set; }
         public string? CorrelationId { get; set; }
+    }
+
+    private sealed class RecordingIdempotencyStore : IIdempotencyStore
+    {
+        private readonly HashSet<string> _keys = [];
+        private readonly object _lock = new();
+
+        public Task<bool> ExistsAsync(string idempotencyKey, CancellationToken cancellationToken = default)
+        {
+            lock (_lock)
+            {
+                return Task.FromResult(_keys.Contains(idempotencyKey));
+            }
+        }
+
+        public Task StoreAsync(string idempotencyKey, CancellationToken cancellationToken = default)
+        {
+            lock (_lock)
+            {
+                _ = _keys.Add(idempotencyKey);
+            }
+
+            return Task.CompletedTask;
+        }
     }
 
     private sealed class TrackingIdempotencyStore : IIdempotencyStore


### PR DESCRIPTION
The interceptor checked ExistsAsync, ran the handler, and stored the key
only afterwards, so concurrent submissions with the same key could both
execute. The key is now reserved via a new IIdempotencyStore.TryReserveAsync
default member before the handler runs, closing the race window to the
reservation itself and keeping failed executions from re-running committed
side effects.