### PR TITLE
fix(mediator): resolve event handlers from the caller's scope in PublishAsync

### DIFF
--- a/src/NetEvolve.Pulse/Internals/PulseMediator.cs
+++ b/src/NetEvolve.Pulse/Internals/PulseMediator.cs
@@ -70,10 +70,12 @@ internal sealed partial class PulseMediator : IMediator
     /// The event's <see cref="IEvent.PublishedAt"/> property is automatically set before handlers execute.
     /// If any handler throws an exception, it is logged but does not prevent other handlers from executing.
     /// Event interceptors are applied in reverse registration order, allowing pre- and post-processing.
-    /// A new DI scope is created per invocation so that concurrent publishes each receive isolated scoped
-    /// services, preventing thread-safety violations caused by shared state across parallel calls.
+    /// Handlers are resolved from the same service provider the mediator was resolved from, so scoped
+    /// handlers share the caller's scoped services (e.g. the same DbContext) and can participate in the
+    /// caller's transaction — a prerequisite for atomic outbox writes. When the mediator is resolved from
+    /// the root provider, scoped handler dependencies live in the root scope for the provider's lifetime.
     /// </remarks>
-    public async Task PublishAsync<TEvent>([NotNull] TEvent message, CancellationToken cancellationToken = default)
+    public Task PublishAsync<TEvent>([NotNull] TEvent message, CancellationToken cancellationToken = default)
         where TEvent : IEvent
     {
         ArgumentNullException.ThrowIfNull(message);
@@ -81,23 +83,18 @@ internal sealed partial class PulseMediator : IMediator
         // Set the publication timestamp for tracking purposes
         message.PublishedAt = _timeProvider.GetUtcNow();
 
-        // Create a new scope per publish so concurrent invocations each get isolated
-        // scoped services (e.g. a fresh DbContext), preventing thread-safety violations.
-        var scope = _serviceProvider.CreateAsyncScope();
-        await using (scope.ConfigureAwait(false))
+        // Resolve handlers from the caller's provider so scoped services (e.g. DbContext)
+        // are shared with the publishing code and ambient transactions remain effective.
+        var handlers = _serviceProvider.GetServices<IEventHandler<TEvent>>().ToArray();
+
+        // If there are no handlers, simply return
+        if (handlers.Length == 0)
         {
-            // Retrieve all handlers for the event type from the new scope
-            var handlers = scope.ServiceProvider.GetServices<IEventHandler<TEvent>>().ToArray();
-
-            // If there are no handlers, simply return
-            if (handlers.Length == 0)
-            {
-                return;
-            }
-
-            // Execute handlers through the interceptor pipeline and dispatcher using scoped services
-            await ExecuteAsync(message, handlers, scope.ServiceProvider, cancellationToken).ConfigureAwait(false);
+            return Task.CompletedTask;
         }
+
+        // Execute handlers through the interceptor pipeline and dispatcher using the caller's services
+        return ExecuteAsync(message, handlers, _serviceProvider, cancellationToken);
     }
 
     /// <inheritdoc />

--- a/tests/NetEvolve.Pulse.Tests.Unit/Internals/PulseMediatorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Internals/PulseMediatorTests.cs
@@ -371,6 +371,59 @@ public class PulseMediatorTests
         }
     }
 
+    [Test]
+    public async Task PublishAsync_WithScopedHandler_ResolvesHandlersFromCallerScope(
+        CancellationToken cancellationToken
+    )
+    {
+        var collector = new ScopedDependencyCollector();
+        var services = new ServiceCollection();
+        _ = services.AddLogging();
+        _ = services.AddSingleton(collector);
+        _ = services.AddScoped<ScopedDependency>();
+        _ = services.AddScoped<IEventHandler<TestEvent>, ScopedDependencyCapturingHandler>();
+        var serviceProvider = services.BuildServiceProvider();
+
+        var scope = serviceProvider.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            var logger = scope.ServiceProvider.GetRequiredService<ILogger<PulseMediator>>();
+            var mediator = new PulseMediator(logger, scope.ServiceProvider, TimeProvider.System);
+            var callerDependency = scope.ServiceProvider.GetRequiredService<ScopedDependency>();
+
+            await mediator.PublishAsync(new TestEvent(), cancellationToken).ConfigureAwait(false);
+
+            // The handler must observe the same scoped dependency instance as the caller's scope,
+            // so that e.g. an outbox write shares the caller's DbContext and its transaction.
+            _ = await Assert.That(collector.Captured).IsSameReferenceAs(callerDependency);
+        }
+    }
+
+    private sealed class ScopedDependency;
+
+    private sealed class ScopedDependencyCollector
+    {
+        public ScopedDependency? Captured { get; set; }
+    }
+
+    private sealed class ScopedDependencyCapturingHandler : IEventHandler<TestEvent>
+    {
+        private readonly ScopedDependency _dependency;
+        private readonly ScopedDependencyCollector _collector;
+
+        public ScopedDependencyCapturingHandler(ScopedDependency dependency, ScopedDependencyCollector collector)
+        {
+            _dependency = dependency;
+            _collector = collector;
+        }
+
+        public Task HandleAsync(TestEvent message, CancellationToken cancellationToken = default)
+        {
+            _collector.Captured = _dependency;
+            return Task.CompletedTask;
+        }
+    }
+
     private sealed class TestEvent : IEvent
     {
         public string Id { get; init; } = Guid.NewGuid().ToString();

--- a/tests/NetEvolve.Pulse.Tests.Unit/Internals/PulseMediatorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Internals/PulseMediatorTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace NetEvolve.Pulse.Tests.Unit.Internals;
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -399,7 +400,10 @@ public class PulseMediatorTests
         }
     }
 
-    private sealed class ScopedDependency;
+    private sealed class ScopedDependency
+    {
+        public Guid Id { get; } = Guid.NewGuid();
+    }
 
     private sealed class ScopedDependencyCollector
     {
@@ -411,6 +415,11 @@ public class PulseMediatorTests
         private readonly ScopedDependency _dependency;
         private readonly ScopedDependencyCollector _collector;
 
+        [SuppressMessage(
+            "Major Code Smell",
+            "S1144:Unused private types or members should be removed",
+            Justification = "Handler is resolved by the mediator through dependency injection."
+        )]
         public ScopedDependencyCapturingHandler(ScopedDependency dependency, ScopedDependencyCollector collector)
         {
             _dependency = dependency;


### PR DESCRIPTION
PublishAsync created a fresh DI scope per invocation, so scoped event
handlers (including the outbox handler chain) received a different
DbContext/connection than the publishing business code and outbox writes
committed outside the caller's transaction, producing phantom or lost
events. Handlers are now resolved from the provider the mediator itself
was resolved from; since IMediator is scoped, this is the caller's scope.