### PR TITLE
perf(outbox): index MongoDB claim queries on status and creation time

### DIFF
--- a/src/NetEvolve.Pulse.MongoDB/Outbox/MongoDbOutboxRepository.cs
+++ b/src/NetEvolve.Pulse.MongoDB/Outbox/MongoDbOutboxRepository.cs
@@ -36,6 +36,9 @@ internal sealed class MongoDbOutboxRepository : IOutboxRepository
     /// <summary>The name of the MongoDB collection used to store outbox documents.</summary>
     private readonly string _collectionName;
 
+    /// <summary>Tracks whether the claim index has already been created by this instance (0 = no, 1 = yes).</summary>
+    private int _claimIndexCreated;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="MongoDbOutboxRepository"/> class.
     /// </summary>
@@ -99,7 +102,7 @@ internal sealed class MongoDbOutboxRepository : IOutboxRepository
         };
 
         var messages = new List<OutboxMessage>(batchSize);
-        var collection = GetCollection();
+        var collection = await GetClaimCollectionAsync(cancellationToken).ConfigureAwait(false);
 
         for (var i = 0; i < batchSize; i++)
         {
@@ -148,7 +151,7 @@ internal sealed class MongoDbOutboxRepository : IOutboxRepository
         };
 
         var messages = new List<OutboxMessage>(batchSize);
-        var collection = GetCollection();
+        var collection = await GetClaimCollectionAsync(cancellationToken).ConfigureAwait(false);
 
         for (var i = 0; i < batchSize; i++)
         {
@@ -301,4 +304,38 @@ internal sealed class MongoDbOutboxRepository : IOutboxRepository
     /// <returns>The outbox MongoDB collection.</returns>
     private IMongoCollection<OutboxDocument> GetCollection() =>
         _mongoClient.GetDatabase(_databaseName).GetCollection<OutboxDocument>(_collectionName);
+
+    /// <summary>
+    /// Returns the outbox collection and ensures a compound index on <c>Status</c> and <c>CreatedAt</c>
+    /// exists, so each sorted claim operation avoids a full collection scan with an in-memory sort.
+    /// The index is created at most once per repository instance; <c>createIndexes</c> is idempotent,
+    /// so concurrent instances targeting the same collection are safe.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token to observe.</param>
+    /// <returns>The outbox MongoDB collection.</returns>
+    private async Task<IMongoCollection<OutboxDocument>> GetClaimCollectionAsync(CancellationToken cancellationToken)
+    {
+        var collection = GetCollection();
+
+        if (Interlocked.CompareExchange(ref _claimIndexCreated, 1, 0) == 0)
+        {
+            try
+            {
+                var keys = Builders<OutboxDocument>.IndexKeys.Ascending(d => d.Status).Ascending(d => d.CreatedAt);
+                _ = await collection
+                    .Indexes.CreateOneAsync(
+                        new CreateIndexModel<OutboxDocument>(keys),
+                        cancellationToken: cancellationToken
+                    )
+                    .ConfigureAwait(false);
+            }
+            catch
+            {
+                _ = Interlocked.Exchange(ref _claimIndexCreated, 0);
+                throw;
+            }
+        }
+
+        return collection;
+    }
 }

--- a/tests/NetEvolve.Pulse.Tests.Integration/Outbox/MongoDbOutboxRepositoryIndexTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Outbox/MongoDbOutboxRepositoryIndexTests.cs
@@ -1,0 +1,94 @@
+namespace NetEvolve.Pulse.Tests.Integration.Outbox;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse;
+using NetEvolve.Pulse.Extensibility.Outbox;
+using NetEvolve.Pulse.Outbox;
+using NetEvolve.Pulse.Tests.Integration.Internals.Services;
+using TUnit.Core;
+
+[TestGroup("MongoDB")]
+public sealed class MongoDbOutboxRepositoryIndexTests
+{
+    [ClassDataSource<MongoDbContainerFixture>(Shared = SharedType.PerTestSession)]
+    public required MongoDbContainerFixture Container { get; init; }
+
+    private sealed record IndexTestEvent;
+
+    private static OutboxMessage CreateMessage(DateTimeOffset createdAt) =>
+        new OutboxMessage
+        {
+            Id = Guid.NewGuid(),
+            EventType = typeof(IndexTestEvent),
+            Payload = "{}",
+            CreatedAt = createdAt,
+            UpdatedAt = createdAt,
+            Status = OutboxMessageStatus.Pending,
+        };
+
+    [Test]
+    public async Task GetPendingAsync_CreatesClaimIndexOnStatusAndCreatedAt()
+    {
+        using var client = new MongoClient(Container.ConnectionString);
+        var databaseName = $"pulse{Guid.NewGuid():N}";
+        var repository = new MongoDbOutboxRepository(
+            client,
+            Options.Create(new MongoDbOutboxOptions { DatabaseName = databaseName }),
+            TimeProvider.System
+        );
+
+        await repository.AddAsync(CreateMessage(DateTimeOffset.UtcNow));
+        _ = await repository.GetPendingAsync(10);
+
+        var collection = client
+            .GetDatabase(databaseName)
+            .GetCollection<OutboxDocument>(new MongoDbOutboxOptions().CollectionName);
+        var indexes = await (await collection.Indexes.ListAsync()).ToListAsync();
+
+        var hasClaimIndex = indexes.Any(index =>
+        {
+            var key = index["key"].AsBsonDocument;
+            return key.ElementCount == 2
+                && key.GetElement(0).Name == OutboxMessageSchema.Columns.Status
+                && key.GetElement(1).Name == OutboxMessageSchema.Columns.CreatedAt;
+        });
+
+        _ = await Assert.That(hasClaimIndex).IsTrue();
+    }
+
+    [Test]
+    public async Task GetFailedForRetryAsync_CreatesClaimIndexOnStatusAndCreatedAt()
+    {
+        using var client = new MongoClient(Container.ConnectionString);
+        var databaseName = $"pulse{Guid.NewGuid():N}";
+        var repository = new MongoDbOutboxRepository(
+            client,
+            Options.Create(new MongoDbOutboxOptions { DatabaseName = databaseName }),
+            TimeProvider.System
+        );
+
+        await repository.AddAsync(CreateMessage(DateTimeOffset.UtcNow));
+        _ = await repository.GetFailedForRetryAsync(5, 10);
+
+        var collection = client
+            .GetDatabase(databaseName)
+            .GetCollection<OutboxDocument>(new MongoDbOutboxOptions().CollectionName);
+        var indexes = await (await collection.Indexes.ListAsync()).ToListAsync();
+
+        var hasClaimIndex = indexes.Any(index =>
+        {
+            var key = index["key"].AsBsonDocument;
+            return key.ElementCount == 2
+                && key.GetElement(0).Name == OutboxMessageSchema.Columns.Status
+                && key.GetElement(1).Name == OutboxMessageSchema.Columns.CreatedAt;
+        });
+
+        _ = await Assert.That(hasClaimIndex).IsTrue();
+    }
+}


### PR DESCRIPTION
Every sorted FindOneAndUpdateAsync claim ran as a collection scan with an
in-memory sort because the provider never created any index. The claim paths
now ensure a compound index on Status and CreatedAt once per repository
instance before polling.