### PR TITLE
fix(kafka): propagate cancellation token through EnsureTopicAsync

### DIFF
--- a/src/NetEvolve.Pulse.Kafka/Outbox/KafkaMessageTransport.cs
+++ b/src/NetEvolve.Pulse.Kafka/Outbox/KafkaMessageTransport.cs
@@ -59,7 +59,7 @@ public sealed class KafkaMessageTransport : IMessageTransport, IAsyncDisposable
 
         var topic = _topicNameResolver.Resolve(message);
 
-        await EnsureTopicAsync(topic).ConfigureAwait(false);
+        await EnsureTopicAsync(topic, cancellationToken).ConfigureAwait(false);
 
         var kafkaMessage = CreateKafkaMessage(message);
 
@@ -82,7 +82,7 @@ public sealed class KafkaMessageTransport : IMessageTransport, IAsyncDisposable
         {
             var topic = _topicNameResolver.Resolve(message);
 
-            await EnsureTopicAsync(topic).ConfigureAwait(false);
+            await EnsureTopicAsync(topic, cancellationToken).ConfigureAwait(false);
 
             var kafkaMessage = CreateKafkaMessage(message);
 
@@ -136,12 +136,14 @@ public sealed class KafkaMessageTransport : IMessageTransport, IAsyncDisposable
             )
             .WaitAsync(cancellationToken);
 
-    private async Task EnsureTopicAsync(string topic)
+    private async Task EnsureTopicAsync(string topic, CancellationToken cancellationToken)
     {
         if (!_options.AutoCreateTopics || _ensuredTopics.ContainsKey(topic))
         {
             return;
         }
+
+        cancellationToken.ThrowIfCancellationRequested();
 
         var configs = new Dictionary<string, string>();
 
@@ -162,7 +164,7 @@ public sealed class KafkaMessageTransport : IMessageTransport, IAsyncDisposable
 
         try
         {
-            await _adminClient.CreateTopicsAsync([spec]).ConfigureAwait(false);
+            await _adminClient.CreateTopicsAsync([spec]).WaitAsync(cancellationToken).ConfigureAwait(false);
             _ = _ensuredTopics.TryAdd(topic, true);
         }
         catch (CreateTopicsException ex) when (ex.Results.All(static r => r.Error.Code == ErrorCode.TopicAlreadyExists))

--- a/tests/NetEvolve.Pulse.Tests.Unit/Kafka/KafkaMessageTransportTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Kafka/KafkaMessageTransportTests.cs
@@ -200,7 +200,13 @@ public sealed class KafkaMessageTransportTests
     {
         using var producer = new FakeProducer();
         using var admin = new FakeAdminClient { BrokerCount = 1 };
-        await using var transport = CreateTransport(producer, admin);
+        // AutoCreateTopics is disabled so this scenario is isolated to Flush cancellation;
+        // EnsureTopicAsync's own (separately tested) cancellation check would otherwise fire first.
+        await using var transport = CreateTransport(
+            producer,
+            admin,
+            options: new KafkaTransportOptions { AutoCreateTopics = false }
+        );
         var messages = new[] { CreateOutboxMessage(), CreateOutboxMessage() };
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -428,6 +434,55 @@ public sealed class KafkaMessageTransportTests
         var messages = new[] { CreateOutboxMessage(), CreateOutboxMessage() };
 
         await transport.SendBatchAsync(messages, cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(admin.CreateTopicsCallCount).IsEqualTo(0);
+    }
+
+    // INVARIANT: EnsureTopicAsync must forward the caller's CancellationToken instead of ignoring
+    // it. A pre-cancelled token must abort the topic-creation round-trip promptly (before it runs
+    // to whatever timeout the admin client would otherwise use) rather than letting SendAsync
+    // proceed to produce, or otherwise swallowing the cancellation.
+    [Test]
+    public async Task SendAsync_When_cancellation_already_requested_throws_OperationCanceledException_promptly(
+        CancellationToken cancellationToken
+    )
+    {
+        using var producer = new FakeProducer();
+        using var admin = new FakeAdminClient { BrokerCount = 1 };
+        await using var transport = CreateTransport(
+            producer,
+            admin,
+            options: new KafkaTransportOptions { AutoCreateTopics = true }
+        );
+        var outboxMessage = CreateOutboxMessage();
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        await cts.CancelAsync().ConfigureAwait(false);
+
+        _ = await Assert.ThrowsAsync<OperationCanceledException>(() => transport.SendAsync(outboxMessage, cts.Token));
+
+        _ = await Assert.That(admin.CreateTopicsCallCount).IsEqualTo(0);
+        _ = await Assert.That(producer.ProducedMessages).IsEmpty();
+    }
+
+    [Test]
+    public async Task SendBatchAsync_When_cancellation_already_requested_throws_OperationCanceledException_promptly(
+        CancellationToken cancellationToken
+    )
+    {
+        using var producer = new FakeProducer();
+        using var admin = new FakeAdminClient { BrokerCount = 1 };
+        await using var transport = CreateTransport(
+            producer,
+            admin,
+            options: new KafkaTransportOptions { AutoCreateTopics = true }
+        );
+        var messages = new[] { CreateOutboxMessage() };
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        await cts.CancelAsync().ConfigureAwait(false);
+
+        _ = await Assert.ThrowsAsync<OperationCanceledException>(() => transport.SendBatchAsync(messages, cts.Token));
 
         _ = await Assert.That(admin.CreateTopicsCallCount).IsEqualTo(0);
     }


### PR DESCRIPTION
SendAsync and SendBatchAsync called EnsureTopicAsync without forwarding
the caller's CancellationToken, and the admin CreateTopicsAsync call had
no way to observe cancellation, so a cancelled worker shutdown could not
abort an in-flight topic-creation round-trip promptly. Forward the token,
check it before starting the admin call, and bound the call with
WaitAsync(token) so cancellation surfaces immediately instead of waiting
for the admin client's own timeout.