### PR TITLE
perf(outbox): claim Cosmos DB candidates with query ETag instead of point reads

### DIFF
--- a/src/NetEvolve.Pulse.CosmosDb/Outbox/CosmosDbOutboxDocument.cs
+++ b/src/NetEvolve.Pulse.CosmosDb/Outbox/CosmosDbOutboxDocument.cs
@@ -109,6 +109,16 @@ internal sealed class CosmosDbOutboxDocument
     public int? Ttl { get; set; }
 
     /// <summary>
+    /// Gets or sets the Cosmos DB system <c>_etag</c> value returned by queries and reads,
+    /// used for optimistic concurrency via <c>IfMatchEtag</c> preconditions.
+    /// Never written back to the store when unset.
+    /// </summary>
+    [JsonPropertyName("_etag")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonProperty("_etag", NullValueHandling = NullValueHandling.Ignore)]
+    public string? ETag { get; set; }
+
+    /// <summary>
     /// Converts this Cosmos DB document to an <see cref="OutboxMessage"/>.
     /// </summary>
     /// <returns>The corresponding <see cref="OutboxMessage"/>.</returns>

--- a/src/NetEvolve.Pulse.CosmosDb/Outbox/CosmosDbOutboxRepository.cs
+++ b/src/NetEvolve.Pulse.CosmosDb/Outbox/CosmosDbOutboxRepository.cs
@@ -90,7 +90,7 @@ internal sealed class CosmosDbOutboxRepository : IOutboxRepository
 
         if (candidates.Count == 0)
         {
-            return candidates;
+            return [];
         }
 
         return await ClaimMessagesAsync(candidates, (int)OutboxMessageStatus.Processing, cancellationToken)
@@ -117,7 +117,7 @@ internal sealed class CosmosDbOutboxRepository : IOutboxRepository
 
         if (candidates.Count == 0)
         {
-            return candidates;
+            return [];
         }
 
         return await ClaimMessagesAsync(candidates, (int)OutboxMessageStatus.Processing, cancellationToken)
@@ -302,14 +302,14 @@ internal sealed class CosmosDbOutboxRepository : IOutboxRepository
     }
 
     /// <summary>
-    /// Executes a parameterized query and returns all matching documents as <see cref="OutboxMessage"/> instances.
+    /// Executes a parameterized query and returns all matching documents.
     /// </summary>
