### PR TITLE
fix(outbox): guard all tracking executor operations with the semaphore

### DIFF
--- a/src/NetEvolve.Pulse.EntityFramework/Outbox/MySqlOutboxRepositoryExecutor.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Outbox/MySqlOutboxRepositoryExecutor.cs
@@ -43,42 +43,50 @@ internal sealed class MySqlOutboxRepositoryExecutor<TContext>(TContext context, 
         CancellationToken cancellationToken
     )
     {
-        // bulkQuery contains a Guid IN clause that MySQL cannot type-map.
-        // Use FindAsync per ID instead: it resolves the column's own type mapping and
-        // checks the DbContext Local cache before hitting the database.
-        var entities = new List<OutboxMessage>(ids.Count);
-
-        foreach (var id in ids)
+        await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
         {
-            var entity = await _context.OutboxMessages.FindAsync([id], cancellationToken).ConfigureAwait(false);
+            // bulkQuery contains a Guid IN clause that MySQL cannot type-map.
+            // Use FindAsync per ID instead: it resolves the column's own type mapping and
+            // checks the DbContext Local cache before hitting the database.
+            var entities = new List<OutboxMessage>(ids.Count);
 
-            if (entity?.Status == OutboxMessageStatus.Processing)
+            foreach (var id in ids)
             {
-                entities.Add(entity);
-            }
-        }
+                var entity = await _context.OutboxMessages.FindAsync([id], cancellationToken).ConfigureAwait(false);
 
-        if (entities.Count == 0)
+                if (entity?.Status == OutboxMessageStatus.Processing)
+                {
+                    entities.Add(entity);
+                }
+            }
+
+            if (entities.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var entity in entities)
+            {
+                entity.Status = newStatus;
+                entity.UpdatedAt = updatedAt;
+                if (processedAt.HasValue)
+                {
+                    entity.ProcessedAt = processedAt.Value;
+                }
+                entity.NextRetryAt = nextRetryAt;
+                entity.RetryCount += retryIncrement;
+                if (!string.IsNullOrWhiteSpace(errorMessage))
+                {
+                    entity.Error = errorMessage;
+                }
+            }
+
+            _ = await SaveChangesSkippingConflictedAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
         {
-            return;
+            _ = _semaphore.Release();
         }
-
-        foreach (var entity in entities)
-        {
-            entity.Status = newStatus;
-            entity.UpdatedAt = updatedAt;
-            if (processedAt.HasValue)
-            {
-                entity.ProcessedAt = processedAt.Value;
-            }
-            entity.NextRetryAt = nextRetryAt;
-            entity.RetryCount += retryIncrement;
-            if (!string.IsNullOrWhiteSpace(errorMessage))
-            {
-                entity.Error = errorMessage;
-            }
-        }
-
-        _ = await SaveChangesSkippingConflictedAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/NetEvolve.Pulse.EntityFramework/Outbox/TrackingOutboxRepositoryExecutorBase.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Outbox/TrackingOutboxRepositoryExecutorBase.cs
@@ -39,22 +39,30 @@ internal abstract class TrackingOutboxRepositoryExecutorBase<TContext>(TContext 
         CancellationToken cancellationToken
     )
     {
-        var entities = await baseQuery.ToArrayAsync(cancellationToken).ConfigureAwait(false);
-
-        if (entities.Length == 0)
+        await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
         {
-            return entities;
-        }
+            var entities = await baseQuery.ToArrayAsync(cancellationToken).ConfigureAwait(false);
 
-        foreach (var entity in entities)
+            if (entities.Length == 0)
+            {
+                return entities;
+            }
+
+            foreach (var entity in entities)
+            {
+                entity.Status = newStatus;
+                entity.UpdatedAt = updatedAt;
+            }
+
+            var conflicted = await SaveChangesSkippingConflictedAsync(cancellationToken).ConfigureAwait(false);
+
+            return conflicted.Count == 0 ? entities : [.. entities.Where(e => !conflicted.Contains(e))];
+        }
+        finally
         {
-            entity.Status = newStatus;
-            entity.UpdatedAt = updatedAt;
+            _ = _semaphore.Release();
         }
-
-        var conflicted = await SaveChangesSkippingConflictedAsync(cancellationToken).ConfigureAwait(false);
-
-        return conflicted.Count == 0 ? entities : [.. entities.Where(e => !conflicted.Contains(e))];
     }
 
     /// <inheritdoc />
