### PR TITLE
fix(outbox): stop swallowing cancellation in MongoDB health check

### DIFF
--- a/src/NetEvolve.Pulse.MongoDB/Outbox/MongoDbOutboxRepository.cs
+++ b/src/NetEvolve.Pulse.MongoDB/Outbox/MongoDbOutboxRepository.cs
@@ -319,7 +319,11 @@ internal sealed class MongoDbOutboxRepository : IOutboxRepository
 
             return true;
         }
-        catch
+        catch (MongoException)
+        {
+            return false;
+        }
+        catch (TimeoutException)
         {
             return false;
         }

--- a/tests/NetEvolve.Pulse.Tests.Unit/MongoDB/FakeMongo.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/MongoDB/FakeMongo.cs
@@ -1,0 +1,83 @@
+namespace NetEvolve.Pulse.Tests.Unit.MongoDB;
+
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using BsonDocument = global::MongoDB.Bson.BsonDocument;
+using IMongoClient = global::MongoDB.Driver.IMongoClient;
+using IMongoDatabase = global::MongoDB.Driver.IMongoDatabase;
+
+/// <summary>
+/// Minimal <see cref="IMongoClient"/> test double that hands out a single, preconfigured
+/// <see cref="IMongoDatabase"/> for every <c>GetDatabase</c> call. All other members are
+/// intentionally unsupported, since the code under test never invokes them.
+/// </summary>
+internal class FakeMongoClient : DispatchProxy
+{
+    private IMongoDatabase _database = null!;
+
+    public static IMongoClient Create(IMongoDatabase database)
+    {
+        var proxy = Create<IMongoClient, FakeMongoClient>();
+        ((FakeMongoClient)proxy)._database = database;
+        return proxy;
+    }
+
+    protected override object? Invoke(MethodInfo? targetMethod, object?[]? args) =>
+        targetMethod?.Name switch
+        {
+            nameof(IMongoClient.GetDatabase) => _database,
+            nameof(IDisposable.Dispose) => null,
+            _ => throw new NotSupportedException(
+                $"{targetMethod?.Name} is not supported by {nameof(FakeMongoClient)}."
+            ),
+        };
+}
+
+/// <summary>
+/// Minimal <see cref="IMongoDatabase"/> test double whose <c>RunCommandAsync</c> either completes
+/// successfully or fails with a preconfigured exception, so the caller's exception-handling branches
+/// can be exercised deterministically without a real MongoDB server.
+/// </summary>
+internal class FakeMongoDatabase : DispatchProxy
+{
+    private Exception? _exceptionToThrow;
+
+    public static IMongoDatabase ThatSucceeds() => Create<IMongoDatabase, FakeMongoDatabase>();
+
+    public static IMongoDatabase ThatThrows(Exception exceptionToThrow)
+    {
+        var proxy = Create<IMongoDatabase, FakeMongoDatabase>();
+        ((FakeMongoDatabase)proxy)._exceptionToThrow = exceptionToThrow;
+        return proxy;
+    }
+
+    protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+    {
+        if (targetMethod?.Name != nameof(IMongoDatabase.RunCommandAsync))
+        {
+            throw new NotSupportedException($"{targetMethod?.Name} is not supported by {nameof(FakeMongoDatabase)}.");
+        }
+
+        var resultType = targetMethod.ReturnType.GetGenericArguments()[0];
+
+        if (_exceptionToThrow is { } exception)
+        {
+            var fromException = typeof(Task)
+                .GetMethods()
+                .Single(m =>
+                    m.Name == nameof(Task.FromException) && m.IsGenericMethodDefinition && m.GetParameters().Length == 1
+                )
+                .MakeGenericMethod(resultType);
+            return fromException.Invoke(null, [exception]);
+        }
+
+        var fromResult = typeof(Task)
+            .GetMethods()
+            .Single(m => m.Name == nameof(Task.FromResult) && m.GetParameters().Length == 1)
+            .MakeGenericMethod(resultType);
+        var defaultValue = resultType == typeof(BsonDocument) ? new BsonDocument("ok", 1) : null;
+        return fromResult.Invoke(null, [defaultValue]);
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/MongoDB/MongoDbOutboxRepositoryTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/MongoDB/MongoDbOutboxRepositoryTests.cs
@@ -2,6 +2,7 @@ namespace NetEvolve.Pulse.Tests.Unit.MongoDB;
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
@@ -162,5 +163,38 @@ public sealed class MongoDbOutboxRepositoryTests
         );
 
         _ = await Assert.That(() => repository.AddAsync(null!)).Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task IsHealthyAsync_WithCanceledToken_ThrowsOperationCanceledException()
+    {
+        using var client = new global::MongoDB.Driver.MongoClient("mongodb://localhost:27017");
+        var repository = new MongoDbOutboxRepository(
+            client,
+            Options.Create(new MongoDbOutboxOptions { DatabaseName = "testdb" }),
+            TimeProvider.System
+        );
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        _ = await Assert.That(() => repository.IsHealthyAsync(cts.Token)).Throws<OperationCanceledException>();
+    }
+
+    [Test]
+    public async Task IsHealthyAsync_WithUnreachableServer_ReturnsFalse()
+    {
+        using var client = new global::MongoDB.Driver.MongoClient(
+            "mongodb://localhost:1/?serverSelectionTimeoutMS=200&connectTimeoutMS=200&directConnection=true"
+        );
+        var repository = new MongoDbOutboxRepository(
+            client,
+            Options.Create(new MongoDbOutboxOptions { DatabaseName = "testdb" }),
+            TimeProvider.System
+        );
+
+        var result = await repository.IsHealthyAsync(CancellationToken.None);
+
+        _ = await Assert.That(result).IsFalse();
     }
 }