-    private async Task<IReadOnlyList<OutboxMessage>> ExecuteQueryAsync(
+    private async Task<IReadOnlyList<CosmosDbOutboxDocument>> ExecuteQueryAsync(
         QueryDefinition query,
         CancellationToken cancellationToken
     )
     {
-        var messages = new List<OutboxMessage>();
+        var documents = new List<CosmosDbOutboxDocument>();
 
         using var iterator = _container.GetItemQueryIterator<CosmosDbOutboxDocument>(query);
 
@@ -317,22 +317,20 @@ internal sealed class CosmosDbOutboxRepository : IOutboxRepository
         {
             var page = await iterator.ReadNextAsync(cancellationToken).ConfigureAwait(false);
 
-            foreach (var doc in page)
-            {
-                messages.Add(doc.ToOutboxMessage());
-            }
+            documents.AddRange(page);
         }
 
-        return messages;
+        return documents;
     }
 
     /// <summary>
-    /// Attempts to atomically claim each candidate message by patching its status to
-    /// <paramref name="targetStatus"/> using ETag-based optimistic concurrency.
-    /// Messages that have been claimed by another worker (ETag mismatch) are silently skipped.
+    /// Attempts to atomically claim each candidate document by patching its status to
+    /// <paramref name="targetStatus"/> using the <c>_etag</c> returned by the candidate query
+    /// as an <c>IfMatchEtag</c> precondition, avoiding an additional point read per candidate.
+    /// Messages that have been modified by another worker (ETag mismatch) are silently skipped.
     /// </summary>
     private async Task<IReadOnlyList<OutboxMessage>> ClaimMessagesAsync(
-        IReadOnlyList<OutboxMessage> candidates,
+        IReadOnlyList<CosmosDbOutboxDocument> candidates,
         int targetStatus,
         CancellationToken cancellationToken
     )
@@ -340,34 +338,12 @@ internal sealed class CosmosDbOutboxRepository : IOutboxRepository
         var now = _timeProvider.GetUtcNow();
         var claimed = new List<OutboxMessage>(candidates.Count);
 
-        foreach (var message in candidates)
+        foreach (var document in candidates)
         {
-            var id = message.Id.ToString();
+            var id = document.Id;
             var partitionKey = new PartitionKey(id);
 
-            // Read current ETag for optimistic concurrency.
-            ItemResponse<CosmosDbOutboxDocument> current;
-
-            try
-            {
-                current = await _container
-                    .ReadItemAsync<CosmosDbOutboxDocument>(id, partitionKey, cancellationToken: cancellationToken)
-                    .ConfigureAwait(false);
-            }
-            catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
-            {
-                // Document deleted between query and read — skip.
-                continue;
-            }
-
-            // Only claim if the persisted status still matches the in-memory candidate. The
-            // OutboxMessageStatus enum is int-backed, so a single cast to int is sufficient.
-            if (current.Resource.Status != (int)message.Status)
-            {
-                continue;
-            }
-
-            var requestOptions = new PatchItemRequestOptions { IfMatchEtag = current.ETag };
+            var requestOptions = new PatchItemRequestOptions { IfMatchEtag = document.ETag };
 
             var patches = new List<PatchOperation>
             {

--- a/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxRepositoryClaimTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxRepositoryClaimTests.cs
@@ -1,0 +1,71 @@
+namespace NetEvolve.Pulse.Tests.Unit.CosmosDb;
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Options;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("CosmosDb")]
+public sealed class CosmosDbOutboxRepositoryClaimTests
+{
+    [Test]
+    public async Task GetPendingAsync_WithCandidates_ClaimsWithoutAdditionalPointRead(
+        CancellationToken cancellationToken
+    )
+    {
+        var messageId = Guid.NewGuid();
+        var document = CreateDocument(messageId, status: 0);
+        document.ETag = "\"query-etag\"";
+        var capturedOptions = new List<PatchItemRequestOptions?>();
+
+        var container = new FakeCosmosContainer
+        {
+            OnQueryIterator = (_, _, _) =>
+                new FakeFeedIterator<CosmosDbOutboxDocument>([
+                    [document],
+                ]),
+            OnReadItem = (_, _) =>
+                new FakeItemResponse<CosmosDbOutboxDocument>(CreateDocument(messageId, status: 0), "\"read-etag\""),
+            OnPatchItem = (_, _, _, options) =>
+            {
+                capturedOptions.Add(options);
+                return new FakeItemResponse<CosmosDbOutboxDocument>(CreateDocument(messageId, status: 1));
+            },
+        };
+
+        using var client = new FakeCosmosClient(container);
+
+        var repository = new CosmosDbOutboxRepository(
+            client,
+            Options.Create(new CosmosDbOutboxOptions { DatabaseName = "TestDb" }),
+            TimeProvider.System
+        );
+
+        var claimed = await repository.GetPendingAsync(10, cancellationToken).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(claimed.Count).IsEqualTo(1);
+            _ = await Assert.That(container.PatchItemCalls).IsEqualTo(1);
+            _ = await Assert.That(container.ReadItemCalls).IsEqualTo(0);
+            _ = await Assert.That(capturedOptions.Count).IsEqualTo(1);
+            _ = await Assert.That(capturedOptions[0]?.IfMatchEtag).IsEqualTo("\"query-etag\"");
+        }
+    }
+
+    private static CosmosDbOutboxDocument CreateDocument(Guid id, int status) =>
+        new CosmosDbOutboxDocument
+        {
+            Id = id.ToString(),
+            EventType = typeof(string).AssemblyQualifiedName!,
+            Payload = "{}",
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Status = status,
+        };
+}


### PR DESCRIPTION
The claim loop re-read every candidate document with ReadItemAsync solely
to obtain its ETag, adding two extra sequential round trips per message.
The candidate query already returns the full document, so the _etag is now
mapped on the document model and used directly as the IfMatchEtag
precondition, preserving the optimistic-concurrency semantics.