### PR TITLE
perf(outbox): reduce bulk fetch-and-mark to two round trips when uncontended

### DIFF
--- a/src/NetEvolve.Pulse.EntityFramework/Outbox/BulkOutboxRepositoryExecutor.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Outbox/BulkOutboxRepositoryExecutor.cs
@@ -36,16 +36,14 @@ internal sealed class BulkOutboxRepositoryExecutor<TContext>(TContext context, i
         await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            var ids = await baseQuery
-                .AsNoTracking()
-                .Select(m => m.Id)
-                .ToArrayAsync(cancellationToken)
-                .ConfigureAwait(false);
+            var entities = await baseQuery.AsNoTracking().ToArrayAsync(cancellationToken).ConfigureAwait(false);
 
-            if (ids.Length == 0)
+            if (entities.Length == 0)
             {
                 return [];
             }
+
+            var ids = Array.ConvertAll(entities, m => m.Id);
 
             var claimed = await baseQuery
                 .Where(m => ids.Contains(m.Id))
@@ -55,14 +53,28 @@ internal sealed class BulkOutboxRepositoryExecutor<TContext>(TContext context, i
                 )
                 .ConfigureAwait(false);
 
+            if (claimed == entities.Length)
+            {
+                // Uncontended fast path: every selected row was transitioned by this caller,
+                // so the already loaded entities can be patched in memory instead of paying
+                // a third database round trip for a re-fetch.
+                foreach (var entity in entities)
+                {
+                    entity.Status = newStatus;
+                    entity.UpdatedAt = updatedAt;
+                }
+
+                return entities;
+            }
+
             if (claimed == 0)
             {
                 return [];
             }
 
-            // Only return rows this caller actually transitioned; rows claimed by a
-            // competing poller between the candidate SELECT and the UPDATE keep that
-            // poller's UpdatedAt value and are filtered out here.
+            // A competing poller claimed part of the candidate set; re-fetch only the rows
+            // this caller actually transitioned, identified by the new status and this
+            // caller's UpdatedAt stamp.
             return await context
                 .OutboxMessages.AsNoTracking()
                 .Where(m => ids.Contains(m.Id) && m.Status == newStatus && m.UpdatedAt == updatedAt)

--- a/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/BulkOutboxRepositoryExecutorRoundTripTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/BulkOutboxRepositoryExecutorRoundTripTests.cs
@@ -1,0 +1,177 @@
+namespace NetEvolve.Pulse.Tests.Unit.EntityFramework;
+
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility.Outbox;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("EntityFramework")]
+public sealed class BulkOutboxRepositoryExecutorRoundTripTests
+{
+    [Test]
+    public async Task FetchAndMarkAsync_UncontendedBatch_UsesAtMostTwoRoundTrips(CancellationToken cancellationToken)
+    {
+        var connection = new SqliteConnection("Data Source=:memory:");
+        await using (connection.ConfigureAwait(false))
+        {
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            var interceptor = new CountingCommandInterceptor();
+            var options = new DbContextOptionsBuilder<TestDbContext>()
+                .UseSqlite(connection)
+                .AddInterceptors(interceptor)
+                .Options;
+            var context = new TestDbContext(options);
+            await using (context.ConfigureAwait(false))
+            {
+                _ = await context.Database.EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+
+                var createdAt = DateTimeOffset.UtcNow.AddMinutes(-5);
+                var messageIds = new List<Guid>();
+                for (var i = 0; i < 3; i++)
+                {
+                    var message = new OutboxMessage
+                    {
+                        Id = Guid.NewGuid(),
+                        EventType = typeof(string),
+                        Payload = $"{{\"index\":{i}}}",
+                        CreatedAt = createdAt.AddSeconds(i),
+                        UpdatedAt = createdAt.AddSeconds(i),
+                        Status = OutboxMessageStatus.Pending,
+                    };
+                    messageIds.Add(message.Id);
+                    _ = await context.OutboxMessages.AddAsync(message, cancellationToken).ConfigureAwait(false);
+                }
+                _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                context.ChangeTracker.Clear();
+
+                using var executor = new BulkOutboxRepositoryExecutor<TestDbContext>(context, 1);
+
+                var updatedAt = DateTimeOffset.UtcNow;
+
+                interceptor.StartCounting();
+
+                var result = await executor
+                    .FetchAndMarkAsync(
+                        context
+                            .OutboxMessages.Where(m => m.Status == OutboxMessageStatus.Pending)
+                            .OrderBy(m => m.CreatedAt)
+                            .Take(10),
+                        updatedAt,
+                        OutboxMessageStatus.Processing,
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
+
+                var commandCount = interceptor.CommandCount;
+
+                var storedStatuses = await context
+                    .OutboxMessages.AsNoTracking()
+                    .Select(m => m.Status)
+                    .ToArrayAsync(cancellationToken)
+                    .ConfigureAwait(false);
+
+                using (Assert.Multiple())
+                {
+                    _ = await Assert.That(commandCount).IsLessThanOrEqualTo(2);
+                    _ = await Assert.That(result).HasCount().EqualTo(3);
+                    _ = await Assert.That(result.Select(m => m.Id)).Contains(messageIds[0]);
+                    _ = await Assert
+                        .That(result.All(m => m.Status == OutboxMessageStatus.Processing && m.UpdatedAt == updatedAt))
+                        .IsTrue();
+                    _ = await Assert.That(storedStatuses.All(s => s == OutboxMessageStatus.Processing)).IsTrue();
+                }
+            }
+        }
+    }
+
+    [Test]
+    public async Task FetchAndMarkAsync_WithoutPendingMessages_ReturnsEmpty(CancellationToken cancellationToken)
+    {
+        var connection = new SqliteConnection("Data Source=:memory:");
+        await using (connection.ConfigureAwait(false))
+        {
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            var options = new DbContextOptionsBuilder<TestDbContext>().UseSqlite(connection).Options;
+            var context = new TestDbContext(options);
+            await using (context.ConfigureAwait(false))
+            {
+                _ = await context.Database.EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+
+                using var executor = new BulkOutboxRepositoryExecutor<TestDbContext>(context, 1);
+
+                var result = await executor
+                    .FetchAndMarkAsync(
+                        context.OutboxMessages.Where(m => m.Status == OutboxMessageStatus.Pending),
+                        DateTimeOffset.UtcNow,
+                        OutboxMessageStatus.Processing,
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
+
+                _ = await Assert.That(result).IsEmpty();
+            }
+        }
+    }
+
+    private sealed class CountingCommandInterceptor : DbCommandInterceptor
+    {
+        private bool _counting;
+        private int _commandCount;
+
+        public int CommandCount => _commandCount;
+
+        public void StartCounting() => _counting = true;
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default
+        )
+        {
+            Count();
+            return ValueTask.FromResult(result);
+        }
+
+        public override ValueTask<InterceptionResult<int>> NonQueryExecutingAsync(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<int> result,
+            CancellationToken cancellationToken = default
+        )
+        {
+            Count();
+            return ValueTask.FromResult(result);
+        }
+
+        public override ValueTask<InterceptionResult<object>> ScalarExecutingAsync(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<object> result,
+            CancellationToken cancellationToken = default
+        )
+        {
+            Count();
+            return ValueTask.FromResult(result);
+        }
+
+        private void Count()
+        {
+            if (_counting)
+            {
+                _ = Interlocked.Increment(ref _commandCount);
+            }
+        }
+    }
+}


### PR DESCRIPTION
FetchAndMarkAsync always issued three sequential statements per poll: an id
SELECT, the claiming UPDATE, and an unconditional re-fetch. The candidate rows
are now loaded up front and patched in memory when the UPDATE claims the full
set, eliminating the third round trip in the common uncontended case; on
partial claims only the rows actually won are re-fetched.