### PR TITLE
perf(dapr): publish outbox payload bytes directly instead of round-tripping JSON

### DIFF
--- a/src/NetEvolve.Pulse.Dapr/OutBox/DaprMessageTransport.cs
+++ b/src/NetEvolve.Pulse.Dapr/OutBox/DaprMessageTransport.cs
@@ -1,5 +1,6 @@
 ﻿namespace NetEvolve.Pulse.Outbox;
 
+using System.Text;
 using Dapr.Client;
 using Microsoft.Extensions.Options;
 using NetEvolve.Pulse.Extensibility;
@@ -29,16 +30,16 @@ internal sealed class DaprMessageTransport : IMessageTransport
     /// <summary>The topic name resolver used to determine the Dapr topic name from an outbox message.</summary>
     private readonly ITopicNameResolver _topicNameResolver;
 
-    /// <summary>The payload serializer used to serialize and deserialize outbox message payloads.</summary>
-    private readonly IPayloadSerializer _payloadSerializer;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="DaprMessageTransport"/> class.
     /// </summary>
     /// <param name="daprClient">The Dapr client for publishing events.</param>
     /// <param name="topicNameResolver">The topic name resolver for determining topic names from outbox messages.</param>
     /// <param name="options">The transport options.</param>
-    /// <param name="payloadSerializer">The payload serializer for deserializing outbox message payloads.</param>
+    /// <param name="payloadSerializer">
+    /// The payload serializer, kept for API compatibility with the other outbox transports; not used
+    /// for publishing.
+    /// </param>
     public DaprMessageTransport(
         DaprClient daprClient,
         ITopicNameResolver topicNameResolver,
@@ -54,7 +55,6 @@ internal sealed class DaprMessageTransport : IMessageTransport
         _daprClient = daprClient;
         _topicNameResolver = topicNameResolver;
         _options = options.Value;
-        _payloadSerializer = payloadSerializer;
     }
 
     /// <inheritdoc />
@@ -63,10 +63,10 @@ internal sealed class DaprMessageTransport : IMessageTransport
         ArgumentNullException.ThrowIfNull(message);
 
         var topicName = _topicNameResolver.Resolve(message);
-        var payload = _payloadSerializer.Deserialize<object>(message.Payload);
+        var payload = Encoding.UTF8.GetBytes(message.Payload);
 
         await _daprClient
-            .PublishEventAsync(_options.PubSubName, topicName, payload, cancellationToken)
+            .PublishByteEventAsync(_options.PubSubName, topicName, payload, cancellationToken: cancellationToken)
             .ConfigureAwait(false);
     }
 

--- a/tests/NetEvolve.Pulse.Tests.Unit/Dapr/DaprMessageTransportTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Dapr/DaprMessageTransportTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace NetEvolve.Pulse.Tests.Unit.Dapr;
 
 using System;
+using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using global::Dapr.Client;
@@ -104,6 +105,40 @@ public sealed class DaprMessageTransportTests
         );
 
         _ = await Assert.ThrowsAsync<ArgumentNullException>(() => transport.SendAsync(null!, cancellationToken));
