### PR TITLE
fix(outbox): resolve SendBatchAsync doc and behavior contradiction

### DIFF
--- a/src/NetEvolve.Pulse.Extensibility/Outbox/IMessageTransport.cs
+++ b/src/NetEvolve.Pulse.Extensibility/Outbox/IMessageTransport.cs
@@ -59,35 +59,30 @@ public interface IMessageTransport
     }
 
     /// <summary>
-    /// Internal implementation of batch sending that dispatches each message concurrently via <see cref="SendAsync"/>.
-    /// Uses <see cref="Parallel.ForEachAsync{TSource}(IEnumerable{TSource}, CancellationToken, Func{TSource, CancellationToken, ValueTask})"/> to maximize throughput while respecting the provided cancellation token.
+    /// Internal implementation of batch sending that dispatches each message sequentially via <see cref="SendAsync"/>,
+    /// preserving the enumeration order of <paramref name="messages"/>.
     /// </summary>
     /// <remarks>
     /// <para><strong>Concurrency Model:</strong></para>
-    /// Messages are processed in parallel (not sequentially), which may improve throughput significantly.
-    /// The degree of parallelism is determined by the system's thread pool.
+    /// Messages are sent one at a time in enumeration order; <see cref="SendAsync"/> is never invoked
+    /// concurrently by this implementation, matching the documented contract of <see cref="SendBatchAsync"/>.
     /// <para><strong>Error Handling:</strong></para>
-    /// Individual message send failures propagate as exceptions and interrupt batch processing.
-    /// The first exception encountered will be thrown, terminating the batch operation.
+    /// The first send failure propagates as an exception and terminates the batch operation (fail-fast);
+    /// messages after the failed one are not attempted, so a subset of the batch may have been delivered.
     /// <para><strong>Cancellation:</strong></para>
-    /// If the cancellation token is triggered, all remaining concurrent operations are cancelled,
-    /// and the task completes. Already-attempted messages may have partial results depending on
-    /// the transport's concurrency model.
+    /// Cancellation is observed before each send; already-sent messages are unaffected.
     /// </remarks>
-    /// <param name="messages">The collection of messages to send concurrently.</param>
+    /// <param name="messages">The collection of messages to send sequentially.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
-    /// <returns>A task representing the concurrent send operation that completes when all messages have been attempted.</returns>
-    private async Task SendBatchInternalAsync(
-        IEnumerable<OutboxMessage> messages,
-        CancellationToken cancellationToken
-    ) =>
-        await Parallel
-            .ForEachAsync(
-                messages,
-                cancellationToken,
-                async (message, token) => await SendAsync(message, token).ConfigureAwait(false)
-            )
-            .ConfigureAwait(false);
+    /// <returns>A task representing the sequential send operation that completes when all messages have been sent.</returns>
+    private async Task SendBatchInternalAsync(IEnumerable<OutboxMessage> messages, CancellationToken cancellationToken)
+    {
+        foreach (var message in messages)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await SendAsync(message, cancellationToken).ConfigureAwait(false);
+        }
+    }
 
     /// <summary>
     /// Checks if the transport is healthy and ready to send messages.

--- a/tests/NetEvolve.Pulse.Tests.Unit/Outbox/IMessageTransportTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Outbox/IMessageTransportTests.cs
@@ -13,8 +13,8 @@ using TUnit.Core;
 
 /// <summary>
 /// Unit tests for the default interface implementations on <see cref="IMessageTransport"/>,
-/// in particular <see cref="IMessageTransport.SendBatchAsync"/>, which fans out to
-/// <see cref="IMessageTransport.SendAsync"/> concurrently via <see cref="Parallel.ForEachAsync{TSource}(System.Collections.Generic.IEnumerable{TSource}, System.Threading.CancellationToken, System.Func{TSource, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask})"/>
+/// in particular <see cref="IMessageTransport.SendBatchAsync"/>, which calls
+/// <see cref="IMessageTransport.SendAsync"/> for each message sequentially, as documented,
 /// for implementations that do not override the batch method.
 /// </summary>
 [TestGroup("Outbox")]
@@ -43,6 +43,17 @@ public sealed class IMessageTransportTests
     }
 
     [Test]
+    public async Task SendBatchAsync_DefaultImplementation_InvokesSendAsyncSequentiallyAsDocumented()
+    {
+        using var transport = new OverlapDetectingTransport();
+        var messages = new List<OutboxMessage> { CreateMessage(), CreateMessage(), CreateMessage(), CreateMessage() };
+
+        await ((IMessageTransport)transport).SendBatchAsync(messages, CancellationToken.None).ConfigureAwait(false);
+
+        _ = await Assert.That(transport.OverlapDetected).IsFalse();
+    }
+
+    [Test]
     public async Task SendBatchAsync_WithoutOverride_WithNullMessages_ThrowsArgumentNullException()
     {
         var transport = new SendAsyncOnlyTransport();
@@ -64,9 +75,45 @@ public sealed class IMessageTransportTests
         };
 
     /// <summary>
+    /// Transport implementing only <see cref="IMessageTransport.SendAsync"/> that detects overlapping
+    /// (concurrent) invocations. The first send waits briefly for a subsequent send to start; if one
+    /// starts before the first completes, the default batch dispatch is concurrent and violates the
+    /// documented sequential contract of <see cref="IMessageTransport.SendBatchAsync"/>.
+    /// </summary>
+    private sealed class OverlapDetectingTransport : IMessageTransport, IDisposable
+    {
+        private readonly SemaphoreSlim _subsequentSendStarted = new(0);
+        private int _activeSends;
+        private int _totalSends;
+
+        public bool OverlapDetected { get; private set; }
+
+        public async Task SendAsync(OutboxMessage message, CancellationToken cancellationToken = default)
+        {
+            if (Interlocked.Increment(ref _activeSends) > 1)
+            {
+                OverlapDetected = true;
+            }
+
+            if (Interlocked.Increment(ref _totalSends) == 1)
+            {
+                _ = await _subsequentSendStarted.WaitAsync(500, CancellationToken.None).ConfigureAwait(false);
+            }
+            else
+            {
+                _ = _subsequentSendStarted.Release();
+            }
+
+            _ = Interlocked.Decrement(ref _activeSends);
+        }
+
+        public void Dispose() => _subsequentSendStarted.Dispose();
+    }
+
+    /// <summary>
     /// Minimal transport that implements only <see cref="IMessageTransport.SendAsync"/>, leaving
     /// <see cref="IMessageTransport.SendBatchAsync"/> to fall through to the default interface
-    /// implementation, which dispatches concurrently via <see cref="Parallel.ForEachAsync{TSource}(System.Collections.Generic.IEnumerable{TSource}, System.Threading.CancellationToken, System.Func{TSource, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask})"/>.
+    /// implementation, which dispatches each message sequentially.
     /// </summary>
     private sealed class SendAsyncOnlyTransport : IMessageTransport
     {


### PR DESCRIPTION
The public XML doc on IMessageTransport.SendBatchAsync promised sequential
per-message dispatch while the default implementation and its own doc
described parallel dispatch via Parallel.ForEachAsync. The public contract
is authoritative: the default now sends sequentially in enumeration order
with fail-fast semantics, and the internal documentation matches it.