### PR TITLE
perf(outbox): bound Cosmos DB status-polling query fan-out

### DIFF
--- a/src/NetEvolve.Pulse.CosmosDb/Outbox/CosmosDbOutboxOptions.cs
+++ b/src/NetEvolve.Pulse.CosmosDb/Outbox/CosmosDbOutboxOptions.cs
@@ -41,9 +41,18 @@ public sealed class CosmosDbOutboxOptions
     /// Gets or sets the partition key path for the container.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Defaults to <see cref="DefaultPartitionKeyPath"/> (<c>/id</c>).
     /// This value is informational for container creation guidance; the repository uses it
     /// to construct <see cref="Microsoft.Azure.Cosmos.PartitionKey"/> values for point operations.
+    /// </para>
+    /// <para>
+    /// With the default <c>/id</c> path every document is its own logical partition. Point
+    /// operations stay single-partition, but the recurring status-based queries (pending polling,
+    /// retry polling, counts, and cleanup) fan out to all physical partitions, so their RU cost
+    /// and latency grow with the number of physical partitions. Enable
+    /// <see cref="EnableTimeToLive"/> to keep the container small and the fan-out inexpensive.
+    /// </para>
     /// </remarks>
     public string PartitionKeyPath { get; set; } = DefaultPartitionKeyPath;
 

--- a/src/NetEvolve.Pulse.CosmosDb/Outbox/CosmosDbOutboxRepository.cs
+++ b/src/NetEvolve.Pulse.CosmosDb/Outbox/CosmosDbOutboxRepository.cs
@@ -20,6 +20,13 @@ using Newtonsoft.Json;
 /// When <see cref="CosmosDbOutboxOptions.EnableTimeToLive"/> is <see langword="true"/>,
 /// the <c>ttl</c> field is set on completed and dead-letter documents so the Cosmos DB
 /// TTL engine removes them automatically after <see cref="CosmosDbOutboxOptions.TtlSeconds"/> seconds.
+/// <para><strong>Query fan-out:</strong></para>
+/// With the default partition key path <c>/id</c> every document forms its own logical partition,
+/// so the recurring status-polling and count queries cannot target a single partition and fan out
+/// to all physical partitions. The queries are issued with bounded page sizes and maximum
+/// parallelism to limit the cost; keeping the container small (see
+/// <see cref="CosmosDbOutboxOptions.EnableTimeToLive"/>) prevents the fan-out from growing with
+/// accumulated completed documents.
 /// <para><strong>Prerequisites:</strong></para>
 /// The caller must register a <see cref="CosmosClient"/> in the DI container before calling the
 /// registration extension methods.
@@ -86,7 +93,8 @@ internal sealed class CosmosDbOutboxRepository : IOutboxRepository
             .WithParameter("@now", now)
             .WithParameter("@batchSize", batchSize);
 
