### PR TITLE
fix(kafka): honor cancellation in IsHealthyAsync broker check

### DIFF
--- a/src/NetEvolve.Pulse.Kafka/Outbox/KafkaMessageTransport.cs
+++ b/src/NetEvolve.Pulse.Kafka/Outbox/KafkaMessageTransport.cs
@@ -118,18 +118,23 @@ public sealed class KafkaMessageTransport : IMessageTransport, IAsyncDisposable
     }
 
     /// <inheritdoc />
-    public Task<bool> IsHealthyAsync(CancellationToken cancellationToken = default)
-    {
-        try
-        {
-            var metadata = _adminClient.GetMetadata(TimeSpan.FromSeconds(5));
-            return Task.FromResult(metadata.Brokers.Count > 0);
-        }
-        catch (Exception) when (!cancellationToken.IsCancellationRequested)
-        {
-            return Task.FromResult(false);
-        }
-    }
+    public Task<bool> IsHealthyAsync(CancellationToken cancellationToken = default) =>
+        Task.Run(
+                () =>
+                {
+                    try
+                    {
+                        var metadata = _adminClient.GetMetadata(TimeSpan.FromSeconds(5));
+                        return metadata.Brokers.Count > 0;
+                    }
+                    catch (Exception)
+                    {
+                        return false;
+                    }
+                },
+                cancellationToken
+            )
+            .WaitAsync(cancellationToken);
 
     private async Task EnsureTopicAsync(string topic)
     {

--- a/tests/NetEvolve.Pulse.Tests.Unit/Kafka/KafkaMessageTransportTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Kafka/KafkaMessageTransportTests.cs
@@ -254,6 +254,24 @@ public sealed class KafkaMessageTransportTests
         _ = await Assert.That(healthy).IsFalse();
     }
 
+    // INVARIANT: IsHealthyAsync must observe the caller's CancellationToken promptly instead of
+    // always running the blocking GetMetadata() call to completion. With a pre-cancelled token the
+    // method must throw OperationCanceledException without reporting a (misleading) health result.
+    [Test]
+    public async Task IsHealthyAsync_When_cancellation_already_requested_throws_OperationCanceledException_promptly(
+        CancellationToken cancellationToken
+    )
+    {
+        using var producer = new FakeProducer();
+        using var admin = new FakeAdminClient { BrokerCount = 1 };
+        await using var transport = CreateTransport(producer, admin);
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        await cts.CancelAsync().ConfigureAwait(false);
+
+        _ = await Assert.ThrowsAsync<OperationCanceledException>(() => transport.IsHealthyAsync(cts.Token));
+    }
+
     [Test]
     public async Task DisposeAsync_Does_not_dispose_injected_producer_or_admin_client(
         CancellationToken cancellationToken


### PR DESCRIPTION
IsHealthyAsync ran the synchronous IAdminClient.GetMetadata(TimeSpan) call
inline and only inspected the CancellationToken inside an exception filter,
so a caller cancellation never interrupted the up-to-5-second blocking call
and a healthy broker always masked it. Run the call through Task.Run with
the caller's token and wait on it with WaitAsync(token) so a pre-cancelled
or cancelled-during-wait token surfaces OperationCanceledException promptly.