### PR TITLE
fix(polly): keep pipeline-scoped token out of deferred stream enumeration

### DIFF
--- a/src/NetEvolve.Pulse.Polly/Interceptors/PollyStreamQueryInterceptor.cs
+++ b/src/NetEvolve.Pulse.Polly/Interceptors/PollyStreamQueryInterceptor.cs
@@ -75,6 +75,9 @@ internal sealed class PollyStreamQueryInterceptor<TQuery, TResponse> : IStreamQu
     /// <remarks>
     /// If no <see cref="ResiliencePipeline"/> is registered for <typeparamref name="TQuery"/>,
     /// the interceptor delegates directly to <paramref name="handler"/> without wrapping.
+    /// The handler is always invoked with the caller's <paramref name="cancellationToken"/>,
+    /// never with a pipeline-scoped token, because enumeration of the returned stream happens
+    /// after the pipeline execution has completed.
     /// </remarks>
     public IAsyncEnumerable<TResponse> HandleAsync(
         TQuery request,
@@ -100,10 +103,14 @@ internal sealed class PollyStreamQueryInterceptor<TQuery, TResponse> : IStreamQu
     )
     {
         // Wrap the handler invocation (stream open) inside the pipeline.
-        // This protects the stream initialization phase; items are yielded directly afterwards.
+        // The handler receives the caller's token instead of Polly's execution-scoped token,
+        // because the deferred enumerable is consumed after ExecuteAsync has completed and
+        // Polly resets/pools the CancellationTokenSource backing its execution token.
         var stream = await pipeline
             .ExecuteAsync(
-                token => new ValueTask<IAsyncEnumerable<TResponse>>(handler(request, token)),
+                static (state, _) =>
+                    new ValueTask<IAsyncEnumerable<TResponse>>(state.Handler(state.Request, state.CallerToken)),
+                (Handler: handler, Request: request, CallerToken: cancellationToken),
                 cancellationToken
             )
             .ConfigureAwait(false);

--- a/tests/NetEvolve.Pulse.Tests.Unit/Polly/Interceptors/PollyStreamQueryInterceptorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Polly/Interceptors/PollyStreamQueryInterceptorTests.cs
@@ -368,6 +368,42 @@ public sealed class PollyStreamQueryInterceptorTests
     }
 
     [Test]
+    public async Task HandleAsync_WithTimeoutStrategy_DeferredStreamUsesCallerToken(CancellationToken cancellationToken)
+    {
+        // Arrange
+        var pipeline = new ResiliencePipelineBuilder().AddTimeout(TimeSpan.FromSeconds(30)).Build();
+        var serviceProvider = CreateServiceProvider<TestStreamQuery>(pipeline);
+        var interceptor = new PollyStreamQueryInterceptor<TestStreamQuery, string>(serviceProvider);
+        var request = new TestStreamQuery();
+
+        CancellationToken observedToken = default;
+
+        // Act - the handler returns a deferred enumerable that is consumed after ExecuteAsync completed
+        var items = new List<string>();
+        await foreach (
+            var item in interceptor
+                .HandleAsync(
+                    request,
+                    (_, ct) =>
+                    {
+                        observedToken = ct;
+                        return YieldItemsAsync(["item1"], ct);
+                    },
+                    cancellationToken
+                )
+                .ConfigureAwait(false)
+        )
+        {
+            items.Add(item);
+        }
+
+        // Assert - the deferred stream must not capture a pipeline-scoped token, because that
+        // token's CancellationTokenSource is reset/pooled by Polly once ExecuteAsync completes
+        _ = await Assert.That(observedToken).IsEqualTo(cancellationToken);
+        _ = await Assert.That(items).IsEquivalentTo(["item1"]);
+    }
+
+    [Test]
     public async Task HandleAsync_WithCancellation_ThrowsOperationCanceledException(CancellationToken cancellationToken)
     {
         // Arrange


### PR DESCRIPTION
The stream query interceptor invoked the handler with Polly's execution-scoped
token, which is backed by a pooled CancellationTokenSource that Polly resets
once ExecuteAsync completes. Because the returned enumerable is deferred, the
token was consumed during enumeration after execution, risking spurious
cancellation or ObjectDisposedException. The handler now receives the caller's
cancellation token.