### PR TITLE
fix(outbox): reclaim expired processing leases in MongoDB repository

### DIFF
--- a/src/NetEvolve.Pulse.MongoDB/MongoDbOutboxOptions.cs
+++ b/src/NetEvolve.Pulse.MongoDB/MongoDbOutboxOptions.cs
@@ -20,4 +20,18 @@ public sealed class MongoDbOutboxOptions
     /// Default: <c>outbox_messages</c>.
     /// </summary>
     public string CollectionName { get; set; } = "outbox_messages";
+
+    /// <summary>
+    /// Gets or sets the maximum duration a claimed message may remain in the
+    /// <see cref="NetEvolve.Pulse.Extensibility.Outbox.OutboxMessageStatus.Processing"/> status
+    /// before it becomes eligible for reclaiming by a subsequent pending poll.
+    /// Default: 5 minutes.
+    /// </summary>
+    /// <remarks>
+    /// When a worker crashes or is cancelled after claiming a message but before completing it,
+    /// the message stays in the <c>Processing</c> status. Once this lease expires, the next pending
+    /// poll claims the message again, preserving at-least-once delivery. Choose a value comfortably
+    /// larger than the longest expected message dispatch duration to avoid duplicate publishing.
+    /// </remarks>
+    public TimeSpan ProcessingLeaseTimeout { get; set; } = TimeSpan.FromMinutes(5);
 }

--- a/src/NetEvolve.Pulse.MongoDB/Outbox/MongoDbOutboxRepository.cs
+++ b/src/NetEvolve.Pulse.MongoDB/Outbox/MongoDbOutboxRepository.cs
@@ -18,6 +18,11 @@ using NetEvolve.Pulse.Extensibility.Outbox;
 /// Each pending-message claim uses <c>FindOneAndUpdateAsync</c> to atomically transition one document
 /// from <see cref="OutboxMessageStatus.Pending"/> to <see cref="OutboxMessageStatus.Processing"/>.
 /// A batch is claimed by calling this operation up to <c>batchSize</c> times.
+/// <para><strong>Claim Lease:</strong></para>
+/// Each claim records the claim timestamp. Messages that remain in
+/// <see cref="OutboxMessageStatus.Processing"/> longer than
+/// <see cref="MongoDbOutboxOptions.ProcessingLeaseTimeout"/> (for example, after a worker crash or
+/// host shutdown) are reclaimed by subsequent pending polls, preserving at-least-once delivery.
 /// <para><strong>Date/Time Storage:</strong></para>
 /// All <see cref="DateTimeOffset"/> values are stored as UTC <see cref="DateTime"/> in BSON. The UTC offset
 /// is always zero when reading back from the database.
@@ -39,6 +44,9 @@ internal sealed class MongoDbOutboxRepository : IOutboxRepository
     /// <summary>Tracks whether the claim index has already been created by this instance (0 = no, 1 = yes).</summary>
     private int _claimIndexCreated;
 
+    /// <summary>The maximum duration a claimed message may remain in the Processing status before it is reclaimed.</summary>
+    private readonly TimeSpan _processingLeaseTimeout;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="MongoDbOutboxRepository"/> class.
     /// </summary>
@@ -59,10 +67,13 @@ internal sealed class MongoDbOutboxRepository : IOutboxRepository
         ArgumentException.ThrowIfNullOrWhiteSpace(opts.DatabaseName);
         ArgumentException.ThrowIfNullOrWhiteSpace(opts.CollectionName);
 
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(opts.ProcessingLeaseTimeout, TimeSpan.Zero);
+
         _mongoClient = mongoClient;
         _timeProvider = timeProvider;
         _databaseName = opts.DatabaseName;
         _collectionName = opts.CollectionName;
+        _processingLeaseTimeout = opts.ProcessingLeaseTimeout;
     }
 
     /// <inheritdoc />
