### PR TITLE
perf(outbox): delete tracked outbox rows via key projection

### DIFF
--- a/src/NetEvolve.Pulse.EntityFramework/Outbox/TrackingOutboxRepositoryExecutorBase.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Outbox/TrackingOutboxRepositoryExecutorBase.cs
@@ -8,9 +8,10 @@ using NetEvolve.Pulse.Extensibility.Outbox;
 /// through EF Core change tracking and <c>SaveChangesAsync</c>.
 /// </summary>
 /// <remarks>
-/// Provides shared implementations of <see cref="FetchAndMarkAsync"/>,
-/// <see cref="UpdateByQueryAsync"/>, and <see cref="DeleteByQueryAsync"/> that load entities
-/// into the change tracker, apply in-memory mutations, and flush via <c>SaveChangesAsync</c>.
+/// Provides shared implementations of <see cref="FetchAndMarkAsync"/> and
+/// <see cref="UpdateByQueryAsync"/> that load entities into the change tracker, apply in-memory
+/// mutations, and flush via <c>SaveChangesAsync</c>. <see cref="DeleteByQueryAsync"/> projects
+/// only the entity keys and deletes through key stubs, avoiding materialization of payloads.
 /// Rows claimed by a competing poller between load and save are detected through the
 /// <see cref="OutboxMessage.Status"/> concurrency token and skipped instead of overwritten.
 /// Derived classes only need to implement <see cref="UpdateByIdsAsync"/>, which varies by provider.
