### PR TITLE
fix(outbox): clamp bulk executor semaphore permits to at least one

### DIFF
--- a/src/NetEvolve.Pulse.EntityFramework/Outbox/BulkOutboxRepositoryExecutor.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Outbox/BulkOutboxRepositoryExecutor.cs
@@ -11,13 +11,18 @@ using NetEvolve.Pulse.Extensibility.Outbox;
 /// Suitable for any EF Core provider that supports these operations and can correctly
 /// translate a parameterised <see cref="Guid"/> collection into a SQL <c>IN</c> clause
 /// (SQL Server, PostgreSQL, SQLite, and others).
+/// A <c>maxDegreeOfParallelism</c> below one is clamped to one, so the executor stays usable
+/// on single-CPU hosts where callers derive the value from <see cref="Environment.ProcessorCount"/>.
 /// </remarks>
 /// <typeparam name="TContext">The DbContext type that implements <see cref="IOutboxDbContext"/>.</typeparam>
 internal sealed class BulkOutboxRepositoryExecutor<TContext>(TContext context, int maxDegreeOfParallelism)
     : IOutboxRepositoryExecutor
     where TContext : DbContext, IOutboxDbContext
 {
-    private readonly SemaphoreSlim _semaphore = new(maxDegreeOfParallelism, maxDegreeOfParallelism);
+    private readonly SemaphoreSlim _semaphore = new(
+        Math.Max(1, maxDegreeOfParallelism),
+        Math.Max(1, maxDegreeOfParallelism)
+    );
     private bool _disposedValue;
 
     /// <inheritdoc />

--- a/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/BulkOutboxRepositoryExecutorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/BulkOutboxRepositoryExecutorTests.cs
@@ -1,0 +1,69 @@
+namespace NetEvolve.Pulse.Tests.Unit.EntityFramework;
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility.Outbox;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("EntityFramework")]
+public sealed class BulkOutboxRepositoryExecutorTests
+{
+    [Test]
+    public async Task Constructor_WithZeroMaxDegreeOfParallelism_CreatesInstance()
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase(nameof(Constructor_WithZeroMaxDegreeOfParallelism_CreatesInstance))
+            .Options;
+        var context = new TestDbContext(options);
+        await using (context.ConfigureAwait(false))
+        {
+            using var executor = new BulkOutboxRepositoryExecutor<TestDbContext>(context, 0);
+
+            _ = await Assert.That(executor).IsNotNull();
+        }
+    }
+
+    [Test]
+    public async Task FetchAndMarkAsync_WithZeroMaxDegreeOfParallelism_CompletesWithoutDeadlock(
+        CancellationToken cancellationToken
+    )
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase(nameof(FetchAndMarkAsync_WithZeroMaxDegreeOfParallelism_CompletesWithoutDeadlock))
+            .Options;
+        var context = new TestDbContext(options);
+        await using (context.ConfigureAwait(false))
+        {
+            using var executor = new BulkOutboxRepositoryExecutor<TestDbContext>(context, 0);
+
+            var result = await executor
+                .FetchAndMarkAsync(
+                    context.OutboxMessages.Where(m => m.Status == OutboxMessageStatus.Pending),
+                    DateTimeOffset.UtcNow,
+                    OutboxMessageStatus.Processing,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+
+            _ = await Assert.That(result).IsEmpty();
+        }
+    }
+
+    [Test]
+    public async Task Constructor_WithNegativeMaxDegreeOfParallelism_CreatesInstance()
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase(nameof(Constructor_WithNegativeMaxDegreeOfParallelism_CreatesInstance))
+            .Options;
+        var context = new TestDbContext(options);
+        await using (context.ConfigureAwait(false))
+        {
+            using var executor = new BulkOutboxRepositoryExecutor<TestDbContext>(context, -1);
+
+            _ = await Assert.That(executor).IsNotNull();
+        }
+    }
+}


### PR DESCRIPTION
EntityFrameworkOutboxRepository passes Environment.ProcessorCount - 1 to
BulkOutboxRepositoryExecutor, which is zero on single-CPU hosts and made the
SemaphoreSlim constructor throw ArgumentOutOfRangeException on every scope
resolution. The executor now clamps the permit count to a minimum of one.