--- a/tests/NetEvolve.Pulse.Tests.Unit/MongoDB/MongoDbOutboxRepositoryTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/MongoDB/MongoDbOutboxRepositoryTests.cs
@@ -197,4 +197,52 @@ public sealed class MongoDbOutboxRepositoryTests
 
         _ = await Assert.That(result).IsFalse();
     }
+
+    [Test]
+    public async Task IsHealthyAsync_WhenRunCommandThrowsMongoException_ReturnsFalse()
+    {
+        var database = FakeMongoDatabase.ThatThrows(new global::MongoDB.Driver.MongoException("connection lost"));
+        using var client = FakeMongoClient.Create(database);
+        var repository = new MongoDbOutboxRepository(
+            client,
+            Options.Create(new MongoDbOutboxOptions { DatabaseName = "testdb" }),
+            TimeProvider.System
+        );
+
+        var result = await repository.IsHealthyAsync(CancellationToken.None);
+
+        _ = await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task IsHealthyAsync_WhenRunCommandThrowsTimeoutException_ReturnsFalse()
+    {
+        var database = FakeMongoDatabase.ThatThrows(new TimeoutException("server selection timed out"));
+        using var client = FakeMongoClient.Create(database);
+        var repository = new MongoDbOutboxRepository(
+            client,
+            Options.Create(new MongoDbOutboxOptions { DatabaseName = "testdb" }),
+            TimeProvider.System
+        );
+
+        var result = await repository.IsHealthyAsync(CancellationToken.None);
+
+        _ = await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task IsHealthyAsync_WhenPingSucceeds_ReturnsTrue()
+    {
+        var database = FakeMongoDatabase.ThatSucceeds();
+        using var client = FakeMongoClient.Create(database);
+        var repository = new MongoDbOutboxRepository(
+            client,
+            Options.Create(new MongoDbOutboxOptions { DatabaseName = "testdb" }),
+            TimeProvider.System
+        );
+
+        var result = await repository.IsHealthyAsync(CancellationToken.None);
+
+        _ = await Assert.That(result).IsTrue();
+    }
 }


### PR DESCRIPTION
IsHealthyAsync used a bare catch that converted OperationCanceledException
and fatal runtime errors into a false health result. The ping now catches
only MongoException and TimeoutException, letting cancellation and fatal
exceptions propagate, mirroring the Cosmos DB repository.