@@ -81,8 +92,9 @@ internal sealed class MongoDbOutboxRepository : IOutboxRepository
     )
     {
         var now = _timeProvider.GetUtcNow().UtcDateTime;
+        var leaseExpiredBefore = now - _processingLeaseTimeout;
 
-        var filter = Builders<OutboxDocument>.Filter.And(
+        var pendingFilter = Builders<OutboxDocument>.Filter.And(
             Builders<OutboxDocument>.Filter.Eq(d => d.Status, (int)OutboxMessageStatus.Pending),
             Builders<OutboxDocument>.Filter.Or(
                 Builders<OutboxDocument>.Filter.Eq(d => d.NextRetryAt, null),
@@ -90,9 +102,23 @@ internal sealed class MongoDbOutboxRepository : IOutboxRepository
             )
         );
 
+        var expiredLeaseFilter = Builders<OutboxDocument>.Filter.And(
+            Builders<OutboxDocument>.Filter.Eq(d => d.Status, (int)OutboxMessageStatus.Processing),
+            Builders<OutboxDocument>.Filter.Or(
+                Builders<OutboxDocument>.Filter.Lte(d => d.ProcessingStartedAt, (DateTime?)leaseExpiredBefore),
+                Builders<OutboxDocument>.Filter.And(
+                    Builders<OutboxDocument>.Filter.Eq(d => d.ProcessingStartedAt, null),
+                    Builders<OutboxDocument>.Filter.Lte(d => d.UpdatedAt, leaseExpiredBefore)
+                )
+            )
+        );
+
+        var filter = Builders<OutboxDocument>.Filter.Or(pendingFilter, expiredLeaseFilter);
+
         var update = Builders<OutboxDocument>
             .Update.Set(d => d.Status, (int)OutboxMessageStatus.Processing)
-            .Set(d => d.UpdatedAt, now);
+            .Set(d => d.UpdatedAt, now)
+            .Set(d => d.ProcessingStartedAt, (DateTime?)now);
 
         var sort = Builders<OutboxDocument>.Sort.Ascending(d => d.CreatedAt);
         var findOptions = new FindOneAndUpdateOptions<OutboxDocument>
@@ -141,7 +167,8 @@ internal sealed class MongoDbOutboxRepository : IOutboxRepository
 
         var update = Builders<OutboxDocument>
             .Update.Set(d => d.Status, (int)OutboxMessageStatus.Processing)
-            .Set(d => d.UpdatedAt, now);
+            .Set(d => d.UpdatedAt, now)
+            .Set(d => d.ProcessingStartedAt, (DateTime?)now);
 
         var sort = Builders<OutboxDocument>.Sort.Ascending(d => d.CreatedAt);
         var findOptions = new FindOneAndUpdateOptions<OutboxDocument>

--- a/src/NetEvolve.Pulse.MongoDB/Outbox/OutboxDocument.cs
+++ b/src/NetEvolve.Pulse.MongoDB/Outbox/OutboxDocument.cs
@@ -57,6 +57,15 @@ internal sealed class OutboxDocument
     [BsonElement(OutboxMessageSchema.Columns.NextRetryAt)]
     public DateTime? NextRetryAt { get; set; }
 
+    /// <summary>
+    /// Gets or sets the UTC timestamp when the message was claimed for processing, or <see langword="null"/>
+    /// when the message is not currently claimed. Documents written by earlier versions of this provider
+    /// do not contain this element; the value then remains <see langword="null"/> after deserialization.
+    /// </summary>
+    [BsonElement("ProcessingStartedAt")]
+    [BsonIgnoreIfNull]
+    public DateTime? ProcessingStartedAt { get; set; }
+
     /// <summary>Gets or sets the number of processing attempts made so far.</summary>
     [BsonElement(OutboxMessageSchema.Columns.RetryCount)]
     public int RetryCount { get; set; }

--- a/tests/NetEvolve.Pulse.Tests.Integration/Outbox/MongoDbOutboxRepositoryLeaseTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Outbox/MongoDbOutboxRepositoryLeaseTests.cs
@@ -1,0 +1,115 @@
+namespace NetEvolve.Pulse.Tests.Integration.Outbox;
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using MongoDB.Driver;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse;
+using NetEvolve.Pulse.Extensibility.Outbox;
+using NetEvolve.Pulse.Outbox;
+using NetEvolve.Pulse.Tests.Integration.Internals.Services;
+using TUnit.Core;
+
+[TestGroup("MongoDB")]
+public sealed class MongoDbOutboxRepositoryLeaseTests
+{
+    [ClassDataSource<MongoDbContainerFixture>(Shared = SharedType.PerTestSession)]
+    public required MongoDbContainerFixture Container { get; init; }
+
+    private sealed record LeaseTestEvent;
+
+    private static OutboxMessage CreateMessage(DateTimeOffset createdAt) =>
+        new OutboxMessage
+        {
+            Id = Guid.NewGuid(),
+            EventType = typeof(LeaseTestEvent),
+            Payload = "{}",
+            CreatedAt = createdAt,
+            UpdatedAt = createdAt,
+            Status = OutboxMessageStatus.Pending,
+        };
+
+    private static (
+        MongoDbOutboxRepository Repository,
+        FakeTimeProvider TimeProvider,
+        string DatabaseName
+    ) CreateRepository(IMongoClient client)
+    {
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2025, 6, 1, 12, 0, 0, TimeSpan.Zero));
+        var databaseName = $"pulse{Guid.NewGuid():N}";
+        var options = Options.Create(
+            new MongoDbOutboxOptions { DatabaseName = databaseName, ProcessingLeaseTimeout = TimeSpan.FromMinutes(5) }
+        );
+        var repository = new MongoDbOutboxRepository(client, options, timeProvider);
+        return (repository, timeProvider, databaseName);
+    }
+
+    [Test]
+    public async Task GetPendingAsync_WhenProcessingLeaseExpired_ReclaimsClaimedMessage()
+    {
+        using var client = new MongoClient(Container.ConnectionString);
+        var (repository, timeProvider, _) = CreateRepository(client);
+
+        var message = CreateMessage(timeProvider.GetUtcNow());
+        await repository.AddAsync(message);
+
+        var claimed = await repository.GetPendingAsync(10);
+        _ = await Assert.That(claimed).Count().IsEqualTo(1);
+
+        // Simulate a crashed worker: the claimed message is never completed or failed.
+        timeProvider.Advance(TimeSpan.FromMinutes(10));
+
+        var reclaimed = await repository.GetPendingAsync(10);
+
+        _ = await Assert.That(reclaimed).Count().IsEqualTo(1);
+        _ = await Assert.That(reclaimed[0].Id).IsEqualTo(message.Id);
+    }
+
+    [Test]
+    public async Task GetPendingAsync_WhileProcessingLeaseActive_DoesNotReclaimClaimedMessage()
+    {
+        using var client = new MongoClient(Container.ConnectionString);
+        var (repository, timeProvider, _) = CreateRepository(client);
+
+        var message = CreateMessage(timeProvider.GetUtcNow());
+        await repository.AddAsync(message);
+
+        var claimed = await repository.GetPendingAsync(10);
+        _ = await Assert.That(claimed).Count().IsEqualTo(1);
+
+        timeProvider.Advance(TimeSpan.FromMinutes(1));
+
+        var reclaimed = await repository.GetPendingAsync(10);
+
+        _ = await Assert.That(reclaimed).IsEmpty();
+    }
+
+    [Test]
+    public async Task GetPendingAsync_WithLegacyProcessingDocumentWithoutLeaseField_ReclaimsAfterLeaseExpiry()
+    {
+        using var client = new MongoClient(Container.ConnectionString);
+        var (repository, timeProvider, databaseName) = CreateRepository(client);
+
+        var message = CreateMessage(timeProvider.GetUtcNow());
+        await repository.AddAsync(message);
+
+        var claimed = await repository.GetPendingAsync(10);
+        _ = await Assert.That(claimed).Count().IsEqualTo(1);
+
+        // Simulate a document claimed by a previous library version without lease tracking.
+        var collection = client
+            .GetDatabase(databaseName)
+            .GetCollection<OutboxDocument>(new MongoDbOutboxOptions().CollectionName);
+        var unset = Builders<OutboxDocument>.Update.Unset("ProcessingStartedAt");
+        _ = await collection.UpdateOneAsync(Builders<OutboxDocument>.Filter.Eq(d => d.Id, message.Id), unset);
+
+        timeProvider.Advance(TimeSpan.FromMinutes(10));
+
+        var reclaimed = await repository.GetPendingAsync(10);
+
+        _ = await Assert.That(reclaimed).Count().IsEqualTo(1);
+        _ = await Assert.That(reclaimed[0].Id).IsEqualTo(message.Id);
+    }
+}


### PR DESCRIPTION
Messages flipped from Pending to Processing were never selected again after
a worker crash or cancellation, silently losing events. Claims now record a
ProcessingStartedAt timestamp and pending polls reclaim Processing documents
whose configurable lease (MongoDbOutboxOptions.ProcessingLeaseTimeout,
default 5 minutes) has expired; legacy documents without the field fall back
to UpdatedAt.