-        var candidates = await ExecuteQueryAsync(query, cancellationToken).ConfigureAwait(false);
+        var candidates = await ExecuteQueryAsync(query, CreateBatchQueryOptions(batchSize), cancellationToken)
+            .ConfigureAwait(false);
 
         if (candidates.Count == 0)
         {
@@ -113,7 +121,8 @@ internal sealed class CosmosDbOutboxRepository : IOutboxRepository
             .WithParameter("@now", now)
             .WithParameter("@batchSize", batchSize);
 
-        var candidates = await ExecuteQueryAsync(query, cancellationToken).ConfigureAwait(false);
+        var candidates = await ExecuteQueryAsync(query, CreateBatchQueryOptions(batchSize), cancellationToken)
+            .ConfigureAwait(false);
 
         if (candidates.Count == 0)
         {
@@ -232,7 +241,10 @@ internal sealed class CosmosDbOutboxRepository : IOutboxRepository
     {
         var query = new QueryDefinition("SELECT VALUE COUNT(1) FROM c WHERE c.status = 0");
 
-        using var iterator = _container.GetItemQueryIterator<long>(query);
+        using var iterator = _container.GetItemQueryIterator<long>(
+            query,
+            requestOptions: new QueryRequestOptions { MaxConcurrency = -1 }
+        );
 
         var count = 0L;
 
@@ -257,7 +269,10 @@ internal sealed class CosmosDbOutboxRepository : IOutboxRepository
 
         var deleted = 0;
 
-        using var iterator = _container.GetItemQueryIterator<IdProjection>(query);
+        using var iterator = _container.GetItemQueryIterator<IdProjection>(
+            query,
+            requestOptions: new QueryRequestOptions { MaxConcurrency = -1 }
+        );
 
         while (iterator.HasMoreResults)
         {
@@ -302,16 +317,29 @@ internal sealed class CosmosDbOutboxRepository : IOutboxRepository
     }
 
     /// <summary>
+    /// Creates <see cref="QueryRequestOptions"/> for the recurring status-polling queries.
+    /// The queries filter on <c>c.status</c> without a partition key and therefore fan out to
+    /// every physical partition; bounding the page size to the batch size and enabling maximum
+    /// parallelism keeps the per-poll latency and RU cost as low as possible.
+    /// </summary>
+    private static QueryRequestOptions CreateBatchQueryOptions(int batchSize) =>
+        new QueryRequestOptions { MaxItemCount = batchSize, MaxConcurrency = -1 };
+
+    /// <summary>
     /// Executes a parameterized query and returns all matching documents.
     /// </summary>
     private async Task<IReadOnlyList<CosmosDbOutboxDocument>> ExecuteQueryAsync(
         QueryDefinition query,
+        QueryRequestOptions requestOptions,
         CancellationToken cancellationToken
     )
     {
         var documents = new List<CosmosDbOutboxDocument>();
 
-        using var iterator = _container.GetItemQueryIterator<CosmosDbOutboxDocument>(query);
+        using var iterator = _container.GetItemQueryIterator<CosmosDbOutboxDocument>(
+            query,
+            requestOptions: requestOptions
+        );
 
         while (iterator.HasMoreResults)
         {

--- a/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxRepositoryQueryOptionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxRepositoryQueryOptionsTests.cs
@@ -1,0 +1,86 @@
+namespace NetEvolve.Pulse.Tests.Unit.CosmosDb;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("CosmosDb")]
+public sealed class CosmosDbOutboxRepositoryQueryOptionsTests
+{
+    [Test]
+    public async Task GetPendingAsync_PassesBoundedQueryRequestOptions(CancellationToken cancellationToken)
+    {
+        var container = new FakeCosmosContainer
+        {
+            OnQueryIterator = (_, _, _) => new FakeFeedIterator<CosmosDbOutboxDocument>([]),
+        };
+
+        var repository = CreateRepository(container);
+
+        _ = await repository.GetPendingAsync(25, cancellationToken).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(container.CapturedQueryRequestOptions.Count).IsEqualTo(1);
+            _ = await Assert.That(container.CapturedQueryRequestOptions[0]?.MaxItemCount).IsEqualTo(25);
+            _ = await Assert.That(container.CapturedQueryRequestOptions[0]?.MaxConcurrency).IsEqualTo(-1);
+        }
+    }
+
+    [Test]
+    public async Task GetFailedForRetryAsync_PassesBoundedQueryRequestOptions(CancellationToken cancellationToken)
+    {
+        var container = new FakeCosmosContainer
+        {
+            OnQueryIterator = (_, _, _) => new FakeFeedIterator<CosmosDbOutboxDocument>([]),
+        };
+
+        var repository = CreateRepository(container);
+
+        _ = await repository.GetFailedForRetryAsync(5, 42, cancellationToken).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(container.CapturedQueryRequestOptions.Count).IsEqualTo(1);
+            _ = await Assert.That(container.CapturedQueryRequestOptions[0]?.MaxItemCount).IsEqualTo(42);
+            _ = await Assert.That(container.CapturedQueryRequestOptions[0]?.MaxConcurrency).IsEqualTo(-1);
+        }
+    }
+
+    [Test]
+    public async Task GetPendingCountAsync_PassesParallelQueryRequestOptions(CancellationToken cancellationToken)
+    {
+        var container = new FakeCosmosContainer
+        {
+            OnQueryIterator = (_, _, _) =>
+                new FakeFeedIterator<long>([
+                    [0L],
+                ]),
+        };
+
+        var repository = CreateRepository(container);
+
+        _ = await repository.GetPendingCountAsync(cancellationToken).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(container.CapturedQueryRequestOptions.Count).IsEqualTo(1);
+            _ = await Assert.That(container.CapturedQueryRequestOptions[0]?.MaxConcurrency).IsEqualTo(-1);
+        }
+    }
+
+    private static CosmosDbOutboxRepository CreateRepository(FakeCosmosContainer container)
+    {
+        using var client = new FakeCosmosClient(container);
+
+        return new CosmosDbOutboxRepository(
+            client,
+            Options.Create(new CosmosDbOutboxOptions { DatabaseName = "TestDb" }),
+            TimeProvider.System
+        );
+    }
+}


### PR DESCRIPTION
Documents are partitioned by message id, so the recurring status-based
queries fan out to every physical partition. The queries now run with
MaxItemCount bounded to the batch size and MaxConcurrency set to unbounded
parallelism, and the fan-out limitation of the default /id partition key
path is documented on the repository and the options.