+    }
+
+    [Test]
+    public async Task SendAsync_Publishes_original_payload_bytes_without_deserialize_reserialize_roundtrip(
+        CancellationToken cancellationToken
+    )
+    {
+        var daprClient = new FakeDaprClient();
+        var transport = new DaprMessageTransport(
+            daprClient,
+            new FakeTopicNameResolver(),
+            Options.Create(new DaprMessageTransportOptions { PubSubName = "test-pubsub" }),
+            DefaultSerializer
+        );
+
+        // Property order and number formatting a JsonElement round-trip could alter.
+        const string OriginalPayload = "{\"z\":1,\"a\":1.50,\"m\":10}";
+        var message = new OutboxMessage
+        {
+            Id = Guid.Parse("11111111-2222-3333-4444-555555555555"),
+            EventType = typeof(string),
+            Payload = OriginalPayload,
+            CreatedAt = DateTimeOffset.UnixEpoch,
+            UpdatedAt = DateTimeOffset.UnixEpoch,
+        };
+
+        await transport.SendAsync(message, cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(daprClient.PublishByteEventAsyncCalled).IsTrue();
+        _ = await Assert.That(daprClient.PublishEventAsyncCalled).IsFalse();
+        _ = await Assert.That(daprClient.PublishedPubsubName).IsEqualTo("test-pubsub");
+        _ = await Assert.That(daprClient.PublishedTopicName).IsEqualTo("test-topic");
+        _ = await Assert.That(daprClient.PublishedContentType).IsEqualTo("application/json");
+        _ = await Assert.That(daprClient.PublishedBytes).IsEquivalentTo(Encoding.UTF8.GetBytes(OriginalPayload));
     }
 
     [Test]

--- a/tests/NetEvolve.Pulse.Tests.Unit/Dapr/FakeDaprClient.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Dapr/FakeDaprClient.cs
@@ -1,0 +1,423 @@
+namespace NetEvolve.Pulse.Tests.Unit.Dapr;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using global::Dapr.Client;
+using Google.Protobuf;
+
+/// <summary>
+/// Minimal <see cref="DaprClient"/> test double that records <see cref="PublishByteEventAsync"/> and
+/// <see cref="PublishEventAsync{TData}(string, string, TData, CancellationToken)"/> invocations.
+/// All other abstract members are not exercised by <see cref="DaprMessageTransportTests"/> and throw
+/// <see cref="NotSupportedException"/> if invoked.
+/// </summary>
+internal sealed class FakeDaprClient : DaprClient
+{
+    public string? PublishedPubsubName { get; private set; }
+
+    public string? PublishedTopicName { get; private set; }
+
+    public byte[]? PublishedBytes { get; private set; }
+
+    public string? PublishedContentType { get; private set; }
+
+    public bool PublishByteEventAsyncCalled { get; private set; }
+
+    public bool PublishEventAsyncCalled { get; private set; }
+
+    public override JsonSerializerOptions JsonSerializerOptions => JsonSerializerOptions.Default;
+
+    public override Task PublishByteEventAsync(
+        string pubsubName,
+        string topicName,
+        ReadOnlyMemory<byte> data,
+        string dataContentType = "application/json",
+        Dictionary<string, string>? metadata = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        PublishByteEventAsyncCalled = true;
+        PublishedPubsubName = pubsubName;
+        PublishedTopicName = topicName;
+        PublishedBytes = data.ToArray();
+        PublishedContentType = dataContentType;
+
+        return Task.CompletedTask;
+    }
+
+    public override Task PublishEventAsync<TData>(
+        string pubsubName,
+        string topicName,
+        TData data,
+        CancellationToken cancellationToken = default
+    )
+    {
+        PublishEventAsyncCalled = true;
+        return Task.CompletedTask;
+    }
+
+    public override Task PublishEventAsync<TData>(
+        string pubsubName,
+        string topicName,
+        TData data,
+        Dictionary<string, string> metadata,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task PublishEventAsync(
+        string pubsubName,
+        string topicName,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task PublishEventAsync(
+        string pubsubName,
+        string topicName,
+        Dictionary<string, string> metadata,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task<BulkPublishResponse<TValue>> BulkPublishEventAsync<TValue>(
+        string pubsubName,
+        string topicName,
+        IReadOnlyList<TValue> events,
+        Dictionary<string, string>? metadata = null,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task InvokeBindingAsync<TRequest>(
+        string bindingName,
+        string operation,
+        TRequest data,
+        IReadOnlyDictionary<string, string>? metadata = null,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task<TResponse> InvokeBindingAsync<TRequest, TResponse>(
+        string bindingName,
+        string operation,
+        TRequest data,
+        IReadOnlyDictionary<string, string>? metadata = null,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task<BindingResponse> InvokeBindingAsync(
+        BindingRequest request,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override HttpRequestMessage CreateInvokeMethodRequest(
+        HttpMethod httpMethod,
+        string appId,
+        string methodName
+    ) => throw new NotSupportedException();
+
+    public override HttpRequestMessage CreateInvokeMethodRequest(
+        HttpMethod httpMethod,
+        string appId,
+        string methodName,
+        IReadOnlyCollection<KeyValuePair<string, string>> queryStringParameters
+    ) => throw new NotSupportedException();
+
+    public override HttpRequestMessage CreateInvokeMethodRequest<TRequest>(
+        HttpMethod httpMethod,
+        string appId,
+        string methodName,
+        IReadOnlyCollection<KeyValuePair<string, string>> queryStringParameters,
+        TRequest data
+    ) => throw new NotSupportedException();
+
+    public override Task<bool> CheckHealthAsync(CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException();
+
+    public override Task<bool> CheckOutboundHealthAsync(CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException();
+
+    public override Task WaitForSidecarAsync(CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException();
+
+    public override Task ShutdownSidecarAsync(CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException();
+
+    public override Task<DaprMetadata> GetMetadataAsync(CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException();
+
+    public override Task SetMetadataAsync(
+        string attributeName,
+        string attributeValue,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+#pragma warning disable CS0672 // overriding obsolete members with non-obsolete no-op implementations
+    public override Task<HttpResponseMessage> InvokeMethodWithResponseAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override HttpClient CreateInvokableHttpClient(string? appId = null) => throw new NotSupportedException();
+
+    public override Task InvokeMethodAsync(HttpRequestMessage request, CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException();
+
+    public override Task<TResponse> InvokeMethodAsync<TResponse>(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task InvokeMethodGrpcAsync(
+        string appId,
+        string methodName,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task InvokeMethodGrpcAsync<TRequest>(
+        string appId,
+        string methodName,
+        TRequest data,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task<TResponse> InvokeMethodGrpcAsync<TResponse>(
+        string appId,
+        string methodName,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task<TResponse> InvokeMethodGrpcAsync<TRequest, TResponse>(
+        string appId,
+        string methodName,
+        TRequest data,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+#pragma warning restore CS0672
+
+    public override Task<TValue> GetStateAsync<TValue>(
+        string storeName,
+        string key,
+        ConsistencyMode? consistencyMode = default,
+        IReadOnlyDictionary<string, string>? metadata = null,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task<IReadOnlyList<BulkStateItem>> GetBulkStateAsync(
+        string storeName,
+        IReadOnlyList<string> keys,
+        int? parallelism,
+        IReadOnlyDictionary<string, string>? metadata = null,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task<IReadOnlyList<BulkStateItem<TValue>>> GetBulkStateAsync<TValue>(
+        string storeName,
+        IReadOnlyList<string> keys,
+        int? parallelism,
+        IReadOnlyDictionary<string, string>? metadata = null,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task SaveBulkStateAsync<TValue>(
+        string storeName,
+        IReadOnlyList<SaveStateItem<TValue>> items,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task DeleteBulkStateAsync(
+        string storeName,
+        IReadOnlyList<BulkDeleteStateItem> items,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task<(TValue value, string etag)> GetStateAndETagAsync<TValue>(
+        string storeName,
+        string key,
+        ConsistencyMode? consistencyMode = null,
+        IReadOnlyDictionary<string, string>? metadata = null,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task SaveStateAsync<TValue>(
+        string storeName,
+        string key,
+        TValue value,
+        StateOptions? stateOptions = null,
+        IReadOnlyDictionary<string, string>? metadata = null,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task SaveByteStateAsync(
+        string storeName,
+        string key,
+        ReadOnlyMemory<byte> binaryValue,
+        StateOptions? stateOptions = null,
+        IReadOnlyDictionary<string, string>? metadata = null,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task<bool> TrySaveByteStateAsync(
+        string storeName,
+        string key,
+        ReadOnlyMemory<byte> binaryValue,
+        string etag,
+        StateOptions? stateOptions = null,
+        IReadOnlyDictionary<string, string>? metadata = null,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task<ReadOnlyMemory<byte>> GetByteStateAsync(
+        string storeName,
+        string key,
+        ConsistencyMode? consistencyMode = null,
+        IReadOnlyDictionary<string, string>? metadata = null,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task<(ReadOnlyMemory<byte>, string etag)> GetByteStateAndETagAsync(
+        string storeName,
+        string key,
+        ConsistencyMode? consistencyMode = null,
+        IReadOnlyDictionary<string, string>? metadata = null,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task<bool> TrySaveStateAsync<TValue>(
+        string storeName,
+        string key,
+        TValue value,
+        string etag,
+        StateOptions? stateOptions = null,
+        IReadOnlyDictionary<string, string>? metadata = null,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task ExecuteStateTransactionAsync(
+        string storeName,
+        IReadOnlyList<StateTransactionRequest> operations,
+        IReadOnlyDictionary<string, string>? metadata = null,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task DeleteStateAsync(
+        string storeName,
+        string key,
+        StateOptions? stateOptions = null,
+        IReadOnlyDictionary<string, string>? metadata = null,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task<bool> TryDeleteStateAsync(
+        string storeName,
+        string key,
+        string etag,
+        StateOptions? stateOptions = null,
+        IReadOnlyDictionary<string, string>? metadata = null,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task<StateQueryResponse<TValue>> QueryStateAsync<TValue>(
+        string storeName,
+        string jsonQuery,
+        IReadOnlyDictionary<string, string>? metadata = null,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task<Dictionary<string, string>> GetSecretAsync(
+        string storeName,
+        string key,
+        IReadOnlyDictionary<string, string>? metadata = null,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task<Dictionary<string, Dictionary<string, string>>> GetBulkSecretAsync(
+        string storeName,
+        IReadOnlyDictionary<string, string>? metadata = null,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task<GetConfigurationResponse> GetConfiguration(
+        string storeName,
+        IReadOnlyList<string> keys,
+        IReadOnlyDictionary<string, string>? metadata = null,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task<SubscribeConfigurationResponse> SubscribeConfiguration(
+        string storeName,
+        IReadOnlyList<string> keys,
+        IReadOnlyDictionary<string, string>? metadata = null,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task<UnsubscribeConfigurationResponse> UnsubscribeConfiguration(
+        string storeName,
+        string id,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task<ReadOnlyMemory<byte>> EncryptAsync(
+        string vaultResourceName,
+        ReadOnlyMemory<byte> plaintextBytes,
+        string keyName,
+        EncryptionOptions encryptionOptions,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override IAsyncEnumerable<ReadOnlyMemory<byte>> EncryptAsync(
+        string vaultResourceName,
+        Stream plaintextStream,
+        string keyName,
+        EncryptionOptions encryptionOptions,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task<ReadOnlyMemory<byte>> DecryptAsync(
+        string vaultResourceName,
+        ReadOnlyMemory<byte> ciphertextBytes,
+        string keyName,
+        DecryptionOptions options,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task<ReadOnlyMemory<byte>> DecryptAsync(
+        string vaultResourceName,
+        ReadOnlyMemory<byte> ciphertextBytes,
+        string keyName,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override IAsyncEnumerable<ReadOnlyMemory<byte>> DecryptAsync(
+        string vaultResourceName,
+        Stream ciphertextStream,
+        string keyName,
+        DecryptionOptions options,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override IAsyncEnumerable<ReadOnlyMemory<byte>> DecryptAsync(
+        string vaultResourceName,
+        Stream ciphertextStream,
+        string keyName,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+#pragma warning disable DAPR_DISTRIBUTEDLOCK // Distributed Lock API is experimental in the Dapr SDK
+    public override Task<TryLockResponse> Lock(
+        string storeName,
+        string resourceId,
+        string lockOwner,
+        int expiryInSeconds,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+
+    public override Task<UnlockResponse> Unlock(
+        string storeName,
+        string resourceId,
+        string lockOwner,
+        CancellationToken cancellationToken = default
+    ) => throw new NotSupportedException();
+#pragma warning restore DAPR_DISTRIBUTEDLOCK
+}


### PR DESCRIPTION
DaprMessageTransport.SendAsync deserialized the outbox JSON payload into an
object graph only for DaprClient to re-serialize it before publishing,
doubling parse/allocation cost per message and risking property-order or
number-formatting drift. Publish the payload's raw UTF-8 bytes via
DaprClient.PublishByteEventAsync with the application/json content type
instead, matching how the other outbox transports forward the payload.