### PR TITLE
perf(outbox): cache event type lookups in MongoDB document mapping

### DIFF
--- a/src/NetEvolve.Pulse.MongoDB/Outbox/OutboxDocumentMapper.cs
+++ b/src/NetEvolve.Pulse.MongoDB/Outbox/OutboxDocumentMapper.cs
@@ -1,6 +1,7 @@
 namespace NetEvolve.Pulse.Outbox;
 
 using System;
+using System.Collections.Concurrent;
 using NetEvolve.Pulse.Extensibility.Outbox;
 
 /// <summary>
@@ -8,6 +9,13 @@ using NetEvolve.Pulse.Extensibility.Outbox;
 /// </summary>
 internal static class OutboxDocumentMapper
 {
+    /// <summary>
+    /// Caches resolved event types by their persisted type name, since <see cref="Type.GetType(string)"/>
+    /// parses the assembly-qualified name and probes loaded assemblies on every call. Only successful
+    /// resolutions are cached; unresolvable names keep failing on each encounter.
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, Type> _eventTypeCache = new(StringComparer.Ordinal);
+
     /// <summary>
     /// Converts an <see cref="OutboxDocument"/> retrieved from MongoDB to an <see cref="OutboxMessage"/>.
     /// </summary>
@@ -17,9 +25,7 @@ internal static class OutboxDocumentMapper
         new OutboxMessage
         {
             Id = doc.Id,
-            EventType =
-                Type.GetType(doc.EventType)
-                ?? throw new InvalidOperationException($"Cannot resolve event type '{doc.EventType}'."),
+            EventType = ResolveEventType(doc.EventType),
             Payload = doc.Payload,
             CorrelationId = doc.CorrelationId,
             CausationId = doc.CausationId,
@@ -57,4 +63,20 @@ internal static class OutboxDocumentMapper
             Error = message.Error,
             Status = (int)message.Status,
         };
+
+    /// <summary>
+    /// Resolves the event <see cref="Type"/> for the given persisted type name, using a cache to avoid
+    /// repeated reflection lookups for the same name.
+    /// </summary>
+    /// <param name="eventTypeName">The persisted, assembly-qualified event type name.</param>
+    /// <returns>The resolved event <see cref="Type"/>.</returns>
+    /// <exception cref="InvalidOperationException">The type name cannot be resolved.</exception>
+    private static Type ResolveEventType(string eventTypeName) =>
+        _eventTypeCache.TryGetValue(eventTypeName, out var eventType)
+            ? eventType
+            : _eventTypeCache.GetOrAdd(
+                eventTypeName,
+                static name =>
+                    Type.GetType(name) ?? throw new InvalidOperationException($"Cannot resolve event type '{name}'.")
+            );
 }

--- a/tests/NetEvolve.Pulse.Tests.Unit/MongoDB/OutboxDocumentMapperTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/MongoDB/OutboxDocumentMapperTests.cs
@@ -144,4 +144,51 @@ public sealed class OutboxDocumentMapperTests
 
         _ = await Assert.That(() => OutboxDocumentMapper.ToOutboxMessage(doc)).Throws<InvalidOperationException>();
     }
+
+    // INVARIANT: Repeated materialization of the same persisted type name resolves to the
+    // identical Type instance (the resolution is memoized instead of re-parsed per document).
+    [Test]
+    public async Task ToOutboxMessage_with_Repeated_EventType_resolves_same_type_instance()
+    {
+        var doc = new OutboxDocument
+        {
+            Id = Guid.NewGuid(),
+            EventType = typeof(SampleEvent).AssemblyQualifiedName!,
+            Payload = "{}",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+            Status = (int)OutboxMessageStatus.Pending,
+        };
+
+        var first = OutboxDocumentMapper.ToOutboxMessage(doc);
+        var second = OutboxDocumentMapper.ToOutboxMessage(doc);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(first.EventType).IsEqualTo(typeof(SampleEvent));
+            _ = await Assert.That(ReferenceEquals(first.EventType, second.EventType)).IsTrue();
+        }
+    }
+
+    // INVARIANT: Failed resolutions are not cached; every re-encounter of an unresolvable
+    // type name fails loudly again instead of returning a stale poisoned entry.
+    [Test]
+    public async Task ToOutboxMessage_with_Unresolvable_EventType_throws_on_every_call()
+    {
+        var doc = new OutboxDocument
+        {
+            Id = Guid.NewGuid(),
+            EventType = "Nonexistent.Repeated.Type, Nonexistent.Assembly",
+            Payload = "{}",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+            Status = (int)OutboxMessageStatus.Pending,
+        };
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(() => OutboxDocumentMapper.ToOutboxMessage(doc)).Throws<InvalidOperationException>();
+            _ = await Assert.That(() => OutboxDocumentMapper.ToOutboxMessage(doc)).Throws<InvalidOperationException>();
+        }
+    }
 }


### PR DESCRIPTION
Type.GetType parsed the assembly-qualified event type name for every
materialized document in the polling hot path. Successful resolutions are
now memoized in a ConcurrentDictionary; unresolvable names still fail on
each encounter.