@@ -118,33 +126,41 @@ internal abstract class TrackingOutboxRepositoryExecutorBase<TContext>(TContext 
     /// <inheritdoc />
     public async Task<int> DeleteByQueryAsync(IQueryable<OutboxMessage> query, CancellationToken cancellationToken)
     {
-        // Project only the key (plus status) instead of materializing full entities —
-        // deleting does not need the potentially large payload column in memory.
-        var rows = await query
-            .Select(m => new { m.Id, m.Status })
-            .ToArrayAsync(cancellationToken)
-            .ConfigureAwait(false);
-
-        if (rows.Length == 0)
+        await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
         {
-            return 0;
+            // Project only the key (plus status) instead of materializing full entities —
+            // deleting does not need the potentially large payload column in memory.
+            var rows = await query
+                .Select(m => new { m.Id, m.Status })
+                .ToArrayAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            if (rows.Length == 0)
+            {
+                return 0;
+            }
+
+            var tracked = _context.ChangeTracker.Entries<OutboxMessage>().ToDictionary(e => e.Entity.Id, e => e.Entity);
+
+            var entities = new OutboxMessage[rows.Length];
+            for (var i = 0; i < rows.Length; i++)
+            {
+                var row = rows[i];
+                entities[i] = tracked.TryGetValue(row.Id, out var entity)
+                    ? entity
+                    : new OutboxMessage { Id = row.Id, Status = row.Status };
+            }
+
+            _context.OutboxMessages.RemoveRange(entities);
+            var conflicted = await SaveChangesSkippingConflictedAsync(cancellationToken).ConfigureAwait(false);
+
+            return entities.Length - conflicted.Count;
         }
-
-        var tracked = _context.ChangeTracker.Entries<OutboxMessage>().ToDictionary(e => e.Entity.Id, e => e.Entity);
-
-        var entities = new OutboxMessage[rows.Length];
-        for (var i = 0; i < rows.Length; i++)
+        finally
         {
-            var row = rows[i];
-            entities[i] = tracked.TryGetValue(row.Id, out var entity)
-                ? entity
-                : new OutboxMessage { Id = row.Id, Status = row.Status };
+            _ = _semaphore.Release();
         }
-
-        _context.OutboxMessages.RemoveRange(entities);
-        var conflicted = await SaveChangesSkippingConflictedAsync(cancellationToken).ConfigureAwait(false);
-
-        return entities.Length - conflicted.Count;
     }
 
     /// <summary>

--- a/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/TrackingOutboxRepositoryExecutorSemaphoreTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/TrackingOutboxRepositoryExecutorSemaphoreTests.cs
@@ -1,0 +1,155 @@
+namespace NetEvolve.Pulse.Tests.Unit.EntityFramework;
+
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility.Outbox;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("EntityFramework")]
+public sealed class TrackingOutboxRepositoryExecutorSemaphoreTests
+{
+    [Test]
+    public async Task FetchAndMarkAsync_WhileSemaphoreHeld_WaitsForRelease(CancellationToken cancellationToken)
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase(nameof(FetchAndMarkAsync_WhileSemaphoreHeld_WaitsForRelease))
+            .Options;
+        var context = new TestDbContext(options);
+        await using (context.ConfigureAwait(false))
+        {
+            await SeedMessageAsync(context, OutboxMessageStatus.Pending, cancellationToken).ConfigureAwait(false);
+
+            using var executor = new InMemoryOutboxRepositoryExecutor<TestDbContext>(context, 1);
+            var semaphore = GetSemaphore(executor);
+
+            await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+            var operation = executor.FetchAndMarkAsync(
+                context.OutboxMessages.Where(m => m.Status == OutboxMessageStatus.Pending),
+                DateTimeOffset.UtcNow,
+                OutboxMessageStatus.Processing,
+                cancellationToken
+            );
+
+            var completedWhileHeld = await Task.WhenAny(operation, Task.Delay(500, cancellationToken))
+                .ConfigureAwait(false);
+            _ = await Assert.That(completedWhileHeld).IsNotEqualTo((Task)operation);
+
+            _ = semaphore.Release();
+
+            var result = await operation.ConfigureAwait(false);
+            _ = await Assert.That(result).HasCount().EqualTo(1);
+        }
+    }
+
+    [Test]
+    public async Task DeleteByQueryAsync_WhileSemaphoreHeld_WaitsForRelease(CancellationToken cancellationToken)
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase(nameof(DeleteByQueryAsync_WhileSemaphoreHeld_WaitsForRelease))
+            .Options;
+        var context = new TestDbContext(options);
+        await using (context.ConfigureAwait(false))
+        {
+            await SeedMessageAsync(context, OutboxMessageStatus.Completed, cancellationToken).ConfigureAwait(false);
+
+            using var executor = new InMemoryOutboxRepositoryExecutor<TestDbContext>(context, 1);
+            var semaphore = GetSemaphore(executor);
+
+            await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+            var operation = executor.DeleteByQueryAsync(
+                context.OutboxMessages.Where(m => m.Status == OutboxMessageStatus.Completed),
+                cancellationToken
+            );
+
+            var completedWhileHeld = await Task.WhenAny(operation, Task.Delay(500, cancellationToken))
+                .ConfigureAwait(false);
+            _ = await Assert.That(completedWhileHeld).IsNotEqualTo((Task)operation);
+
+            _ = semaphore.Release();
+
+            var deleted = await operation.ConfigureAwait(false);
+            _ = await Assert.That(deleted).IsEqualTo(1);
+        }
+    }
+
+    [Test]
+    public async Task UpdateByIdsAsync_MySqlExecutor_WhileSemaphoreHeld_WaitsForRelease(
+        CancellationToken cancellationToken
+    )
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase(nameof(UpdateByIdsAsync_MySqlExecutor_WhileSemaphoreHeld_WaitsForRelease))
+            .Options;
+        var context = new TestDbContext(options);
+        await using (context.ConfigureAwait(false))
+        {
+            var messageId = await SeedMessageAsync(context, OutboxMessageStatus.Processing, cancellationToken)
+                .ConfigureAwait(false);
+
+            using var executor = new MySqlOutboxRepositoryExecutor<TestDbContext>(context, 1);
+            var semaphore = GetSemaphore(executor);
+
+            await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+            var operation = executor.UpdateByIdsAsync(
+                [messageId],
+                DateTimeOffset.UtcNow,
+                DateTimeOffset.UtcNow,
+                null,
+                OutboxMessageStatus.Completed,
+                0,
+                null,
+                cancellationToken
+            );
+
+            var completedWhileHeld = await Task.WhenAny(operation, Task.Delay(500, cancellationToken))
+                .ConfigureAwait(false);
+            _ = await Assert.That(completedWhileHeld).IsNotEqualTo(operation);
+
+            _ = semaphore.Release();
+
+            await operation.ConfigureAwait(false);
+
+            var message = await context
+                .OutboxMessages.SingleAsync(m => m.Id == messageId, cancellationToken)
+                .ConfigureAwait(false);
+            _ = await Assert.That(message.Status).IsEqualTo(OutboxMessageStatus.Completed);
+        }
+    }
+
+    private static async Task<Guid> SeedMessageAsync(
+        TestDbContext context,
+        OutboxMessageStatus status,
+        CancellationToken cancellationToken
+    )
+    {
+        var message = new OutboxMessage
+        {
+            Id = Guid.NewGuid(),
+            EventType = typeof(string),
+            Payload = "{}",
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            ProcessedAt = status == OutboxMessageStatus.Completed ? DateTimeOffset.UtcNow.AddMinutes(-10) : null,
+            Status = status,
+        };
+        _ = await context.OutboxMessages.AddAsync(message, cancellationToken).ConfigureAwait(false);
+        _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        context.ChangeTracker.Clear();
+        return message.Id;
+    }
+
+    private static SemaphoreSlim GetSemaphore(object executor) =>
+        (SemaphoreSlim)
+            typeof(TrackingOutboxRepositoryExecutorBase<TestDbContext>)
+                .GetField("_semaphore", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .GetValue(executor)!;
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/TrackingOutboxRepositoryExecutorSemaphoreTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/TrackingOutboxRepositoryExecutorSemaphoreTests.cs
@@ -23,7 +23,7 @@ public sealed class TrackingOutboxRepositoryExecutorSemaphoreTests
         var context = new TestDbContext(options);
         await using (context.ConfigureAwait(false))
         {
-            await SeedMessageAsync(context, OutboxMessageStatus.Pending, cancellationToken).ConfigureAwait(false);
+            _ = await SeedMessageAsync(context, OutboxMessageStatus.Pending, cancellationToken).ConfigureAwait(false);
 
             using var executor = new InMemoryOutboxRepositoryExecutor<TestDbContext>(context, 1);
             var semaphore = GetSemaphore(executor);
@@ -57,7 +57,7 @@ public sealed class TrackingOutboxRepositoryExecutorSemaphoreTests
         var context = new TestDbContext(options);
         await using (context.ConfigureAwait(false))
         {
-            await SeedMessageAsync(context, OutboxMessageStatus.Completed, cancellationToken).ConfigureAwait(false);
+            _ = await SeedMessageAsync(context, OutboxMessageStatus.Completed, cancellationToken).ConfigureAwait(false);
 
             using var executor = new InMemoryOutboxRepositoryExecutor<TestDbContext>(context, 1);
             var semaphore = GetSemaphore(executor);


### PR DESCRIPTION
FetchAndMarkAsync, DeleteByQueryAsync, and the MySQL UpdateByIdsAsync override
queried and flushed the shared DbContext without acquiring the executor
semaphore, so they could run concurrently with guarded operations on the same
non-thread-safe context. All mutating operations now serialize on the
semaphore like UpdateByQueryAsync.