### PR TITLE
perf(outbox): cache Type.GetType lookups in the event type converter

### DIFF
--- a/src/NetEvolve.Pulse.EntityFramework/Configurations/TypeValueConverter.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Configurations/TypeValueConverter.cs
@@ -1,5 +1,6 @@
 namespace NetEvolve.Pulse.Configurations;
 
+using System.Collections.Concurrent;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetEvolve.Pulse.Extensibility.Outbox;
 
@@ -14,6 +15,15 @@ using NetEvolve.Pulse.Extensibility.Outbox;
 /// </remarks>
 internal sealed class TypeValueConverter : ValueConverter<Type, string>
 {
+    /// <summary>
+    /// Caches resolved types by their assembly-qualified name. <see cref="Type.GetType(string)"/>
+    /// parses the name and probes loaded assemblies on every call, which is measurable in the
+    /// outbox polling hot path where the conversion runs once per materialized row. The set of
+    /// distinct event type names is small and bounded, so the cache cannot grow unbounded.
+    /// Failed resolutions are not cached and throw on every attempt.
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, Type> _typeCache = new(StringComparer.Ordinal);
+
     /// <summary>
     /// Initializes a new instance of the <see cref="TypeValueConverter"/> class.
     /// </summary>
@@ -38,5 +48,9 @@ internal sealed class TypeValueConverter : ValueConverter<Type, string>
     }
 
     private static Type ConvertFromString(string typeName) =>
-        Type.GetType(typeName) ?? throw new InvalidOperationException($"Cannot resolve event type '{typeName}'.");
+        _typeCache.GetOrAdd(
+            typeName,
+            static name =>
+                Type.GetType(name) ?? throw new InvalidOperationException($"Cannot resolve event type '{name}'.")
+        );
 }

--- a/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/TypeValueConverterTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/TypeValueConverterTests.cs
@@ -54,4 +54,38 @@ public sealed class TypeValueConverterTests
             .That(() => fromProvider("Invalid.Type.Name, InvalidAssembly"))
             .Throws<InvalidOperationException>();
     }
+
+    [Test]
+    public async Task ConvertFromProvider_Called_repeatedly_returns_same_type()
+    {
+        var converter = new TypeValueConverter();
+        var fromProvider = converter.ConvertFromProvider;
+        var typeName = typeof(TypeValueConverterTests).AssemblyQualifiedName;
+
+        var first = fromProvider(typeName) as Type;
+        var second = fromProvider(typeName) as Type;
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(first).IsEqualTo(typeof(TypeValueConverterTests));
+            _ = await Assert.That(second).IsSameReferenceAs(first);
+        }
+    }
+
+    [Test]
+    public async Task ConvertFromProvider_With_invalid_type_name_throws_on_every_attempt()
+    {
+        var converter = new TypeValueConverter();
+        var fromProvider = converter.ConvertFromProvider;
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert
+                .That(() => fromProvider("Invalid.Repeated.Type, InvalidAssembly"))
+                .Throws<InvalidOperationException>();
+            _ = await Assert
+                .That(() => fromProvider("Invalid.Repeated.Type, InvalidAssembly"))
+                .Throws<InvalidOperationException>();
+        }
+    }
 }


### PR DESCRIPTION
ConvertFromString resolved the assembly-qualified type name via Type.GetType
for every materialized outbox row, re-parsing the name and probing loaded
assemblies on each poll. Resolved types are now memoized in a static
ConcurrentDictionary; failed resolutions still throw on every attempt.