### PR TITLE
fix(outbox): serialize bulk executor access to the shared DbContext

### DIFF
--- a/src/NetEvolve.Pulse.EntityFramework/Outbox/EntityFrameworkOutboxRepository.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Outbox/EntityFrameworkOutboxRepository.cs
@@ -53,7 +53,9 @@ internal sealed class EntityFrameworkOutboxRepository<TContext> : IOutboxReposit
             // cannot translate a parameterised Guid collection into a SQL IN clause.
             ProviderName.OracleMySql => new MySqlOutboxRepositoryExecutor<TContext>(context, 1),
             ProviderName.Npgsql => new BulkOutboxRepositoryExecutor<TContext>(context, 1),
-            _ => new BulkOutboxRepositoryExecutor<TContext>(context, Environment.ProcessorCount - 1),
+            // DbContext is not thread-safe, so a single permit is the only safe degree of
+            // parallelism for executors sharing the scoped context instance.
+            _ => new BulkOutboxRepositoryExecutor<TContext>(context, 1),
         };
     }
 

--- a/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/EntityFrameworkOutboxRepositoryTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/EntityFrameworkOutboxRepositoryTests.cs
@@ -1,6 +1,8 @@
 ﻿namespace NetEvolve.Pulse.Tests.Unit.EntityFramework;
 
 using System;
+using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using NetEvolve.Extensions.TUnit;
@@ -10,6 +12,28 @@ using TUnit.Core;
 [TestGroup("EntityFramework")]
 public sealed class EntityFrameworkOutboxRepositoryTests
 {
+    [Test]
+    public async Task Constructor_WithRelationalProvider_CreatesExecutorWithSinglePermit()
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>().UseSqlite("Data Source=:memory:").Options;
+        var context = new TestDbContext(options);
+        await using (context.ConfigureAwait(false))
+        {
+            using var repository = new EntityFrameworkOutboxRepository<TestDbContext>(context, TimeProvider.System);
+
+            var executor = typeof(EntityFrameworkOutboxRepository<TestDbContext>)
+                .GetField("_executor", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .GetValue(repository)!;
+            var semaphore = (SemaphoreSlim)
+                executor
+                    .GetType()
+                    .GetField("_semaphore", BindingFlags.NonPublic | BindingFlags.Instance)!
+                    .GetValue(executor)!;
+
+            _ = await Assert.That(semaphore.CurrentCount).IsEqualTo(1);
+        }
+    }
+
     [Test]
     public async Task Constructor_WithNullContext_ThrowsArgumentNullException() =>
         _ = await Assert

--- a/tests/NetEvolve.Pulse.Tests.Unit/NetEvolve.Pulse.Tests.Unit.csproj
+++ b/tests/NetEvolve.Pulse.Tests.Unit/NetEvolve.Pulse.Tests.Unit.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.Azure.Cosmos" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="MySql.Data" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="NetEvolve.Extensions.TUnit" />


### PR DESCRIPTION
The default provider branch created BulkOutboxRepositoryExecutor with
Environment.ProcessorCount - 1 semaphore permits, allowing multiple
concurrent operations on one non-thread-safe DbContext and throwing at
construction on single-CPU hosts. All provider branches now use a single
permit, matching the InMemory, MySQL, and Npgsql branches.