### PR TITLE
fix(outbox): bind pending gauge lifetime to the hosted service

### DIFF
--- a/src/NetEvolve.Pulse/Outbox/OutboxProcessorHostedService.cs
+++ b/src/NetEvolve.Pulse/Outbox/OutboxProcessorHostedService.cs
@@ -83,6 +83,13 @@ internal sealed partial class OutboxProcessorHostedService : BackgroundService
     private long _pendingCount;
 
     /// <summary>
+    /// Instance-scoped meter hosting the <c>pulse.outbox.pending</c> observable gauge. The gauge callback
+    /// captures this service instance, so the instrument lifetime is bound to the service lifetime by
+    /// disposing this meter in <see cref="Dispose"/> instead of publishing on the process-wide static meter.
+    /// </summary>
+    private readonly Meter _meter;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="OutboxProcessorHostedService"/> class.
     /// </summary>
     /// <param name="repository">The repository for outbox message persistence.</param>
@@ -110,12 +117,20 @@ internal sealed partial class OutboxProcessorHostedService : BackgroundService
         _options = options.Value;
         _logger = logger;
 
-        _ = Defaults.Meter.CreateObservableGauge(
+        _meter = new Meter(Defaults.Meter.Name, Defaults.Version);
+        _ = _meter.CreateObservableGauge(
             "pulse.outbox.pending",
             observeValue: () => Volatile.Read(ref _pendingCount),
             unit: "messages",
             description: "Current number of pending outbox messages."
         );
+    }
+
+    /// <inheritdoc />
+    public override void Dispose()
+    {
+        _meter.Dispose();
+        base.Dispose();
     }
 
     /// <inheritdoc />

--- a/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorHostedServiceTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorHostedServiceTests.cs
@@ -845,6 +845,44 @@ public sealed class OutboxProcessorHostedServiceTests
     }
 
     [Test]
+    [NotInParallel("OutboxMetrics")]
+    public async Task Dispose_ReleasesPendingGaugeInstrument()
+    {
+        var gaugeCompleted = false;
+        using var meterListener = new MeterListener();
+        meterListener.InstrumentPublished = (instrument, listener) =>
+        {
+            if (
+                string.Equals(instrument.Meter.Name, "NetEvolve.Pulse", StringComparison.Ordinal)
+                && string.Equals(instrument.Name, "pulse.outbox.pending", StringComparison.Ordinal)
+            )
+            {
+                listener.EnableMeasurementEvents(instrument);
+            }
+        };
+        meterListener.MeasurementsCompleted = (instrument, _) =>
+        {
+            if (string.Equals(instrument.Name, "pulse.outbox.pending", StringComparison.Ordinal))
+            {
+                Volatile.Write(ref gaugeCompleted, value: true);
+            }
+        };
+        meterListener.Start();
+
+        using var repository = new InMemoryOutboxRepository();
+        var transport = new InMemoryMessageTransport();
+        var options = Options.Create(new OutboxProcessorOptions());
+        var logger = CreateLogger();
+        var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+
+        service.Dispose();
+
+        // Disposing the service must release its observable gauge so the instance is not
+        // rooted for the process lifetime by a static Meter.
+        _ = await Assert.That(Volatile.Read(ref gaugeCompleted)).IsTrue();
+    }
+
+    [Test]
     public async Task ExecuteAsync_WithExponentialBackoffEnabled_SetsNextRetryAt(CancellationToken cancellationToken)
     {
         using var repository = new InMemoryOutboxRepository();


### PR DESCRIPTION
The pulse.outbox.pending observable gauge was registered on the static
process-wide Meter with a callback capturing the service instance, rooting
every constructed service (and its dependency graph) for the process
lifetime and accumulating duplicate stale gauges across host restarts.
The gauge now lives on an instance Meter that is disposed with the service.