### PR TITLE
perf(postgresql): mark outbox message batches with a single set-based statement

### DIFF
--- a/src/NetEvolve.Pulse.PostgreSql/Outbox/PostgreSqlOutboxRepository.cs
+++ b/src/NetEvolve.Pulse.PostgreSql/Outbox/PostgreSqlOutboxRepository.cs
@@ -56,6 +56,12 @@ internal sealed class PostgreSqlOutboxRepository : IOutboxRepository
     /// <summary>Cached SQL for calling the mark_outbox_message_failed function.</summary>
     private readonly string _markFailedSql;
 
+    /// <summary>Cached SQL for marking a batch of messages as completed in a single set-based statement.</summary>
+    private readonly string _markCompletedBatchSql;
+
+    /// <summary>Cached SQL for marking a batch of messages as failed in a single set-based statement.</summary>
+    private readonly string _markFailedBatchSql;
+
     /// <summary>Cached SQL for calling the mark_outbox_message_dead_letter function.</summary>
     private readonly string _markDeadLetterSql;
 
@@ -99,6 +105,26 @@ internal sealed class PostgreSqlOutboxRepository : IOutboxRepository
             $"SELECT \"{schema}\".mark_outbox_message_completed(@message_id, @processed_at, @updated_at)";
         _markFailedSql = $"SELECT \"{schema}\".mark_outbox_message_failed(@message_id, @error, @next_retry_at)";
         _markDeadLetterSql = $"SELECT \"{schema}\".mark_outbox_message_dead_letter(@message_id, @error)";
+        _markCompletedBatchSql = $"""
+            UPDATE {options.Value.FullTableName}
+            SET
+                "{OutboxMessageSchema.Columns.Status}" = 2,
+                "{OutboxMessageSchema.Columns.ProcessedAt}" = @processed_at,
+                "{OutboxMessageSchema.Columns.UpdatedAt}" = @updated_at
+            WHERE "{OutboxMessageSchema.Columns.Id}" = ANY(@message_ids)
+              AND "{OutboxMessageSchema.Columns.Status}" = 1
+            """;
+        _markFailedBatchSql = $"""
+            UPDATE {options.Value.FullTableName}
+            SET
+                "{OutboxMessageSchema.Columns.Status}" = 3,
+                "{OutboxMessageSchema.Columns.RetryCount}" = "{OutboxMessageSchema.Columns.RetryCount}" + 1,
+                "{OutboxMessageSchema.Columns.Error}" = @error,
+                "{OutboxMessageSchema.Columns.NextRetryAt}" = @next_retry_at,
+                "{OutboxMessageSchema.Columns.UpdatedAt}" = NOW()
+            WHERE "{OutboxMessageSchema.Columns.Id}" = ANY(@message_ids)
+              AND "{OutboxMessageSchema.Columns.Status}" = 1
+            """;
         _deleteCompletedSql = $"SELECT \"{schema}\".delete_completed_outbox_messages(@older_than_utc)";
         _getPendingCountSql =
             $"SELECT COUNT(*) FROM {options.Value.FullTableName} WHERE \"{OutboxMessageSchema.Columns.Status}\" = 0";
@@ -246,21 +272,26 @@ internal sealed class PostgreSqlOutboxRepository : IOutboxRepository
         CancellationToken cancellationToken = default
     )
     {
+        ArgumentNullException.ThrowIfNull(messageIds);
+
+        if (messageIds.Count == 0)
+        {
+            return;
+        }
+
         var now = _timeProvider.GetUtcNow();
 
         var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
         await using (connection.ConfigureAwait(false))
         {
-            foreach (var messageId in messageIds)
+            var command = new NpgsqlCommand(_markCompletedBatchSql, connection);
+            await using (command.ConfigureAwait(false))
             {
-                var command = new NpgsqlCommand(_markCompletedSql, connection);
-                await using (command.ConfigureAwait(false))
-                {
-                    _ = command.Parameters.AddWithValue("message_id", messageId);
-                    _ = command.Parameters.AddWithValue("processed_at", now);
-                    _ = command.Parameters.AddWithValue("updated_at", now);
-                    _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-                }
+                _ = command.Parameters.AddWithValue("message_ids", messageIds.ToArray());
+                _ = command.Parameters.AddWithValue("processed_at", now);
+                _ = command.Parameters.AddWithValue("updated_at", now);
+
+                _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             }
         }
     }
