### PR TITLE
fix(idempotency): rethrow unique violations from unrelated pending changes

### DIFF
--- a/src/NetEvolve.Pulse.EntityFramework/Idempotency/EntityFrameworkIdempotencyKeyRepository.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Idempotency/EntityFrameworkIdempotencyKeyRepository.cs
@@ -78,7 +78,7 @@ internal sealed class EntityFrameworkIdempotencyKeyRepository<TContext> : IIdemp
         {
             _ = await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         }
-        catch (Exception ex) when (IsDuplicateKeyException(ex))
+        catch (Exception ex) when (IsDuplicateKeyException(ex) && IsIdempotencyKeyConflict(ex, entry))
         {
             // A concurrent request already stored the same key — this is idempotent and safe to ignore.
             // Detach the conflicting entry so the context remains in a clean state.
@@ -105,6 +105,36 @@ internal sealed class EntityFrameworkIdempotencyKeyRepository<TContext> : IIdemp
     /// </description></item>
     /// </list>
     /// </remarks>
+    /// <summary>
+    /// Determines whether a duplicate-key failure can be attributed to the idempotency key
+    /// insert rather than to unrelated pending changes flushed by the same
+    /// <c>SaveChangesAsync</c> call on the shared <see cref="DbContext"/>.
+    /// </summary>
+    /// <remarks>
+    /// When the provider reports the failing entries on the <see cref="DbUpdateException"/>,
+    /// the failure is only treated as an idempotency-key duplicate if one of those entries is
+    /// the freshly added <see cref="IdempotencyKey"/>. Unique-constraint violations caused by
+    /// other entities (e.g. a domain row with its own unique index) are rethrown so callers
+    /// learn that their changes were not persisted. When no entries are reported (some
+    /// providers omit them), the failure is attributed to the idempotency key to preserve the
+    /// idempotent store semantics.
+    /// </remarks>
+    internal static bool IsIdempotencyKeyConflict(Exception ex, IdempotencyKey entry)
+    {
+        var current = ex;
+        while (current is not null)
+        {
+            if (current is DbUpdateException { Entries.Count: > 0 } updateException)
+            {
+                return updateException.Entries.Any(e => ReferenceEquals(e.Entity, entry));
+            }
+
+            current = current.InnerException;
+        }
+
+        return true;
+    }
+
     internal static bool IsDuplicateKeyException(Exception ex)
     {
         // Walk the full exception chain so that providers that nest the root cause

--- a/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/EntityFrameworkIdempotencyKeyRepositoryStoreTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/EntityFrameworkIdempotencyKeyRepositoryStoreTests.cs
@@ -1,0 +1,116 @@
+namespace NetEvolve.Pulse.Tests.Unit.EntityFramework;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Idempotency;
+using TUnit.Core;
+
+[TestGroup("EntityFramework")]
+public sealed class EntityFrameworkIdempotencyKeyRepositoryStoreTests
+{
+    [Test]
+    public async Task StoreAsync_WithUnrelatedUniqueConstraintViolation_ThrowsDbUpdateException(
+        CancellationToken cancellationToken
+    )
+    {
+        var connection = new SqliteConnection("Data Source=:memory:");
+        await using (connection.ConfigureAwait(false))
+        {
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            var options = new DbContextOptionsBuilder<TestIdempotencyWithUsersDbContext>()
+                .UseSqlite(connection)
+                .Options;
+            var context = new TestIdempotencyWithUsersDbContext(options);
+            await using (context.ConfigureAwait(false))
+            {
+                _ = await context.Database.EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+
+                _ = await context
+                    .Users.AddAsync(new TestUser { Email = "duplicate@example.com" }, cancellationToken)
+                    .ConfigureAwait(false);
+                _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+                // A handler queues an unrelated entity that violates its own unique index;
+                // the pending change is flushed by the idempotency store's SaveChangesAsync.
+                _ = await context
+                    .Users.AddAsync(new TestUser { Email = "duplicate@example.com" }, cancellationToken)
+                    .ConfigureAwait(false);
+
+                var repository = new EntityFrameworkIdempotencyKeyRepository<TestIdempotencyWithUsersDbContext>(
+                    context
+                );
+
+                _ = await Assert
+                    .That(async () =>
+                        await repository
+                            .StoreAsync("store-key", DateTimeOffset.UtcNow, cancellationToken)
+                            .ConfigureAwait(false)
+                    )
+                    .Throws<DbUpdateException>();
+            }
+        }
+    }
+
+    [Test]
+    public async Task StoreAsync_WithDuplicateIdempotencyKey_DoesNotThrow(CancellationToken cancellationToken)
+    {
+        var connection = new SqliteConnection("Data Source=:memory:");
+        await using (connection.ConfigureAwait(false))
+        {
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            var options = new DbContextOptionsBuilder<TestIdempotencyWithUsersDbContext>()
+                .UseSqlite(connection)
+                .Options;
+            var context = new TestIdempotencyWithUsersDbContext(options);
+            await using (context.ConfigureAwait(false))
+            {
+                _ = await context.Database.EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+
+                var repository = new EntityFrameworkIdempotencyKeyRepository<TestIdempotencyWithUsersDbContext>(
+                    context
+                );
+
+                await repository.StoreAsync("same-key", DateTimeOffset.UtcNow, cancellationToken).ConfigureAwait(false);
+
+                // Clearing the tracker forces the second store to hit the database
+                // unique constraint instead of the local change tracker check.
+                context.ChangeTracker.Clear();
+
+                await repository.StoreAsync("same-key", DateTimeOffset.UtcNow, cancellationToken).ConfigureAwait(false);
+
+                var count = await context.IdempotencyKeys.CountAsync(cancellationToken).ConfigureAwait(false);
+                _ = await Assert.That(count).IsEqualTo(1);
+            }
+        }
+    }
+
+    internal sealed class TestIdempotencyWithUsersDbContext : DbContext, IIdempotencyStoreDbContext
+    {
+        public TestIdempotencyWithUsersDbContext(DbContextOptions<TestIdempotencyWithUsersDbContext> options)
+            : base(options) { }
+
+        public DbSet<IdempotencyKey> IdempotencyKeys => Set<IdempotencyKey>();
+
+        public DbSet<TestUser> Users => Set<TestUser>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            _ = modelBuilder.ApplyPulseConfiguration(this);
+            _ = modelBuilder.Entity<TestUser>().HasIndex(u => u.Email).IsUnique();
+        }
+    }
+
+    internal sealed class TestUser
+    {
+        public int Id { get; set; }
+
+        public string Email { get; set; } = string.Empty;
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/NetEvolve.Pulse.Tests.Unit.csproj
+++ b/tests/NetEvolve.Pulse.Tests.Unit/NetEvolve.Pulse.Tests.Unit.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.Azure.Cosmos" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="MySql.Data" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="NetEvolve.Extensions.TUnit" />


### PR DESCRIPTION
StoreAsync flushes all pending changes of the shared DbContext, and the broad
message-based duplicate-key filter also swallowed unique-constraint failures
caused by other queued entities, silently dropping their data. The failure is
now attributed via DbUpdateException.Entries and only treated as an idempotent
duplicate when the violating entry is the idempotency key itself.