### PR TITLE
fix(rabbitmq): guard transport disposal against in-flight channel creation

### DIFF
--- a/src/NetEvolve.Pulse.RabbitMQ/Outbox/RabbitMqMessageTransport.cs
+++ b/src/NetEvolve.Pulse.RabbitMQ/Outbox/RabbitMqMessageTransport.cs
@@ -1,5 +1,6 @@
 namespace NetEvolve.Pulse.Outbox;
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Threading;
 using Microsoft.Extensions.Options;
@@ -37,6 +38,11 @@ internal sealed class RabbitMqMessageTransport : IMessageTransport, IDisposable
     private IRabbitMqChannelAdapter? _channel;
 
     /// <summary>Semaphore for thread-safe channel initialization.</summary>
+    [SuppressMessage(
+        "Usage",
+        "CA2213:Disposable fields should be disposed",
+        Justification = "The semaphore must outlive Dispose so in-flight senders can still release it; SemaphoreSlim holds no unmanaged resources unless its wait handle is accessed, which this type never does."
+    )]
     private readonly SemaphoreSlim _initializationLock = new(1, 1);
 
     /// <summary>
@@ -185,6 +191,8 @@ internal sealed class RabbitMqMessageTransport : IMessageTransport, IDisposable
         await _initializationLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
+            ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+
             if (_channel?.IsOpen == true)
             {
                 return _channel;
@@ -217,6 +225,11 @@ internal sealed class RabbitMqMessageTransport : IMessageTransport, IDisposable
     /// <see cref="Interlocked.Exchange(ref int, int)"/> performs the teardown; all subsequent
     /// callers (including concurrent ones) are no-ops. This prevents double-disposal of the
     /// underlying channel adapter when shutdown overlaps with another <c>Dispose()</c> call.
+    /// The teardown acquires <see cref="_initializationLock"/> so that a channel created by an
+    /// in-flight <see cref="EnsureChannelAsync"/> is disposed rather than leaked, and the
+    /// semaphore itself is intentionally never disposed because in-flight senders may still
+    /// need to release it; <see cref="SemaphoreSlim"/> holds no unmanaged resources unless
+    /// its wait handle is accessed, which this type never does.
     /// </remarks>
     public void Dispose()
     {
@@ -225,7 +238,15 @@ internal sealed class RabbitMqMessageTransport : IMessageTransport, IDisposable
             return;
         }
 
-        _channel?.Dispose();
-        _initializationLock.Dispose();
+        _initializationLock.Wait();
+        try
+        {
+            _channel?.Dispose();
+            _channel = null;
+        }
+        finally
+        {
+            _ = _initializationLock.Release();
+        }
     }
 }

--- a/tests/NetEvolve.Pulse.Tests.Unit/RabbitMQ/RabbitMqMessageTransportDisposeConcurrencyTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/RabbitMQ/RabbitMqMessageTransportDisposeConcurrencyTests.cs
@@ -175,6 +175,74 @@ public sealed class RabbitMqMessageTransportDisposeConcurrencyTests
         }
     }
 
+    /// <summary>
+    /// INVARIANT (concurrency / disposal): when <c>Dispose()</c> races a sender that is
+    /// inside <c>EnsureChannelAsync</c> creating a new channel, the freshly created
+    /// channel must not leak (it must end up disposed) and the sender's semaphore
+    /// release must not throw <see cref="ObjectDisposedException"/>. Currently
+    /// <c>Dispose()</c> tears down the semaphore without acquiring it, so the in-flight
+    /// sender's <c>Release()</c> throws and the new channel is orphaned.
+    /// </summary>
+    [Test]
+    public async Task Dispose_DuringInFlightChannelCreation_DisposesNewChannelAndDoesNotThrowOnRelease(
+        CancellationToken cancellationToken
+    )
+    {
+        var connectionAdapter = new FakeConnectionAdapter();
+        var topicNameResolver = new FakeTopicNameResolver();
+        var transport = CreateTransport(connectionAdapter, topicNameResolver);
+        try
+        {
+            // Make the first channel creation block until we explicitly release it.
+            var creationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseCreation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            connectionAdapter.CreationGate = (start: creationStarted, release: releaseCreation);
+
+            var sendTask = Task.Run(
+                async () => await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false),
+                cancellationToken
+            );
+
+            // Wait until the sender is inside EnsureChannelAsync, holding the
+            // initialization lock and awaiting channel creation.
+            await creationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
+
+            var disposeTask = Task.Run(transport.Dispose, cancellationToken);
+
+            // Give an unguarded Dispose implementation time to complete while the
+            // channel creation is still in flight, then let the creation finish.
+            _ = await Task.WhenAny(disposeTask, Task.Delay(500, cancellationToken)).ConfigureAwait(false);
+            releaseCreation.SetResult();
+
+            Exception? sendException = null;
+            try
+            {
+                await sendTask.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
+            }
+#pragma warning disable CA1031 // Test must capture any exception type that SendAsync might surface.
+            catch (Exception ex)
+            {
+                sendException = ex;
+            }
+#pragma warning restore CA1031
+
+            await disposeTask.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
+
+            var createdChannel = connectionAdapter.CreatedChannels[0];
+            using (Assert.Multiple())
+            {
+                // The channel created concurrently with Dispose must not leak.
+                _ = await Assert.That(createdChannel.DisposeCallCount).IsGreaterThan(0);
+                // The sender's semaphore release must not observe a disposed semaphore.
+                _ = await Assert.That(sendException is ObjectDisposedException).IsFalse();
+            }
+        }
+        finally
+        {
+            transport.Dispose();
+        }
+    }
+
     private static RabbitMqMessageTransport CreateTransport(
         IRabbitMqConnectionAdapter connectionAdapter,
         ITopicNameResolver topicNameResolver,
@@ -215,11 +283,22 @@ public sealed class RabbitMqMessageTransportDisposeConcurrencyTests
 
         public List<FakeChannelAdapter> CreatedChannels { get; } = [];
 
-        public Task<IRabbitMqChannelAdapter> CreateChannelAsync(CancellationToken cancellationToken = default)
+        public (TaskCompletionSource start, TaskCompletionSource release)? CreationGate { get; set; }
+
+        public async Task<IRabbitMqChannelAdapter> CreateChannelAsync(CancellationToken cancellationToken = default)
         {
+            if (CreationGate is { } gate)
+            {
+                CreationGate = null;
+                _ = gate.start.TrySetResult();
+#pragma warning disable VSTHRD003 // TaskCompletionSource gate is signaled by the test, not started here
+                await gate.release.Task.ConfigureAwait(false);
+#pragma warning restore VSTHRD003
+            }
+
             var channel = new FakeChannelAdapter();
             CreatedChannels.Add(channel);
-            return Task.FromResult<IRabbitMqChannelAdapter>(channel);
+            return channel;
         }
     }
 


### PR DESCRIPTION
Dispose tore down the channel and initialization semaphore without acquiring the
lock, so a channel created by a concurrent EnsureChannelAsync leaked and the
sender''s semaphore release threw ObjectDisposedException. Dispose now acquires the
initialization lock before disposing the channel, EnsureChannelAsync re-checks the
disposed flag under the lock, and the semaphore is intentionally left undisposed so
in-flight senders can still release it.