### PR TITLE
perf(outbox): document per-id fallback and make batch MarkAs defaults sequential

### DIFF
--- a/src/NetEvolve.Pulse.Extensibility/Outbox/IOutboxRepository.cs
+++ b/src/NetEvolve.Pulse.Extensibility/Outbox/IOutboxRepository.cs
@@ -56,6 +56,12 @@ public interface IOutboxRepository
     /// <param name="messageIds">The IDs of the messages to mark as completed.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
+    /// <remarks>
+    /// The default implementation calls <see cref="MarkAsCompletedAsync(Guid, CancellationToken)"/>
+    /// once per id sequentially, resulting in one storage round trip per message. Implementations
+    /// SHOULD override this overload with a single set-based storage operation
+    /// (e.g., <c>UPDATE ... WHERE Id IN (...)</c>) to reduce round trips for large batches.
+    /// </remarks>
     async Task MarkAsCompletedAsync(IReadOnlyCollection<Guid> messageIds, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(messageIds);
@@ -107,6 +113,10 @@ public interface IOutboxRepository
     /// <returns>A task representing the asynchronous operation.</returns>
     /// <remarks>
     /// Implementations SHOULD increment the retry count and update the status accordingly.
+    /// The default implementation calls <see cref="MarkAsFailedAsync(Guid, string, CancellationToken)"/>
+    /// once per id sequentially, resulting in one storage round trip per message. Implementations
+    /// SHOULD override this overload with a single set-based storage operation
+    /// (e.g., <c>UPDATE ... WHERE Id IN (...)</c>) to reduce round trips for large batches.
     /// </remarks>
     async Task MarkAsFailedAsync(
         IReadOnlyCollection<Guid> messageIds,
@@ -138,6 +148,12 @@ public interface IOutboxRepository
     /// <param name="errorMessage">The final error message.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
+    /// <remarks>
+    /// The default implementation calls <see cref="MarkAsDeadLetterAsync(Guid, string, CancellationToken)"/>
+    /// once per id sequentially, resulting in one storage round trip per message. Implementations
+    /// SHOULD override this overload with a single set-based storage operation
+    /// (e.g., <c>UPDATE ... WHERE Id IN (...)</c>) to reduce round trips for large batches.
+    /// </remarks>
     async Task MarkAsDeadLetterAsync(
         IReadOnlyCollection<Guid> messageIds,
         string errorMessage,

--- a/tests/NetEvolve.Pulse.Tests.Unit/Outbox/IOutboxRepositoryTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Outbox/IOutboxRepositoryTests.cs
@@ -45,6 +45,11 @@ public sealed class IOutboxRepositoryTests
 
         _ = await Assert.That(repository.OverlapDetected).IsFalse();
         await AssertCallOrderAsync(repository, messageIds).ConfigureAwait(false);
+        _ = await Assert.That(repository.ErrorMessages.Count).IsEqualTo(messageIds.Count);
+        foreach (var errorMessage in repository.ErrorMessages)
+        {
+            _ = await Assert.That(errorMessage).IsEqualTo("error");
+        }
     }
 
     [Test]
@@ -59,6 +64,11 @@ public sealed class IOutboxRepositoryTests
 
         _ = await Assert.That(repository.OverlapDetected).IsFalse();
         await AssertCallOrderAsync(repository, messageIds).ConfigureAwait(false);
+        _ = await Assert.That(repository.ErrorMessages.Count).IsEqualTo(messageIds.Count);
+        foreach (var errorMessage in repository.ErrorMessages)
+        {
+            _ = await Assert.That(errorMessage).IsEqualTo("error");
+        }
     }
 
     private static List<Guid> CreateMessageIds() => [Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()];
@@ -89,20 +99,22 @@ public sealed class IOutboxRepositoryTests
 
         public List<Guid> CallOrder { get; } = [];
 
+        public List<string> ErrorMessages { get; } = [];
+
         public Task MarkAsCompletedAsync(Guid messageId, CancellationToken cancellationToken = default) =>
-            RecordCallAsync(messageId);
+            RecordCallAsync(messageId, null);
 
         public Task MarkAsFailedAsync(
             Guid messageId,
             string errorMessage,
             CancellationToken cancellationToken = default
-        ) => RecordCallAsync(messageId);
+        ) => RecordCallAsync(messageId, errorMessage);
 
         public Task MarkAsDeadLetterAsync(
             Guid messageId,
             string errorMessage,
             CancellationToken cancellationToken = default
-        ) => RecordCallAsync(messageId);
+        ) => RecordCallAsync(messageId, errorMessage);
 
         public Task AddAsync(OutboxMessage message, CancellationToken cancellationToken = default) =>
             Task.CompletedTask;
@@ -123,7 +135,7 @@ public sealed class IOutboxRepositoryTests
 
         public void Dispose() => _subsequentCallStarted.Dispose();
 
-        private async Task RecordCallAsync(Guid messageId)
+        private async Task RecordCallAsync(Guid messageId, string? errorMessage)
         {
             if (Interlocked.Increment(ref _activeCalls) > 1)
             {
@@ -133,6 +145,10 @@ public sealed class IOutboxRepositoryTests
             lock (CallOrder)
             {
                 CallOrder.Add(messageId);
+                if (errorMessage is not null)
+                {
+                    ErrorMessages.Add(errorMessage);
+                }
             }
 
             if (Interlocked.Increment(ref _totalCalls) == 1)


### PR DESCRIPTION
The default batch overloads of MarkAsCompletedAsync, MarkAsFailedAsync,
and MarkAsDeadLetterAsync decompose N ids into N single-id calls, one
storage round trip each. True set-based batching must live in providers,
so the XML docs now direct implementers to override with a single
set-based operation, and the default fallback iterates sequentially
instead of fanning out in parallel on one repository instance.