### PR TITLE
perf(outbox): replay Cosmos DB dead-letter messages without per-item reads

### DIFF
--- a/src/NetEvolve.Pulse.CosmosDb/Outbox/CosmosDbOutboxManagement.cs
+++ b/src/NetEvolve.Pulse.CosmosDb/Outbox/CosmosDbOutboxManagement.cs
@@ -152,19 +152,18 @@ internal sealed class CosmosDbOutboxManagement : IOutboxManagement
     /// <inheritdoc />
     public async Task<int> ReplayAllDeadLetterAsync(CancellationToken cancellationToken = default)
     {
-        var query = new QueryDefinition("SELECT c.id FROM c WHERE c.status = 4");
+        var query = new QueryDefinition("SELECT * FROM c WHERE c.status = 4");
         var replayed = 0;
 
-        using var iterator = _container.GetItemQueryIterator<IdProjection>(query);
+        using var iterator = _container.GetItemQueryIterator<CosmosDbOutboxDocument>(query);
 
         while (iterator.HasMoreResults)
         {
             var page = await iterator.ReadNextAsync(cancellationToken).ConfigureAwait(false);
 
-            foreach (var item in page)
+            foreach (var document in page)
             {
-                var replayed1 = await ReplayMessageAsync(Guid.Parse(item.Id), cancellationToken).ConfigureAwait(false);
-                if (replayed1)
+                if (await TryReplayDocumentAsync(document, cancellationToken).ConfigureAwait(false))
                 {
                     replayed++;
                 }
@@ -172,6 +171,47 @@ internal sealed class CosmosDbOutboxManagement : IOutboxManagement
         }
 
         return replayed;
+    }
+
+    /// <summary>
+    /// Attempts to reset a dead-letter document to pending using the <c>_etag</c> returned by the
+    /// query as an <c>IfMatchEtag</c> precondition, avoiding an additional point read per document.
+    /// Documents modified or deleted by another worker in the meantime are silently skipped.
+    /// </summary>
+    private async Task<bool> TryReplayDocumentAsync(
+        CosmosDbOutboxDocument document,
+        CancellationToken cancellationToken
+    )
+    {
+        var now = _timeProvider.GetUtcNow();
+        var requestOptions = new PatchItemRequestOptions { IfMatchEtag = document.ETag };
+
+        var patches = new List<PatchOperation>
+        {
+            PatchOperation.Set("/status", (int)OutboxMessageStatus.Pending),
+            PatchOperation.Set("/retryCount", 0),
+            PatchOperation.Set("/error", (string?)null),
+            PatchOperation.Set("/updatedAt", now),
+        };
+
+        try
+        {
+            _ = await _container
+                .PatchItemAsync<CosmosDbOutboxDocument>(
+                    document.Id,
+                    new PartitionKey(document.Id),
+                    patches,
+                    requestOptions,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+
+            return true;
+        }
+        catch (CosmosException ex) when (ex.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.PreconditionFailed)
+        {
+            return false;
+        }
     }
 
     /// <inheritdoc />
@@ -226,15 +266,6 @@ internal sealed class CosmosDbOutboxManagement : IOutboxManagement
         }
 
         return messages;
-    }
-
-    /// <summary>
-    /// Minimal projection used when querying only the document <c>id</c> field.
-    /// </summary>
-    private sealed class IdProjection
-    {
-        [System.Text.Json.Serialization.JsonPropertyName("id")]
-        public string Id { get; set; } = string.Empty;
     }
 
     /// <summary>

--- a/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxManagementReplayTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxManagementReplayTests.cs
@@ -30,15 +30,13 @@ public sealed class CosmosDbOutboxManagementReplayTests
                 capturedEtags.Add(options?.IfMatchEtag);
                 return new FakeItemResponse<CosmosDbOutboxDocument>(CreateDeadLetterDocument(Guid.NewGuid(), null));
             },
+            OnQueryIterator = (itemType, _, _) => CreateIterator(itemType, [firstDocument, secondDocument]),
+            OnReadItem = (id, _) =>
+                new FakeItemResponse<CosmosDbOutboxDocument>(
+                    CreateDeadLetterDocument(Guid.Parse(id), "\"read-etag\""),
+                    "\"read-etag\""
+                ),
         };