@@ -320,19 +351,26 @@ internal sealed class PostgreSqlOutboxRepository : IOutboxRepository
         CancellationToken cancellationToken = default
     )
     {
+        ArgumentNullException.ThrowIfNull(messageIds);
+
+        if (messageIds.Count == 0)
+        {
+            return;
+        }
+
         var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
         await using (connection.ConfigureAwait(false))
         {
-            foreach (var messageId in messageIds)
+            var command = new NpgsqlCommand(_markFailedBatchSql, connection);
+            await using (command.ConfigureAwait(false))
             {
-                var command = new NpgsqlCommand(_markFailedSql, connection);
-                await using (command.ConfigureAwait(false))
-                {
-                    _ = command.Parameters.AddWithValue("message_id", messageId);
-                    _ = command.Parameters.AddWithValue("error", (object?)errorMessage ?? DBNull.Value);
-                    _ = command.Parameters.AddWithValue("next_retry_at", DBNull.Value);
-                    _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-                }
+                _ = command.Parameters.AddWithValue("message_ids", messageIds.ToArray());
+                _ = command.Parameters.AddWithValue("error", (object?)errorMessage ?? DBNull.Value);
+                _ = command.Parameters.Add(
+                    new NpgsqlParameter("next_retry_at", NpgsqlTypes.NpgsqlDbType.TimestampTz) { Value = DBNull.Value }
+                );
+
+                _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             }
         }
     }

--- a/tests/NetEvolve.Pulse.Tests.Integration/Outbox/PostgreSqlAdoNetOutboxTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Outbox/PostgreSqlAdoNetOutboxTests.cs
@@ -1,6 +1,10 @@
 namespace NetEvolve.Pulse.Tests.Integration.Outbox;
 
+using Microsoft.Extensions.DependencyInjection;
 using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.Outbox;
