### PR TITLE
fix(outbox): observe stopping token while waiting for application start

### DIFF
--- a/src/NetEvolve.Pulse/Outbox/OutboxProcessorHostedService.cs
+++ b/src/NetEvolve.Pulse/Outbox/OutboxProcessorHostedService.cs
@@ -136,10 +136,17 @@ internal sealed partial class OutboxProcessorHostedService : BackgroundService
     /// <inheritdoc />
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        var applicationStarted = new TaskCompletionSource();
-        _ = _lifetime.ApplicationStarted.Register(() => applicationStarted.TrySetResult());
+        var applicationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var startedRegistration = _lifetime.ApplicationStarted.Register(() => applicationStarted.TrySetResult());
 
-        await applicationStarted.Task.ConfigureAwait(false);
+        try
+        {
+            await applicationStarted.Task.WaitAsync(stoppingToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            return;
+        }
 
         LogProcessorStarted(_logger, _options.PollingInterval, _options.BatchSize);
 

--- a/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorHostedServiceTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorHostedServiceTests.cs
@@ -1062,6 +1062,35 @@ public sealed class OutboxProcessorHostedServiceTests
     }
 
     [Test]
+    public async Task StopAsync_BeforeApplicationStarted_CompletesWithoutWaitingForStartup(
+        CancellationToken cancellationToken
+    )
+    {
+        using var repository = new InMemoryOutboxRepository();
+        var transport = new InMemoryMessageTransport();
+        var options = Options.Create(new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50) });
+        var logger = CreateLogger();
+        using var lifetime = new PendingStartLifetime();
+        using var service = new OutboxProcessorHostedService(repository, transport, lifetime, options, logger);
+
+        // Startup never completes: ApplicationStarted is never signaled.
+        await service.StartAsync(cancellationToken).ConfigureAwait(false);
+
+        // Stopping must not hang until the caller-provided token expires; ExecuteAsync has to
+        // observe the stopping token while still waiting for ApplicationStarted.
+        using var stopTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        stopTimeout.CancelAfter(TimeSpan.FromSeconds(5));
+        await service.StopAsync(stopTimeout.Token).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(service.ExecuteTask).IsNotNull();
+            _ = await Assert.That(service.ExecuteTask!.IsCompleted).IsTrue();
+            _ = await Assert.That(repository.GetPendingCallCount).IsEqualTo(0);
+        }
+    }
+
+    [Test]
     public async Task ExecuteAsync_WhenDatabaseIsUnhealthy_SkipsProcessingCycle(CancellationToken cancellationToken)
     {
         using var repository = new InMemoryOutboxRepository { IsHealthy = false };

--- a/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorHostedServiceTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorHostedServiceTests.cs
@@ -1085,7 +1085,7 @@ public sealed class OutboxProcessorHostedServiceTests
         using (Assert.Multiple())
         {
             _ = await Assert.That(service.ExecuteTask).IsNotNull();
-            _ = await Assert.That(service.ExecuteTask!.IsCompleted).IsTrue();
+            _ = await Assert.That(service.ExecuteTask.IsCompleted).IsTrue();
             _ = await Assert.That(repository.GetPendingCallCount).IsEqualTo(0);
         }
     }


### PR DESCRIPTION
ExecuteAsync awaited an ApplicationStarted-completed TaskCompletionSource
without linking the stopping token, so stopping a host whose startup never
completed parked the service until the shutdown timeout expired. The wait
now uses WaitAsync(stoppingToken), the callback registration is disposed,
and the TCS runs continuations asynchronously to keep lifetime callbacks
from executing the polling loop inline.