-
-        container.OnQueryIterator = (itemType, _, _) => CreateIterator(itemType, [firstDocument, secondDocument]);
-
-        container.OnReadItem = (id, _) =>
-            new FakeItemResponse<CosmosDbOutboxDocument>(
-                CreateDeadLetterDocument(Guid.Parse(id), "\"read-etag\""),
-                "\"read-etag\""
-            );
 
         using var client = new FakeCosmosClient(container);
 

--- a/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxManagementReplayTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxManagementReplayTests.cs
@@ -1,0 +1,99 @@
+namespace NetEvolve.Pulse.Tests.Unit.CosmosDb;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Options;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("CosmosDb")]
+public sealed class CosmosDbOutboxManagementReplayTests
+{
+    [Test]
+    public async Task ReplayAllDeadLetterAsync_WithDeadLetterMessages_ReplaysWithoutPointReads(
+        CancellationToken cancellationToken
+    )
+    {
+        var firstDocument = CreateDeadLetterDocument(Guid.NewGuid(), "\"etag-1\"");
+        var secondDocument = CreateDeadLetterDocument(Guid.NewGuid(), "\"etag-2\"");
+        var capturedEtags = new List<string?>();
+
+        var container = new FakeCosmosContainer
+        {
+            OnPatchItem = (_, _, _, options) =>
+            {
+                capturedEtags.Add(options?.IfMatchEtag);
+                return new FakeItemResponse<CosmosDbOutboxDocument>(CreateDeadLetterDocument(Guid.NewGuid(), null));
+            },
+        };
+
+        container.OnQueryIterator = (itemType, _, _) => CreateIterator(itemType, [firstDocument, secondDocument]);
+
+        container.OnReadItem = (id, _) =>
+            new FakeItemResponse<CosmosDbOutboxDocument>(
+                CreateDeadLetterDocument(Guid.Parse(id), "\"read-etag\""),
+                "\"read-etag\""
+            );
+
+        using var client = new FakeCosmosClient(container);
+
+        var management = new CosmosDbOutboxManagement(
+            client,
+            Options.Create(new CosmosDbOutboxOptions { DatabaseName = "TestDb" }),
+            TimeProvider.System
+        );
+
+        var replayed = await management.ReplayAllDeadLetterAsync(cancellationToken).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(replayed).IsEqualTo(2);
+            _ = await Assert.That(container.PatchItemCalls).IsEqualTo(2);
+            _ = await Assert.That(container.ReadItemCalls).IsEqualTo(0);
+            _ = await Assert.That(capturedEtags.Count).IsEqualTo(2);
+            _ = await Assert.That(capturedEtags[0]).IsEqualTo("\"etag-1\"");
+            _ = await Assert.That(capturedEtags[1]).IsEqualTo("\"etag-2\"");
+        }
+    }
+
+    private static CosmosDbOutboxDocument CreateDeadLetterDocument(Guid id, string? etag) =>
+        new CosmosDbOutboxDocument
+        {
+            Id = id.ToString(),
+            EventType = typeof(string).AssemblyQualifiedName!,
+            Payload = "{}",
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Status = 4,
+            ETag = etag,
+        };
+
+    private static object CreateIterator(Type itemType, IReadOnlyList<CosmosDbOutboxDocument> documents)
+    {
+        if (itemType == typeof(CosmosDbOutboxDocument))
+        {
+            return new FakeFeedIterator<CosmosDbOutboxDocument>([documents]);
+        }
+
+        // Legacy id-projection path: materialize instances of the requested projection type.
+        var idProperty = itemType.GetProperty("Id");
+        var page = Array.CreateInstance(itemType, documents.Count);
+
+        for (var i = 0; i < documents.Count; i++)
+        {
+            var item = Activator.CreateInstance(itemType)!;
+            idProperty!.SetValue(item, documents[i].Id);
+            page.SetValue(item, i);
+        }
+
+        var pages = Array.CreateInstance(page.GetType(), 1);
+        pages.SetValue(page, 0);
+
+        return Activator.CreateInstance(typeof(FakeFeedIterator<>).MakeGenericType(itemType), [pages])!;
+    }
+}


### PR DESCRIPTION
ReplayAllDeadLetterAsync queried document ids and then performed a point
read plus a patch for every message, tripling the round trips per replay.
The query now returns the full documents once and each message is reset to
pending with a conditional patch using the query-provided _etag.