+using NetEvolve.Pulse.Outbox;
 using NetEvolve.Pulse.Tests.Integration.Internals;
 
 [ClassDataSource<PostgreSqlDatabaseServiceFixture, PostgreSqlAdoNetOutboxInitializer>(
@@ -12,4 +16,131 @@ using NetEvolve.Pulse.Tests.Integration.Internals;
 public class PostgreSqlAdoNetOutboxTests(
     IServiceFixture databaseServiceFixture,
     IServiceInitializer databaseInitializer
-) : OutboxTestsBase(databaseServiceFixture, databaseInitializer);
+) : OutboxTestsBase(databaseServiceFixture, databaseInitializer)
+{
+    [Test]
+    public async Task Should_Mark_Multiple_Messages_AsCompleted_OnlyProcessingMessages(
+        CancellationToken cancellationToken
+    ) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var mediator = services.GetRequiredService<IMediator>();
+
+                    await PublishEventsAsync(mediator, 3, x => new BatchTestEvent { Id = $"Test{x:D3}" }, token)
+                        .ConfigureAwait(false);
+
+                    var outbox = services.GetRequiredService<IOutboxRepository>();
+                    var processing = await outbox.GetPendingAsync(2, token).ConfigureAwait(false);
+
+                    _ = await Assert.That(processing.Count).IsEqualTo(2);
+
+                    var pendingCountBefore = await outbox.GetPendingCountAsync(token).ConfigureAwait(false);
+
+                    _ = await Assert.That(pendingCountBefore).IsEqualTo(1);
+
+                    var messageIds = processing.Select(m => m.Id).ToArray();
+                    await outbox.MarkAsCompletedAsync(messageIds, token).ConfigureAwait(false);
+
+                    var management = services.GetRequiredService<IOutboxManagement>();
+                    var statistics = await management.GetStatisticsAsync(token).ConfigureAwait(false);
+
+                    using (Assert.Multiple())
+                    {
+                        _ = await Assert.That(statistics.Completed).IsEqualTo(2L);
+                        _ = await Assert.That(statistics.Processing).IsEqualTo(0L);
+                        _ = await Assert.That(statistics.Pending).IsEqualTo(1L);
+                    }
+                },
+                cancellationToken,
+                configureServices: services =>
+                    services.Configure<OutboxProcessorOptions>(options => options.DisableProcessing = true)
+            )
+            .ConfigureAwait(false);
+
+    [Test]
+    public async Task Should_Mark_Multiple_Messages_AsFailed_IncrementsRetryCountPerMessage(
+        CancellationToken cancellationToken
+    ) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var mediator = services.GetRequiredService<IMediator>();
+
+                    await PublishEventsAsync(mediator, 3, x => new BatchTestEvent { Id = $"Test{x:D3}" }, token)
+                        .ConfigureAwait(false);
+
+                    var outbox = services.GetRequiredService<IOutboxRepository>();
+                    var pending = await outbox.GetPendingAsync(50, token).ConfigureAwait(false);
+
+                    _ = await Assert.That(pending.Count).IsEqualTo(3);
+
+                    var messageIds = pending.Select(m => m.Id).ToArray();
+                    await outbox.MarkAsFailedAsync(messageIds, "Batch error", token).ConfigureAwait(false);
+
+                    var failedForRetry = await outbox.GetFailedForRetryAsync(10, 50, token).ConfigureAwait(false);
+
+                    using (Assert.Multiple())
+                    {
+                        _ = await Assert.That(failedForRetry.Count).IsEqualTo(3);
+                        _ = await Assert.That(failedForRetry.All(m => m.RetryCount == 1)).IsTrue();
+                        _ = await Assert
+                            .That(
+                                failedForRetry.All(m => string.Equals(m.Error, "Batch error", StringComparison.Ordinal))
+                            )
+                            .IsTrue();
+                        _ = await Assert.That(failedForRetry.All(m => m.NextRetryAt is null)).IsTrue();
+                    }
+                },
+                cancellationToken,
+                configureServices: services =>
+                    services.Configure<OutboxProcessorOptions>(options => options.DisableProcessing = true)
+            )
+            .ConfigureAwait(false);
+
+    [Test]
+    public async Task Should_Mark_Multiple_Messages_AsFailed_OnlyProcessingMessages(
+        CancellationToken cancellationToken
+    ) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var mediator = services.GetRequiredService<IMediator>();
+
+                    await PublishEventsAsync(mediator, 3, x => new BatchTestEvent { Id = $"Test{x:D3}" }, token)
+                        .ConfigureAwait(false);
+
+                    var outbox = services.GetRequiredService<IOutboxRepository>();
+                    var processing = await outbox.GetPendingAsync(2, token).ConfigureAwait(false);
+
+                    _ = await Assert.That(processing.Count).IsEqualTo(2);
+
+                    var messageIds = processing.Select(m => m.Id).ToArray();
+                    await outbox.MarkAsFailedAsync(messageIds, "Batch error", token).ConfigureAwait(false);
+
+                    var management = services.GetRequiredService<IOutboxManagement>();
+                    var statistics = await management.GetStatisticsAsync(token).ConfigureAwait(false);
+
+                    using (Assert.Multiple())
+                    {
+                        _ = await Assert.That(statistics.Failed).IsEqualTo(2L);
+                        _ = await Assert.That(statistics.Processing).IsEqualTo(0L);
+                        _ = await Assert.That(statistics.Pending).IsEqualTo(1L);
+                    }
+                },
+                cancellationToken,
+                configureServices: services =>
+                    services.Configure<OutboxProcessorOptions>(options => options.DisableProcessing = true)
+            )
+            .ConfigureAwait(false);
+
+    private sealed class BatchTestEvent : IEvent
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+
+        public required string Id { get; init; }
+
+        public DateTimeOffset? PublishedAt { get; set; }
+    }
+}


### PR DESCRIPTION
The batch overloads of MarkAsCompletedAsync and MarkAsFailedAsync executed one
stored function call per message id, causing N sequential network round trips
per batch. They now issue a single UPDATE using a uuid[] parameter with
"Id" = ANY(@message_ids), preserving the per-row Processing status guard,
timestamps, and retry-count semantics of the single-item path.