### PR TITLE
fix(outbox): return only rows won by the claiming update in bulk fetch

### DIFF
--- a/src/NetEvolve.Pulse.EntityFramework/Outbox/BulkOutboxRepositoryExecutor.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Outbox/BulkOutboxRepositoryExecutor.cs
@@ -42,7 +42,7 @@ internal sealed class BulkOutboxRepositoryExecutor<TContext>(TContext context, i
                 return [];
             }
 
-            _ = await baseQuery
+            var claimed = await baseQuery
                 .Where(m => ids.Contains(m.Id))
                 .ExecuteUpdateAsync(
                     m => m.SetProperty(m => m.Status, newStatus).SetProperty(m => m.UpdatedAt, updatedAt),
@@ -50,9 +50,17 @@ internal sealed class BulkOutboxRepositoryExecutor<TContext>(TContext context, i
                 )
                 .ConfigureAwait(false);
 
+            if (claimed == 0)
+            {
+                return [];
+            }
+
+            // Only return rows this caller actually transitioned; rows claimed by a
+            // competing poller between the candidate SELECT and the UPDATE keep that
+            // poller's UpdatedAt value and are filtered out here.
             return await context
                 .OutboxMessages.AsNoTracking()
-                .Where(m => ids.Contains(m.Id))
+                .Where(m => ids.Contains(m.Id) && m.Status == newStatus && m.UpdatedAt == updatedAt)
                 .ToArrayAsync(cancellationToken)
                 .ConfigureAwait(false);
         }

--- a/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/BulkOutboxRepositoryExecutorFetchAndMarkTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/BulkOutboxRepositoryExecutorFetchAndMarkTests.cs
@@ -1,0 +1,133 @@
+namespace NetEvolve.Pulse.Tests.Unit.EntityFramework;
+
+using System;
+using System.Data.Common;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility.Outbox;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("EntityFramework")]
+public sealed class BulkOutboxRepositoryExecutorFetchAndMarkTests
+{
+    [Test]
+    public async Task FetchAndMarkAsync_WhenCompetingPollerClaimsSelectedRows_DoesNotReturnLostRows(
+        CancellationToken cancellationToken
+    )
+    {
+        var connectionString =
+            "Data Source=FetchAndMarkClaimRace;Mode=Memory;Cache=Shared;Foreign Keys=False;Pooling=False";
+
+        var keeperConnection = new SqliteConnection(connectionString);
+        await using (keeperConnection.ConfigureAwait(false))
+        {
+            await keeperConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            var winnerOptions = new DbContextOptionsBuilder<TestDbContext>().UseSqlite(connectionString).Options;
+            var winnerContext = new TestDbContext(winnerOptions);
+            await using (winnerContext.ConfigureAwait(false))
+            {
+                _ = await winnerContext.Database.EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+
+                var message = new OutboxMessage
+                {
+                    Id = Guid.NewGuid(),
+                    EventType = typeof(string),
+                    Payload = "{}",
+                    CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-5),
+                    UpdatedAt = DateTimeOffset.UtcNow.AddMinutes(-5),
+                    Status = OutboxMessageStatus.Pending,
+                };
+                _ = await winnerContext.OutboxMessages.AddAsync(message, cancellationToken).ConfigureAwait(false);
+                _ = await winnerContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                winnerContext.ChangeTracker.Clear();
+
+                using var winnerExecutor = new BulkOutboxRepositoryExecutor<TestDbContext>(winnerContext, 1);
+
+                var winnerTimestamp = DateTimeOffset.UtcNow;
+                var loserTimestamp = winnerTimestamp.AddMilliseconds(50);
+
+                var interceptor = new CompetingClaimInterceptor(async () =>
+                    _ = await winnerExecutor
+                        .FetchAndMarkAsync(
+                            winnerContext
+                                .OutboxMessages.Where(m => m.Status == OutboxMessageStatus.Pending)
+                                .OrderBy(m => m.CreatedAt)
+                                .Take(10),
+                            winnerTimestamp,
+                            OutboxMessageStatus.Processing,
+                            cancellationToken
+                        )
+                        .ConfigureAwait(false)
+                );
+
+                var loserOptions = new DbContextOptionsBuilder<TestDbContext>()
+                    .UseSqlite(connectionString)
+                    .AddInterceptors(interceptor)
+                    .Options;
+                var loserContext = new TestDbContext(loserOptions);
+                await using (loserContext.ConfigureAwait(false))
+                {
+                    using var loserExecutor = new BulkOutboxRepositoryExecutor<TestDbContext>(loserContext, 1);
+
+                    var loserResult = await loserExecutor
+                        .FetchAndMarkAsync(
+                            loserContext
+                                .OutboxMessages.Where(m => m.Status == OutboxMessageStatus.Pending)
+                                .OrderBy(m => m.CreatedAt)
+                                .Take(10),
+                            loserTimestamp,
+                            OutboxMessageStatus.Processing,
+                            cancellationToken
+                        )
+                        .ConfigureAwait(false);
+
+                    var storedMessage = await winnerContext
+                        .OutboxMessages.AsNoTracking()
+                        .SingleAsync(m => m.Id == message.Id, cancellationToken)
+                        .ConfigureAwait(false);
+
+                    using (Assert.Multiple())
+                    {
+                        _ = await Assert.That(interceptor.CompetingClaimExecuted).IsTrue();
+                        _ = await Assert.That(loserResult).IsEmpty();
+                        _ = await Assert.That(storedMessage.Status).IsEqualTo(OutboxMessageStatus.Processing);
+                        _ = await Assert.That(storedMessage.UpdatedAt).IsEqualTo(winnerTimestamp);
+                    }
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Runs a competing claim right before the intercepted context executes its
+    /// <c>ExecuteUpdateAsync</c> statement, reproducing the window between the candidate
+    /// SELECT and the claiming UPDATE of a concurrent poller.
+    /// </summary>
+    private sealed class CompetingClaimInterceptor(Func<Task> competingClaim) : DbCommandInterceptor
+    {
+        public bool CompetingClaimExecuted { get; private set; }
+
+        public override async ValueTask<InterceptionResult<int>> NonQueryExecutingAsync(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<int> result,
+            CancellationToken cancellationToken = default
+        )
+        {
+            if (!CompetingClaimExecuted)
+            {
+                CompetingClaimExecuted = true;
+                await competingClaim().ConfigureAwait(false);
+            }
+
+            return result;
+        }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/NetEvolve.Pulse.Tests.Unit.csproj
+++ b/tests/NetEvolve.Pulse.Tests.Unit/NetEvolve.Pulse.Tests.Unit.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.Azure.Cosmos" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="MySql.Data" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="NetEvolve.Extensions.TUnit" />


### PR DESCRIPTION
FetchAndMarkAsync discarded the rows-affected result of its conditional
ExecuteUpdateAsync and re-fetched by id only, so a poller that lost the claim
race to a concurrent instance still returned and dispatched the contested
messages. The re-fetch now filters on the new status and this caller's
UpdatedAt stamp and short-circuits when no row was claimed.