@@ -117,11 +118,27 @@ internal abstract class TrackingOutboxRepositoryExecutorBase<TContext>(TContext 
     /// <inheritdoc />
     public async Task<int> DeleteByQueryAsync(IQueryable<OutboxMessage> query, CancellationToken cancellationToken)
     {
-        var entities = await query.ToArrayAsync(cancellationToken).ConfigureAwait(false);
+        // Project only the key (plus status) instead of materializing full entities —
+        // deleting does not need the potentially large payload column in memory.
+        var rows = await query
+            .Select(m => new { m.Id, m.Status })
+            .ToArrayAsync(cancellationToken)
+            .ConfigureAwait(false);
 
-        if (entities.Length == 0)
+        if (rows.Length == 0)
         {
             return 0;
+        }
+
+        var tracked = _context.ChangeTracker.Entries<OutboxMessage>().ToDictionary(e => e.Entity.Id, e => e.Entity);
+
+        var entities = new OutboxMessage[rows.Length];
+        for (var i = 0; i < rows.Length; i++)
+        {
+            var row = rows[i];
+            entities[i] = tracked.TryGetValue(row.Id, out var entity)
+                ? entity
+                : new OutboxMessage { Id = row.Id, Status = row.Status };
         }
 
         _context.OutboxMessages.RemoveRange(entities);

--- a/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/TrackingOutboxRepositoryExecutorDeleteTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/TrackingOutboxRepositoryExecutorDeleteTests.cs
@@ -1,0 +1,185 @@
+namespace NetEvolve.Pulse.Tests.Unit.EntityFramework;
+
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility.Outbox;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("EntityFramework")]
+public sealed class TrackingOutboxRepositoryExecutorDeleteTests
+{
+    [Test]
+    public async Task DeleteByQueryAsync_DoesNotMaterializePayloadColumn(CancellationToken cancellationToken)
+    {
+        var connection = new SqliteConnection("Data Source=:memory:");
+        await using (connection.ConfigureAwait(false))
+        {
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            var interceptor = new RecordingCommandInterceptor();
+            var options = new DbContextOptionsBuilder<TestDbContext>()
+                .UseSqlite(connection)
+                .AddInterceptors(interceptor)
+                .Options;
+            var context = new TestDbContext(options);
+            await using (context.ConfigureAwait(false))
+            {
+                _ = await context.Database.EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+
+                var cutoff = DateTimeOffset.UtcNow;
+                for (var i = 0; i < 3; i++)
+                {
+                    _ = await context
+                        .OutboxMessages.AddAsync(
+                            CreateMessage(OutboxMessageStatus.Completed, cutoff.AddMinutes(-10)),
+                            cancellationToken
+                        )
+                        .ConfigureAwait(false);
+                }
+                _ = await context
+                    .OutboxMessages.AddAsync(CreateMessage(OutboxMessageStatus.Pending, null), cancellationToken)
+                    .ConfigureAwait(false);
+                _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                context.ChangeTracker.Clear();
+
+                using var executor = new InMemoryOutboxRepositoryExecutor<TestDbContext>(context, 1);
+
+                interceptor.StartRecording();
+
+                var deleted = await executor
+                    .DeleteByQueryAsync(
+                        context.OutboxMessages.Where(m =>
+                            m.Status == OutboxMessageStatus.Completed && m.ProcessedAt < cutoff
+                        ),
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
+
+                var remaining = await context
+                    .OutboxMessages.AsNoTracking()
+                    .CountAsync(cancellationToken)
+                    .ConfigureAwait(false);
+
+                var payloadQueries = interceptor
+                    .RecordedCommands.Where(c =>
+                        c.StartsWith("SELECT", StringComparison.OrdinalIgnoreCase)
+                        && c.Contains("Payload", StringComparison.OrdinalIgnoreCase)
+                    )
+                    .ToArray();
+
+                using (Assert.Multiple())
+                {
+                    _ = await Assert.That(deleted).IsEqualTo(3);
+                    _ = await Assert.That(remaining).IsEqualTo(1);
+                    _ = await Assert.That(payloadQueries).IsEmpty();
+                }
+            }
+        }
+    }
+
+    [Test]
+    public async Task DeleteByQueryAsync_WithAlreadyTrackedEntity_DeletesAllMatches(CancellationToken cancellationToken)
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase(nameof(DeleteByQueryAsync_WithAlreadyTrackedEntity_DeletesAllMatches))
+            .Options;
+        var context = new TestDbContext(options);
+        await using (context.ConfigureAwait(false))
+        {
+            var cutoff = DateTimeOffset.UtcNow;
+            var trackedMessage = CreateMessage(OutboxMessageStatus.Completed, cutoff.AddMinutes(-10));
+            _ = await context.OutboxMessages.AddAsync(trackedMessage, cancellationToken).ConfigureAwait(false);
+            _ = await context
+                .OutboxMessages.AddAsync(
+                    CreateMessage(OutboxMessageStatus.Completed, cutoff.AddMinutes(-10)),
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+            _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            // trackedMessage stays tracked; the executor must reuse the tracked instance
+            // instead of attaching a conflicting stub with the same key.
+            using var executor = new InMemoryOutboxRepositoryExecutor<TestDbContext>(context, 1);
+
+            var deleted = await executor
+                .DeleteByQueryAsync(
+                    context.OutboxMessages.Where(m =>
+                        m.Status == OutboxMessageStatus.Completed && m.ProcessedAt < cutoff
+                    ),
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+
+            var remaining = await context
+                .OutboxMessages.AsNoTracking()
+                .CountAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            using (Assert.Multiple())
+            {
+                _ = await Assert.That(deleted).IsEqualTo(2);
+                _ = await Assert.That(remaining).IsEqualTo(0);
+            }
+        }
+    }
+
+    private static OutboxMessage CreateMessage(OutboxMessageStatus status, DateTimeOffset? processedAt) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            EventType = typeof(string),
+            Payload = new string('x', 4096),
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-30),
+            UpdatedAt = DateTimeOffset.UtcNow.AddMinutes(-30),
+            ProcessedAt = processedAt,
+            Status = status,
+        };
+
+    private sealed class RecordingCommandInterceptor : DbCommandInterceptor
+    {
+        private readonly List<string> _commands = [];
+        private bool _recording;
+
+        public IReadOnlyList<string> RecordedCommands => _commands;
+
+        public void StartRecording() => _recording = true;
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result
+        )
+        {
+            Record(command);
+            return result;
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default
+        )
+        {
+            Record(command);
+            return ValueTask.FromResult(result);
+        }
+
+        private void Record(DbCommand command)
+        {
+            if (_recording)
+            {
+                _commands.Add(command.CommandText);
+            }
+        }
+    }
+}


### PR DESCRIPTION
DeleteByQueryAsync materialized every matching OutboxMessage entity,
including unbounded payload columns, into the change tracker just to remove
the rows. It now projects only the key and status, reuses already tracked
instances, and deletes through lightweight stub entities.