### PR TITLE
fix(outbox): skip rows claimed concurrently in tracking executors

### DIFF
--- a/src/NetEvolve.Pulse.EntityFramework/Configurations/OutboxMessageConfigurationBase.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Configurations/OutboxMessageConfigurationBase.cs
@@ -152,10 +152,13 @@ internal abstract class OutboxMessageConfigurationBase : IEntityTypeConfiguratio
         _ = builder.Property(m => m.Error).HasColumnName(OutboxMessageSchema.Columns.Error);
 
         // Status column
+        // The status acts as an optimistic concurrency token so that change-tracking based
+        // executors detect competing pollers that claimed the same row after it was loaded.
         _ = builder
             .Property(m => m.Status)
             .HasColumnName(OutboxMessageSchema.Columns.Status)
             .HasDefaultValue(OutboxMessageStatus.Pending)
+            .IsConcurrencyToken()
             .IsRequired();
 
         // Provider-specific column type overrides

--- a/src/NetEvolve.Pulse.EntityFramework/Outbox/MySqlOutboxRepositoryExecutor.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Outbox/MySqlOutboxRepositoryExecutor.cs
@@ -79,6 +79,6 @@ internal sealed class MySqlOutboxRepositoryExecutor<TContext>(TContext context, 
             }
         }
 
-        _ = await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        _ = await SaveChangesSkippingConflictedAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/NetEvolve.Pulse.EntityFramework/Outbox/TrackingOutboxRepositoryExecutorBase.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Outbox/TrackingOutboxRepositoryExecutorBase.cs
@@ -11,6 +11,8 @@ using NetEvolve.Pulse.Extensibility.Outbox;
 /// Provides shared implementations of <see cref="FetchAndMarkAsync"/>,
 /// <see cref="UpdateByQueryAsync"/>, and <see cref="DeleteByQueryAsync"/> that load entities
 /// into the change tracker, apply in-memory mutations, and flush via <c>SaveChangesAsync</c>.
+/// Rows claimed by a competing poller between load and save are detected through the
+/// <see cref="OutboxMessage.Status"/> concurrency token and skipped instead of overwritten.
 /// Derived classes only need to implement <see cref="UpdateByIdsAsync"/>, which varies by provider.
 /// </remarks>
 /// <typeparam name="TContext">The DbContext type that implements <see cref="IOutboxDbContext"/>.</typeparam>
@@ -49,9 +51,9 @@ internal abstract class TrackingOutboxRepositoryExecutorBase<TContext>(TContext 
             entity.UpdatedAt = updatedAt;
         }
 
-        _ = await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        var conflicted = await SaveChangesSkippingConflictedAsync(cancellationToken).ConfigureAwait(false);
 
-        return entities;
+        return conflicted.Count == 0 ? entities : [.. entities.Where(e => !conflicted.Contains(e))];
     }
 
     /// <inheritdoc />
@@ -92,7 +94,7 @@ internal abstract class TrackingOutboxRepositoryExecutorBase<TContext>(TContext 
                 }
             }
 
-            _ = await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            _ = await SaveChangesSkippingConflictedAsync(cancellationToken).ConfigureAwait(false);
         }
         finally
         {
@@ -123,9 +125,40 @@ internal abstract class TrackingOutboxRepositoryExecutorBase<TContext>(TContext 
         }
 
         _context.OutboxMessages.RemoveRange(entities);
-        _ = await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        var conflicted = await SaveChangesSkippingConflictedAsync(cancellationToken).ConfigureAwait(false);
 
-        return entities.Length;
+        return entities.Length - conflicted.Count;
+    }
+
+    /// <summary>
+    /// Persists all pending changes, detaching entities that lost an optimistic concurrency
+    /// race against a competing writer and retrying until the remaining changes are saved.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The set of entities that were detached because their database row changed concurrently.</returns>
+    protected async Task<IReadOnlyCollection<object>> SaveChangesSkippingConflictedAsync(
+        CancellationToken cancellationToken
+    )
+    {
+        HashSet<object>? conflicted = null;
+
+        while (true)
+        {
+            try
+            {
+                _ = await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                return conflicted ?? (IReadOnlyCollection<object>)[];
+            }
+            catch (DbUpdateConcurrencyException ex)
+            {
+                conflicted ??= [];
+                foreach (var entry in ex.Entries)
+                {
+                    _ = conflicted.Add(entry.Entity);
+                    entry.State = EntityState.Detached;
+                }
+            }
+        }
     }
 
     protected virtual void Dispose(bool disposing)

--- a/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/TrackingOutboxRepositoryExecutorConcurrencyTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/TrackingOutboxRepositoryExecutorConcurrencyTests.cs
@@ -1,0 +1,162 @@
+namespace NetEvolve.Pulse.Tests.Unit.EntityFramework;
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility.Outbox;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("EntityFramework")]
+public sealed class TrackingOutboxRepositoryExecutorConcurrencyTests
+{
+    [Test]
+    public async Task Model_StatusProperty_IsConcurrencyToken()
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase(nameof(Model_StatusProperty_IsConcurrencyToken))
+            .Options;
+        var context = new TestDbContext(options);
+        await using (context.ConfigureAwait(false))
+        {
+            var statusProperty = context
+                .Model.FindEntityType(typeof(OutboxMessage))!
+                .FindProperty(nameof(OutboxMessage.Status))!;
+
+            _ = await Assert.That(statusProperty.IsConcurrencyToken).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task FetchAndMarkAsync_WhenCompetingPollerClaimsLoadedRows_DoesNotReturnLostRows(
+        CancellationToken cancellationToken
+    )
+    {
+        var databaseRoot = new InMemoryDatabaseRoot();
+        var databaseName = nameof(FetchAndMarkAsync_WhenCompetingPollerClaimsLoadedRows_DoesNotReturnLostRows);
+
+        var winnerOptions = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase(databaseName, databaseRoot)
+            .Options;
+        var loserOptions = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase(databaseName, databaseRoot)
+            .Options;
+
+        var winnerContext = new TestDbContext(winnerOptions);
+        await using (winnerContext.ConfigureAwait(false))
+        {
+            var loserContext = new TestDbContext(loserOptions);
+            await using (loserContext.ConfigureAwait(false))
+            {
+                var messageId = Guid.NewGuid();
+                _ = await winnerContext
+                    .OutboxMessages.AddAsync(
+                        new OutboxMessage
+                        {
+                            Id = messageId,
+                            EventType = typeof(string),
+                            Payload = "{}",
+                            CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-5),
+                            UpdatedAt = DateTimeOffset.UtcNow.AddMinutes(-5),
+                            Status = OutboxMessageStatus.Pending,
+                        },
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
+                _ = await winnerContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                winnerContext.ChangeTracker.Clear();
+
+                using var winnerExecutor = new InMemoryOutboxRepositoryExecutor<TestDbContext>(winnerContext, 1);
+                using var loserExecutor = new InMemoryOutboxRepositoryExecutor<TestDbContext>(loserContext, 1);
+
+                var winnerTimestamp = DateTimeOffset.UtcNow;
+                var loserTimestamp = winnerTimestamp.AddMilliseconds(50);
+
+                // The wrapped query lets a competing poller claim the rows after this
+                // poller has loaded them but before it saves its own claim, reproducing
+                // the read-modify-write race window.
+                var interleavedQuery = new InterleavingAsyncQueryable<OutboxMessage>(
+                    loserContext.OutboxMessages.Where(m => m.Status == OutboxMessageStatus.Pending),
+                    async () =>
+                        _ = await winnerExecutor
+                            .FetchAndMarkAsync(
+                                winnerContext.OutboxMessages.Where(m => m.Status == OutboxMessageStatus.Pending),
+                                winnerTimestamp,
+                                OutboxMessageStatus.Processing,
+                                cancellationToken
+                            )
+                            .ConfigureAwait(false)
+                );
+
+                var loserResult = await loserExecutor
+                    .FetchAndMarkAsync(
+                        interleavedQuery,
+                        loserTimestamp,
+                        OutboxMessageStatus.Processing,
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
+
+                var verificationContext = new TestDbContext(winnerOptions);
+                await using (verificationContext.ConfigureAwait(false))
+                {
+                    var storedMessage = await verificationContext
+                        .OutboxMessages.AsNoTracking()
+                        .SingleAsync(m => m.Id == messageId, cancellationToken)
+                        .ConfigureAwait(false);
+
+                    using (Assert.Multiple())
+                    {
+                        _ = await Assert.That(loserResult).IsEmpty();
+                        _ = await Assert.That(storedMessage.Status).IsEqualTo(OutboxMessageStatus.Processing);
+                        _ = await Assert.That(storedMessage.UpdatedAt).IsEqualTo(winnerTimestamp);
+                    }
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Wraps an EF Core query so that a callback runs after the inner query has been fully
+    /// enumerated but before the buffered results are handed to the caller.
+    /// </summary>
+    private sealed class InterleavingAsyncQueryable<T>(IQueryable<T> inner, Func<Task> afterEnumeration)
+        : IQueryable<T>,
+            IAsyncEnumerable<T>
+    {
+        public Type ElementType => inner.ElementType;
+
+        public Expression Expression => inner.Expression;
+
+        public IQueryProvider Provider => inner.Provider;
+
+        public IEnumerator<T> GetEnumerator() => inner.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            var buffer = new List<T>();
+            await foreach (
+                var item in ((IAsyncEnumerable<T>)inner).WithCancellation(cancellationToken).ConfigureAwait(false)
+            )
+            {
+                buffer.Add(item);
+            }
+
+            await afterEnumeration().ConfigureAwait(false);
+
+            foreach (var item in buffer)
+            {
+                yield return item;
+            }
+        }
+    }
+}


### PR DESCRIPTION
The tracking FetchAndMarkAsync loaded pending rows, mutated them in memory,
and saved without any concurrency guard, so two pollers could both claim and
publish the same messages via last-writer-wins updates. The Status column is
now an optimistic concurrency token, and the tracking executors detach rows
that lost the race instead of overwriting the winner's claim.