### PR TITLE
fix(sourcegeneration): stop rooting syntax trees in pipeline models

### DIFF
--- a/src/NetEvolve.Pulse.SourceGeneration/Generators/PulseHandlerGenerator.cs
+++ b/src/NetEvolve.Pulse.SourceGeneration/Generators/PulseHandlerGenerator.cs
@@ -136,7 +136,7 @@ public sealed class PulseHandlerGenerator : IIncrementalGenerator
                 spc.ReportDiagnostic(
                     Diagnostic.Create(
                         DiagnosticDescriptors.OpenGenericHandlerNotSupported,
-                        info.Location,
+                        info.Location.ToLocation(),
                         info.HandlerTypeName
                     )
                 )
@@ -167,7 +167,7 @@ public sealed class PulseHandlerGenerator : IIncrementalGenerator
                 spc.ReportDiagnostic(
                     Diagnostic.Create(
                         DiagnosticDescriptors.MissingPulseHandlerAttribute,
-                        info.Location,
+                        info.Location.ToLocation(),
                         info.HandlerTypeName
                     )
                 )
@@ -197,7 +197,7 @@ public sealed class PulseHandlerGenerator : IIncrementalGenerator
                         error.IsPulse005
                             ? DiagnosticDescriptors.InvalidExplicitMessageType
                             : DiagnosticDescriptors.IncompatibleExplicitMessageType,
-                        error.Location,
+                        error.Location.ToLocation(),
                         error.MessageTypeName,
                         error.HandlerTypeName
                     )
@@ -218,7 +218,7 @@ public sealed class PulseHandlerGenerator : IIncrementalGenerator
             return null;
         }
 
-        var location = ctx.TargetNode.GetLocation();
+        var location = LocationInfo.CreateFrom(ctx.TargetNode);
         var registrations = new List<HandlerRegistration>();
 
         foreach (var attr in ctx.Attributes)
@@ -268,7 +268,7 @@ public sealed class PulseHandlerGenerator : IIncrementalGenerator
         }
 
         var handlerTypeName = GetFullyQualifiedName(classSymbol);
-        var location = ctx.TargetNode.GetLocation();
+        var location = LocationInfo.CreateFrom(ctx.TargetNode);
         var errors = ImmutableArray.CreateBuilder<ExplicitTypeError>();
 
         foreach (var attrClass in ctx.Attributes.Select(attr => attr.AttributeClass))
@@ -322,7 +322,7 @@ public sealed class PulseHandlerGenerator : IIncrementalGenerator
         }
 
         var lifetime = ReadLifetime(ctx.Attributes);
-        var location = ctx.TargetNode.GetLocation();
+        var location = LocationInfo.CreateFrom(ctx.TargetNode);
         var registrations = BuildHandlerRegistrations(classSymbol, lifetime);
 
         return new HandlerInfo(GetFullyQualifiedName(classSymbol), [.. registrations], location);
@@ -351,7 +351,7 @@ public sealed class PulseHandlerGenerator : IIncrementalGenerator
         }
 
         var lifetime = ReadLifetime(ctx.Attributes);
-        var location = ctx.TargetNode.GetLocation();
+        var location = LocationInfo.CreateFrom(ctx.TargetNode);
         var registrations = BuildOpenGenericHandlerRegistrations(classSymbol, lifetime);
 
         return new HandlerInfo(GetOpenGenericTypeName(classSymbol), [.. registrations], location);
@@ -375,7 +375,7 @@ public sealed class PulseHandlerGenerator : IIncrementalGenerator
             return null;
         }
 
-        return new HandlerInfo(GetFullyQualifiedName(classSymbol), [], ctx.TargetNode.GetLocation());
+        return new HandlerInfo(GetFullyQualifiedName(classSymbol), [], LocationInfo.CreateFrom(ctx.TargetNode));
     }
 
     /// <summary>
@@ -456,7 +456,7 @@ public sealed class PulseHandlerGenerator : IIncrementalGenerator
             return null;
         }
 
-        return new HandlerInfo(GetFullyQualifiedName(classSymbol), [], typeDeclaration.GetLocation());
+        return new HandlerInfo(GetFullyQualifiedName(classSymbol), [], LocationInfo.CreateFrom(typeDeclaration));
     }
 
     /// <summary>
@@ -513,7 +513,7 @@ public sealed class PulseHandlerGenerator : IIncrementalGenerator
                 spc.ReportDiagnostic(
                     Diagnostic.Create(
                         DiagnosticDescriptors.NoHandlerInterface,
-                        handler.Location,
+                        handler.Location.ToLocation(),
                         handler.HandlerTypeName
                     )
                 );

--- a/src/NetEvolve.Pulse.SourceGeneration/Models/ExplicitTypeError.cs
+++ b/src/NetEvolve.Pulse.SourceGeneration/Models/ExplicitTypeError.cs
@@ -1,7 +1,6 @@
 namespace NetEvolve.Pulse.SourceGeneration.Models;
 
 using System;
-using Microsoft.CodeAnalysis;
 
 /// <summary>
 /// Carries information about an invalid <c>[PulseHandler&lt;T&gt;]</c> usage for diagnostic reporting.
@@ -15,7 +14,7 @@ internal readonly struct ExplicitTypeError : IEquatable<ExplicitTypeError>
     public string HandlerTypeName { get; }
 
     /// <summary>Gets the source location of the type declaration for diagnostic reporting.</summary>
-    public Location Location { get; }
+    public LocationInfo Location { get; }
 
     /// <summary>
     /// Gets a value indicating whether to emit PULSE005 (<see langword="true"/>) or
@@ -26,7 +25,7 @@ internal readonly struct ExplicitTypeError : IEquatable<ExplicitTypeError>
     /// <summary>
     /// Initializes a new <see cref="ExplicitTypeError"/>.
     /// </summary>
-    public ExplicitTypeError(string messageTypeName, string handlerTypeName, Location location, bool isPulse005)
+    public ExplicitTypeError(string messageTypeName, string handlerTypeName, LocationInfo location, bool isPulse005)
     {
         MessageTypeName = messageTypeName;
         HandlerTypeName = handlerTypeName;
@@ -38,6 +37,7 @@ internal readonly struct ExplicitTypeError : IEquatable<ExplicitTypeError>
     public bool Equals(ExplicitTypeError other) =>
         string.Equals(MessageTypeName, other.MessageTypeName, StringComparison.Ordinal)
         && string.Equals(HandlerTypeName, other.HandlerTypeName, StringComparison.Ordinal)
+        && Location.Equals(other.Location)
         && IsPulse005 == other.IsPulse005;
 
     /// <inheritdoc />
@@ -50,6 +50,7 @@ internal readonly struct ExplicitTypeError : IEquatable<ExplicitTypeError>
         {
             var hash = StringComparer.Ordinal.GetHashCode(MessageTypeName);
             hash = (hash * 31) + StringComparer.Ordinal.GetHashCode(HandlerTypeName);
+            hash = (hash * 31) + Location.GetHashCode();
             hash = (hash * 31) + IsPulse005.GetHashCode();
             return hash;
         }

--- a/src/NetEvolve.Pulse.SourceGeneration/Models/HandlerInfo.cs
+++ b/src/NetEvolve.Pulse.SourceGeneration/Models/HandlerInfo.cs
@@ -1,7 +1,6 @@
 namespace NetEvolve.Pulse.SourceGeneration.Models;
 
 using System;
-using Microsoft.CodeAnalysis;
 
 /// <summary>
 /// Lightweight model captured per annotated class for the pipeline.
@@ -15,7 +14,7 @@ internal readonly struct HandlerInfo : IEquatable<HandlerInfo>
     public HandlerRegistration[] Registrations { get; }
 
     /// <summary>Gets the source location of the handler type declaration for diagnostic reporting.</summary>
-    public Location Location { get; }
+    public LocationInfo Location { get; }
 
     /// <summary>
     /// Initializes a new <see cref="HandlerInfo"/> with the given type name, registrations,
@@ -24,7 +23,7 @@ internal readonly struct HandlerInfo : IEquatable<HandlerInfo>
     /// <param name="handlerTypeName">The fully qualified name of the handler type.</param>
     /// <param name="registrations">The handler interface registrations for this type.</param>
     /// <param name="location">The source location of the type declaration.</param>
-    public HandlerInfo(string handlerTypeName, HandlerRegistration[] registrations, Location location)
+    public HandlerInfo(string handlerTypeName, HandlerRegistration[] registrations, LocationInfo location)
     {
         HandlerTypeName = handlerTypeName;
         Registrations = registrations;
@@ -34,6 +33,7 @@ internal readonly struct HandlerInfo : IEquatable<HandlerInfo>
     /// <inheritdoc />
     public bool Equals(HandlerInfo other) =>
         string.Equals(HandlerTypeName, other.HandlerTypeName, StringComparison.Ordinal)
+        && Location.Equals(other.Location)
         && RegistrationsEqual(Registrations, other.Registrations);
 
     /// <inheritdoc />
@@ -45,6 +45,7 @@ internal readonly struct HandlerInfo : IEquatable<HandlerInfo>
         unchecked
         {
             var hash = StringComparer.Ordinal.GetHashCode(HandlerTypeName);
+            hash = (hash * 31) + Location.GetHashCode();
             foreach (var r in Registrations)
             {
                 hash = (hash * 31) + r.GetHashCode();

--- a/src/NetEvolve.Pulse.SourceGeneration/Models/LocationInfo.cs
+++ b/src/NetEvolve.Pulse.SourceGeneration/Models/LocationInfo.cs
@@ -1,0 +1,78 @@
+namespace NetEvolve.Pulse.SourceGeneration.Models;
+
+using System;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+/// <summary>
+/// Equatable, syntax-tree-free representation of a source location for use in incremental
+/// pipeline models. Storing <see cref="Microsoft.CodeAnalysis.Location"/> directly would root
+/// the originating <see cref="SyntaxTree"/> in the generator driver's caches.
+/// </summary>
+internal readonly struct LocationInfo : IEquatable<LocationInfo>
+{
+    /// <summary>Gets the file path of the source location.</summary>
+    public string FilePath { get; }
+
+    /// <summary>Gets the text span of the source location.</summary>
+    public TextSpan TextSpan { get; }
+
+    /// <summary>Gets the line/column span of the source location.</summary>
+    public LinePositionSpan LineSpan { get; }
+
+    /// <summary>
+    /// Initializes a new <see cref="LocationInfo"/> with the given file path, text span, and line span.
+    /// </summary>
+    /// <param name="filePath">The file path of the source location.</param>
+    /// <param name="textSpan">The text span of the source location.</param>
+    /// <param name="lineSpan">The line/column span of the source location.</param>
+    public LocationInfo(string filePath, TextSpan textSpan, LinePositionSpan lineSpan)
+    {
+        FilePath = filePath;
+        TextSpan = textSpan;
+        LineSpan = lineSpan;
+    }
+
+    /// <summary>
+    /// Captures the location of <paramref name="node"/> without retaining a reference to its
+    /// <see cref="SyntaxTree"/>.
+    /// </summary>
+    /// <param name="node">The syntax node whose location is captured.</param>
+    /// <returns>The tree-free location representation.</returns>
+    public static LocationInfo CreateFrom(SyntaxNode node)
+    {
+        var location = node.GetLocation();
+        return new LocationInfo(
+            location.SourceTree?.FilePath ?? string.Empty,
+            location.SourceSpan,
+            location.GetLineSpan().Span
+        );
+    }
+
+    /// <summary>
+    /// Reconstructs a <see cref="Location"/> suitable for diagnostic reporting.
+    /// </summary>
+    /// <returns>The reconstructed location.</returns>
+    public Location ToLocation() => Location.Create(FilePath, TextSpan, LineSpan);
+
+    /// <inheritdoc />
+    public bool Equals(LocationInfo other) =>
+        string.Equals(FilePath, other.FilePath, StringComparison.Ordinal)
+        && TextSpan == other.TextSpan
+        && LineSpan == other.LineSpan;
+
+    /// <inheritdoc />
+    public override bool Equals(object obj) => obj is LocationInfo other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = StringComparer.Ordinal.GetHashCode(FilePath);
+            hash = (hash * 31) + TextSpan.GetHashCode();
+            hash = (hash * 31) + LineSpan.GetHashCode();
+            return hash;
+        }
+    }
+}

--- a/src/NetEvolve.Pulse.SourceGeneration/NetEvolve.Pulse.SourceGeneration.csproj
+++ b/src/NetEvolve.Pulse.SourceGeneration/NetEvolve.Pulse.SourceGeneration.csproj
@@ -22,4 +22,8 @@
   <ItemGroup>
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="NetEvolve.Pulse.SourceGeneration.Tests.Unit" />
+  </ItemGroup>
 </Project>

--- a/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/Models/ExplicitTypeErrorTests.cs
+++ b/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/Models/ExplicitTypeErrorTests.cs
@@ -1,0 +1,90 @@
+namespace NetEvolve.Pulse.SourceGeneration.Tests.Unit.Models;
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Text;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.SourceGeneration.Models;
+using TUnit.Core;
+
+[TestGroup("SourceGeneration")]
+[TestGroup("SourceGeneration.Models")]
+public class ExplicitTypeErrorTests
+{
+    private static LocationInfo CreateLocation(string filePath = "File.cs") =>
+        new(filePath, new TextSpan(0, 1), new LinePositionSpan(new LinePosition(0, 0), new LinePosition(0, 1)));
+
+    [Test]
+    public async Task EqualsThenTrueForIdenticalValues()
+    {
+        var location = CreateLocation();
+        var left = new ExplicitTypeError("global::Ns.Message", "global::Ns.Handler", location, isPulse005: true);
+        var right = new ExplicitTypeError("global::Ns.Message", "global::Ns.Handler", location, isPulse005: true);
+
+        _ = await Assert.That(left.Equals(right)).IsTrue();
+        _ = await Assert.That(left.Equals((object)right)).IsTrue();
+        _ = await Assert.That(left.GetHashCode()).IsEqualTo(right.GetHashCode());
+    }
+
+    [Test]
+    public async Task EqualsThenFalseWhenLocationDiffers()
+    {
+        var left = new ExplicitTypeError(
+            "global::Ns.Message",
+            "global::Ns.Handler",
+            CreateLocation("FileA.cs"),
+            isPulse005: true
+        );
+        var right = new ExplicitTypeError(
+            "global::Ns.Message",
+            "global::Ns.Handler",
+            CreateLocation("FileB.cs"),
+            isPulse005: true
+        );
+
+        _ = await Assert.That(left.Equals(right)).IsFalse();
+    }
+
+    [Test]
+    public async Task EqualsThenFalseWhenIsPulse005Differs()
+    {
+        var location = CreateLocation();
+        var left = new ExplicitTypeError("global::Ns.Message", "global::Ns.Handler", location, isPulse005: true);
+        var right = new ExplicitTypeError("global::Ns.Message", "global::Ns.Handler", location, isPulse005: false);
+
+        _ = await Assert.That(left.Equals(right)).IsFalse();
+        _ = await Assert.That(left.GetHashCode()).IsNotEqualTo(right.GetHashCode());
+    }
+
+    [Test]
+    public async Task EqualsThenFalseWhenMessageTypeNameDiffers()
+    {
+        var location = CreateLocation();
+        var left = new ExplicitTypeError("global::Ns.MessageA", "global::Ns.Handler", location, isPulse005: true);
+        var right = new ExplicitTypeError("global::Ns.MessageB", "global::Ns.Handler", location, isPulse005: true);
+
+        _ = await Assert.That(left.Equals(right)).IsFalse();
+    }
+
+    [Test]
+    public async Task EqualsThenFalseWhenHandlerTypeNameDiffers()
+    {
+        var location = CreateLocation();
+        var left = new ExplicitTypeError("global::Ns.Message", "global::Ns.HandlerA", location, isPulse005: true);
+        var right = new ExplicitTypeError("global::Ns.Message", "global::Ns.HandlerB", location, isPulse005: true);
+
+        _ = await Assert.That(left.Equals(right)).IsFalse();
+    }
+
+    [Test]
+    public async Task EqualsObjectThenFalseWhenOtherIsNotExplicitTypeError()
+    {
+        var error = new ExplicitTypeError(
+            "global::Ns.Message",
+            "global::Ns.Handler",
+            CreateLocation(),
+            isPulse005: true
+        );
+
+        _ = await Assert.That(error.Equals("not an ExplicitTypeError")).IsFalse();
+    }
+}

--- a/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/Models/HandlerInfoTests.cs
+++ b/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/Models/HandlerInfoTests.cs
@@ -1,0 +1,97 @@
+namespace NetEvolve.Pulse.SourceGeneration.Tests.Unit.Models;
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Text;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.SourceGeneration.Models;
+using TUnit.Core;
+
+[TestGroup("SourceGeneration")]
+[TestGroup("SourceGeneration.Models")]
+public class HandlerInfoTests
+{
+    private static LocationInfo CreateLocation(string filePath = "File.cs") =>
+        new(filePath, new TextSpan(0, 1), new LinePositionSpan(new LinePosition(0, 0), new LinePosition(0, 1)));
+
+    private static HandlerRegistration CreateRegistration(string handlerTypeName = "global::Ns.Handler") =>
+        new(handlerTypeName, "global::Ns.IHandler", HandlerKind.Command, lifetime: 1);
+
+    [Test]
+    public async Task EqualsThenTrueForIdenticalValues()
+    {
+        var location = CreateLocation();
+        var left = new HandlerInfo("global::Ns.Handler", [CreateRegistration()], location);
+        var right = new HandlerInfo("global::Ns.Handler", [CreateRegistration()], location);
+
+        _ = await Assert.That(left.Equals(right)).IsTrue();
+        _ = await Assert.That(left.Equals((object)right)).IsTrue();
+        _ = await Assert.That(left.GetHashCode()).IsEqualTo(right.GetHashCode());
+    }
+
+    [Test]
+    public async Task EqualsThenFalseWhenLocationDiffers()
+    {
+        var registrations = new[] { CreateRegistration() };
+        var left = new HandlerInfo("global::Ns.Handler", registrations, CreateLocation("FileA.cs"));
+        var right = new HandlerInfo("global::Ns.Handler", registrations, CreateLocation("FileB.cs"));
+
+        _ = await Assert.That(left.Equals(right)).IsFalse();
+    }
+
+    [Test]
+    public async Task EqualsThenFalseWhenHandlerTypeNameDiffers()
+    {
+        var location = CreateLocation();
+        var registrations = new[] { CreateRegistration() };
+        var left = new HandlerInfo("global::Ns.HandlerA", registrations, location);
+        var right = new HandlerInfo("global::Ns.HandlerB", registrations, location);
+
+        _ = await Assert.That(left.Equals(right)).IsFalse();
+    }
+
+    [Test]
+    public async Task EqualsThenFalseWhenRegistrationCountDiffers()
+    {
+        var location = CreateLocation();
+        var left = new HandlerInfo("global::Ns.Handler", [CreateRegistration()], location);
+        var right = new HandlerInfo(
+            "global::Ns.Handler",
+            [CreateRegistration(), CreateRegistration("global::Ns.OtherHandler")],
+            location
+        );
+
+        _ = await Assert.That(left.Equals(right)).IsFalse();
+    }
+
+    [Test]
+    public async Task EqualsThenFalseWhenRegistrationElementDiffers()
+    {
+        var location = CreateLocation();
+        var left = new HandlerInfo("global::Ns.Handler", [CreateRegistration("global::Ns.HandlerA")], location);
+        var right = new HandlerInfo("global::Ns.Handler", [CreateRegistration("global::Ns.HandlerB")], location);
+
+        _ = await Assert.That(left.Equals(right)).IsFalse();
+    }
+
+    [Test]
+    public async Task EqualsObjectThenFalseWhenOtherIsNotHandlerInfo()
+    {
+        var handlerInfo = new HandlerInfo("global::Ns.Handler", [CreateRegistration()], CreateLocation());
+
+        _ = await Assert.That(handlerInfo.Equals("not a HandlerInfo")).IsFalse();
+    }
+
+    [Test]
+    public async Task GetHashCodeThenIncludesEachRegistration()
+    {
+        var location = CreateLocation();
+        var withOneRegistration = new HandlerInfo("global::Ns.Handler", [CreateRegistration()], location);
+        var withTwoRegistrations = new HandlerInfo(
+            "global::Ns.Handler",
+            [CreateRegistration(), CreateRegistration("global::Ns.OtherHandler")],
+            location
+        );
+
+        _ = await Assert.That(withOneRegistration.GetHashCode()).IsNotEqualTo(withTwoRegistrations.GetHashCode());
+    }
+}

--- a/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/Models/LocationInfoTests.cs
+++ b/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/Models/LocationInfoTests.cs
@@ -1,0 +1,123 @@
+namespace NetEvolve.Pulse.SourceGeneration.Tests.Unit.Models;
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.SourceGeneration.Models;
+using TUnit.Core;
+
+[TestGroup("SourceGeneration")]
+[TestGroup("SourceGeneration.Models")]
+public class LocationInfoTests
+{
+    [Test]
+    public async Task CreateFromThenCapturesFilePathAndSpansOfNode()
+    {
+        const string source = """
+            public class MyClass
+            {
+            }
+            """;
+        var tree = CSharpSyntaxTree.ParseText(source, path: "TestFile.cs");
+        var root = await tree.GetRootAsync().ConfigureAwait(false);
+        var classDeclaration = root.DescendantNodes().OfType<ClassDeclarationSyntax>().Single();
+
+        var locationInfo = LocationInfo.CreateFrom(classDeclaration);
+        var expectedLocation = classDeclaration.GetLocation();
+
+        _ = await Assert.That(locationInfo.FilePath).IsEqualTo("TestFile.cs");
+        _ = await Assert.That(locationInfo.TextSpan).IsEqualTo(expectedLocation.SourceSpan);
+        _ = await Assert.That(locationInfo.LineSpan).IsEqualTo(expectedLocation.GetLineSpan().Span);
+    }
+
+    [Test]
+    public async Task ToLocationThenReconstructsEquivalentLocation()
+    {
+        const string source = """
+            public class MyClass
+            {
+            }
+            """;
+        var tree = CSharpSyntaxTree.ParseText(source, path: "TestFile.cs");
+        var root = await tree.GetRootAsync().ConfigureAwait(false);
+        var classDeclaration = root.DescendantNodes().OfType<ClassDeclarationSyntax>().Single();
+        var originalLocation = classDeclaration.GetLocation();
+
+        var locationInfo = LocationInfo.CreateFrom(classDeclaration);
+        var reconstructed = locationInfo.ToLocation();
+
+        _ = await Assert.That(reconstructed.SourceSpan).IsEqualTo(originalLocation.SourceSpan);
+        _ = await Assert.That(reconstructed.GetLineSpan().Path).IsEqualTo(originalLocation.GetLineSpan().Path);
+        _ = await Assert
+            .That(reconstructed.GetLineSpan().StartLinePosition)
+            .IsEqualTo(originalLocation.GetLineSpan().StartLinePosition);
+    }
+
+    [Test]
+    public async Task EqualsThenTrueForSameFilePathAndSpans()
+    {
+        var span = new TextSpan(10, 5);
+        var lineSpan = new LinePositionSpan(new LinePosition(1, 0), new LinePosition(1, 5));
+        var left = new LocationInfo("File.cs", span, lineSpan);
+        var right = new LocationInfo("File.cs", span, lineSpan);
+
+        _ = await Assert.That(left.Equals(right)).IsTrue();
+        _ = await Assert.That(left.Equals((object)right)).IsTrue();
+        _ = await Assert.That(left.GetHashCode()).IsEqualTo(right.GetHashCode());
+    }
+
+    [Test]
+    public async Task EqualsThenFalseWhenFilePathDiffers()
+    {
+        var span = new TextSpan(10, 5);
+        var lineSpan = new LinePositionSpan(new LinePosition(1, 0), new LinePosition(1, 5));
+        var left = new LocationInfo("FileA.cs", span, lineSpan);
+        var right = new LocationInfo("FileB.cs", span, lineSpan);
+
+        _ = await Assert.That(left.Equals(right)).IsFalse();
+    }
+
+    [Test]
+    public async Task EqualsThenFalseWhenTextSpanDiffers()
+    {
+        var lineSpan = new LinePositionSpan(new LinePosition(1, 0), new LinePosition(1, 5));
+        var left = new LocationInfo("File.cs", new TextSpan(10, 5), lineSpan);
+        var right = new LocationInfo("File.cs", new TextSpan(20, 5), lineSpan);
+
+        _ = await Assert.That(left.Equals(right)).IsFalse();
+    }
+
+    [Test]
+    public async Task EqualsThenFalseWhenLineSpanDiffers()
+    {
+        var span = new TextSpan(10, 5);
+        var left = new LocationInfo(
+            "File.cs",
+            span,
+            new LinePositionSpan(new LinePosition(1, 0), new LinePosition(1, 5))
+        );
+        var right = new LocationInfo(
+            "File.cs",
+            span,
+            new LinePositionSpan(new LinePosition(2, 0), new LinePosition(2, 5))
+        );
+
+        _ = await Assert.That(left.Equals(right)).IsFalse();
+    }
+
+    [Test]
+    public async Task EqualsObjectThenFalseWhenOtherIsNotLocationInfo()
+    {
+        var locationInfo = new LocationInfo(
+            "File.cs",
+            new TextSpan(0, 1),
+            new LinePositionSpan(new LinePosition(0, 0), new LinePosition(0, 1))
+        );
+
+        _ = await Assert.That(locationInfo.Equals("not a LocationInfo")).IsFalse();
+    }
+}

--- a/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/PulseHandlerGeneratorIncrementalTests.cs
+++ b/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/PulseHandlerGeneratorIncrementalTests.cs
@@ -1,0 +1,144 @@
+namespace NetEvolve.Pulse.SourceGeneration.Tests.Unit;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.SourceGeneration.Generators;
+using TUnit.Core;
+
+[TestGroup("SourceGeneration")]
+[TestGroup("SourceGeneration.PulseHandler")]
+public class PulseHandlerGeneratorIncrementalTests
+{
+    [Test]
+    public async Task WhenLinesInsertedAboveUnannotatedHandlerThenPulse003LocationFollowsDeclaration()
+    {
+        const string source = """
+            using NetEvolve.Pulse.Extensibility;
+            using NetEvolve.Pulse.Extensibility.Attributes;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            public record MyQuery(string Id) : IQuery<string>;
+
+            public class MyQueryHandler : IQueryHandler<MyQuery, string>
+            {
+                public Task<string> HandleAsync(MyQuery request, CancellationToken cancellationToken = default)
+                    => Task.FromResult(request.Id);
+            }
+            """;
+
+        var (driver, compilation, tree) = RunInitialGeneration(source);
+
+        var editedTree = CSharpSyntaxTree.ParseText(
+            "// line one" + Environment.NewLine + "// line two" + Environment.NewLine + source,
+            path: "TestFile.cs"
+        );
+        var editedCompilation = compilation.ReplaceSyntaxTree(tree, editedTree);
+        driver = driver.RunGeneratorsAndUpdateCompilation(editedCompilation, out _, out _);
+        var diagnostics = driver.GetRunResult().Results.Single().Diagnostics;
+
+        var diagnostic = diagnostics.Single(d => string.Equals(d.Id, "PULSE003", StringComparison.Ordinal));
+        var editedRoot = await editedTree.GetRootAsync().ConfigureAwait(false);
+        var expectedPosition = editedRoot
+            .DescendantNodes()
+            .OfType<ClassDeclarationSyntax>()
+            .Single()
+            .GetLocation()
+            .GetLineSpan()
+            .StartLinePosition;
+
+        _ = await Assert.That(diagnostic.Location.GetLineSpan().StartLinePosition).IsEqualTo(expectedPosition);
+    }
+
+    [Test]
+    public async Task WhenLinesInsertedAboveInvalidExplicitMessageTypeThenPulse005LocationFollowsDeclaration()
+    {
+        const string source = """
+            using NetEvolve.Pulse.Extensibility;
+            using NetEvolve.Pulse.Extensibility.Attributes;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            [PulseHandler<string>]
+            public class GenericCommandHandler<TCmd, TResult> : ICommandHandler<TCmd, TResult>
+                where TCmd : ICommand<TResult>
+            {
+                public Task<TResult> HandleAsync(TCmd command, CancellationToken cancellationToken = default)
+                    => Task.FromResult(default(TResult)!);
+            }
+            """;
+
+        var (driver, compilation, tree) = RunInitialGeneration(source);
+
+        var editedTree = CSharpSyntaxTree.ParseText(
+            "// line one" + Environment.NewLine + "// line two" + Environment.NewLine + source,
+            path: "TestFile.cs"
+        );
+        var editedCompilation = compilation.ReplaceSyntaxTree(tree, editedTree);
+        driver = driver.RunGeneratorsAndUpdateCompilation(editedCompilation, out _, out _);
+        var diagnostics = driver.GetRunResult().Results.Single().Diagnostics;
+
+        var diagnostic = diagnostics.Single(d => string.Equals(d.Id, "PULSE005", StringComparison.Ordinal));
+        var editedRoot = await editedTree.GetRootAsync().ConfigureAwait(false);
+        var expectedPosition = editedRoot
+            .DescendantNodes()
+            .OfType<ClassDeclarationSyntax>()
+            .Single()
+            .GetLocation()
+            .GetLineSpan()
+            .StartLinePosition;
+
+        _ = await Assert.That(diagnostic.Location.GetLineSpan().StartLinePosition).IsEqualTo(expectedPosition);
+    }
+
+    private static (GeneratorDriver Driver, CSharpCompilation Compilation, SyntaxTree Tree) RunInitialGeneration(
+        string source
+    )
+    {
+        var tree = CSharpSyntaxTree.ParseText(source, path: "TestFile.cs");
+        var compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            [tree],
+            GetMetadataReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+        );
+
+        var optionsProvider = new TestAnalyzerConfigOptionsProvider("TestAssembly");
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            generators: [new PulseHandlerGenerator().AsSourceGenerator()],
+            optionsProvider: optionsProvider
+        );
+
+        driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out _, out _);
+        return (driver, compilation, tree);
+    }
+
+    private static MetadataReference[] GetMetadataReferences()
+    {
+        var trustedAssemblies = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        var runtimeReferences = trustedAssemblies!
+            .Split(Path.PathSeparator)
+            .Where(p =>
+            {
+                var fileName = Path.GetFileName(p);
+                return fileName.StartsWith("System.", StringComparison.Ordinal)
+                    || string.Equals(fileName, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(fileName, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .Select(p => MetadataReference.CreateFromFile(p))
+            .Cast<MetadataReference>()
+            .ToList();
+
+        runtimeReferences.Add(MetadataReference.CreateFromFile(typeof(Extensibility.ICommand<>).Assembly.Location));
+        runtimeReferences.Add(
+            MetadataReference.CreateFromFile(typeof(Extensibility.Attributes.PulseHandlerAttribute).Assembly.Location)
+        );
+
+        return [.. runtimeReferences];
+    }
+}

--- a/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenEventHandlerNotAnnotatedThenPulse003Reported.verified.txt
+++ b/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenEventHandlerNotAnnotatedThenPulse003Reported.verified.txt
@@ -17,21 +17,11 @@
       IsWarningAsError: false,
       Location: {
         IsInMetadata: false,
-        IsInSource: true,
-        Kind: SourceFile,
+        IsInSource: false,
+        Kind: ExternalFile,
         SourceSpan: {
           Start: 400,
           Length: 179
-        },
-        SourceTree: {
-          FilePath: ,
-          HasCompilationUnitRoot: true,
-          Length: 579,
-          Options: {
-            DocumentationMode: Parse,
-            Language: C#,
-            LanguageVersion: CSharpLatest
-          }
         }
       },
       Severity: Info,

--- a/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenExplicitMessageTypeIncompatibleWithHandlerInterfaceThenPulse006Reported.verified.txt
+++ b/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenExplicitMessageTypeIncompatibleWithHandlerInterfaceThenPulse006Reported.verified.txt
@@ -17,21 +17,11 @@
       IsWarningAsError: false,
       Location: {
         IsInMetadata: false,
-        IsInSource: true,
-        Kind: SourceFile,
+        IsInSource: false,
+        Kind: ExternalFile,
         SourceSpan: {
           Start: 400,
           Length: 290
-        },
-        SourceTree: {
-          FilePath: ,
-          HasCompilationUnitRoot: true,
-          Length: 690,
-          Options: {
-            DocumentationMode: Parse,
-            Language: C#,
-            LanguageVersion: CSharpLatest
-          }
         }
       },
       Severity: Error

--- a/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenExplicitMessageTypeNotPulseMessageThenPulse005Reported.verified.txt
+++ b/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenExplicitMessageTypeNotPulseMessageThenPulse005Reported.verified.txt
@@ -17,21 +17,11 @@
       IsWarningAsError: false,
       Location: {
         IsInMetadata: false,
-        IsInSource: true,
-        Kind: SourceFile,
+        IsInSource: false,
+        Kind: ExternalFile,
         SourceSpan: {
           Start: 140,
           Length: 289
-        },
-        SourceTree: {
-          FilePath: ,
-          HasCompilationUnitRoot: true,
-          Length: 429,
-          Options: {
-            DocumentationMode: Parse,
-            Language: C#,
-            LanguageVersion: CSharpLatest
-          }
         }
       },
       Severity: Error

--- a/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenHandlerInterfaceInheritedViaBaseClassAndNotAnnotatedThenPulse003Reported.verified.txt
+++ b/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenHandlerInterfaceInheritedViaBaseClassAndNotAnnotatedThenPulse003Reported.verified.txt
@@ -17,21 +17,11 @@
       IsWarningAsError: false,
       Location: {
         IsInMetadata: false,
-        IsInSource: true,
-        Kind: SourceFile,
+        IsInSource: false,
+        Kind: ExternalFile,
         SourceSpan: {
           Start: 198,
           Length: 193
-        },
-        SourceTree: {
-          FilePath: ,
-          HasCompilationUnitRoot: true,
-          Length: 605,
-          Options: {
-            DocumentationMode: Parse,
-            Language: C#,
-            LanguageVersion: CSharpLatest
-          }
         }
       },
       Severity: Info,
@@ -54,21 +44,11 @@
       IsWarningAsError: false,
       Location: {
         IsInMetadata: false,
-        IsInSource: true,
-        Kind: SourceFile,
+        IsInSource: false,
+        Kind: ExternalFile,
         SourceSpan: {
           Start: 393,
           Length: 212
-        },
-        SourceTree: {
-          FilePath: ,
-          HasCompilationUnitRoot: true,
-          Length: 605,
-          Options: {
-            DocumentationMode: Parse,
-            Language: C#,
-            LanguageVersion: CSharpLatest
-          }
         }
       },
       Severity: Info,

--- a/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenMultipleUnannotatedHandlersThenPulse003ReportedForEach.verified.txt
+++ b/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenMultipleUnannotatedHandlersThenPulse003ReportedForEach.verified.txt
@@ -17,21 +17,11 @@
       IsWarningAsError: false,
       Location: {
         IsInMetadata: false,
-        IsInSource: true,
-        Kind: SourceFile,
+        IsInSource: false,
+        Kind: ExternalFile,
         SourceSpan: {
           Start: 247,
           Length: 204
-        },
-        SourceTree: {
-          FilePath: ,
-          HasCompilationUnitRoot: true,
-          Length: 645,
-          Options: {
-            DocumentationMode: Parse,
-            Language: C#,
-            LanguageVersion: CSharpLatest
-          }
         }
       },
       Severity: Info,
@@ -54,21 +44,11 @@
       IsWarningAsError: false,
       Location: {
         IsInMetadata: false,
-        IsInSource: true,
-        Kind: SourceFile,
+        IsInSource: false,
+        Kind: ExternalFile,
         SourceSpan: {
           Start: 453,
           Length: 192
-        },
-        SourceTree: {
-          FilePath: ,
-          HasCompilationUnitRoot: true,
-          Length: 645,
-          Options: {
-            DocumentationMode: Parse,
-            Language: C#,
-            LanguageVersion: CSharpLatest
-          }
         }
       },
       Severity: Info,

--- a/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenNoHandlerInterfaceImplementedThenPulse001MessageContainsTypeName.verified.txt
+++ b/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenNoHandlerInterfaceImplementedThenPulse001MessageContainsTypeName.verified.txt
@@ -17,21 +17,11 @@
       IsWarningAsError: false,
       Location: {
         IsInMetadata: false,
-        IsInSource: true,
-        Kind: SourceFile,
+        IsInSource: false,
+        Kind: ExternalFile,
         SourceSpan: {
           Start: 86,
           Length: 43
-        },
-        SourceTree: {
-          FilePath: ,
-          HasCompilationUnitRoot: true,
-          Length: 129,
-          Options: {
-            DocumentationMode: Parse,
-            Language: C#,
-            LanguageVersion: CSharpLatest
-          }
         }
       },
       Severity: Error

--- a/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenNoHandlerInterfaceImplementedThenPulse001Reported.verified.txt
+++ b/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenNoHandlerInterfaceImplementedThenPulse001Reported.verified.txt
@@ -17,21 +17,11 @@
       IsWarningAsError: false,
       Location: {
         IsInMetadata: false,
-        IsInSource: true,
-        Kind: SourceFile,
+        IsInSource: false,
+        Kind: ExternalFile,
         SourceSpan: {
           Start: 86,
           Length: 43
-        },
-        SourceTree: {
-          FilePath: ,
-          HasCompilationUnitRoot: true,
-          Length: 129,
-          Options: {
-            DocumentationMode: Parse,
-            Language: C#,
-            LanguageVersion: CSharpLatest
-          }
         }
       },
       Severity: Error

--- a/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenNoHandlerInterfaceThenNoSourceGenerated.verified.txt
+++ b/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenNoHandlerInterfaceThenNoSourceGenerated.verified.txt
@@ -17,21 +17,11 @@
       IsWarningAsError: false,
       Location: {
         IsInMetadata: false,
-        IsInSource: true,
-        Kind: SourceFile,
+        IsInSource: false,
+        Kind: ExternalFile,
         SourceSpan: {
           Start: 86,
           Length: 43
-        },
-        SourceTree: {
-          FilePath: ,
-          HasCompilationUnitRoot: true,
-          Length: 129,
-          Options: {
-            DocumentationMode: Parse,
-            Language: C#,
-            LanguageVersion: CSharpLatest
-          }
         }
       },
       Severity: Error

--- a/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenNoPulseHandlerClassesThenNoOutputGenerated.verified.txt
+++ b/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenNoPulseHandlerClassesThenNoOutputGenerated.verified.txt
@@ -17,21 +17,11 @@
       IsWarningAsError: false,
       Location: {
         IsInMetadata: false,
-        IsInSource: true,
-        Kind: SourceFile,
+        IsInSource: false,
+        Kind: ExternalFile,
         SourceSpan: {
           Start: 198,
           Length: 214
-        },
-        SourceTree: {
-          FilePath: ,
-          HasCompilationUnitRoot: true,
-          Length: 412,
-          Options: {
-            DocumentationMode: Parse,
-            Language: C#,
-            LanguageVersion: CSharpLatest
-          }
         }
       },
       Severity: Info,

--- a/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenOpenGenericHandlerAnnotatedThenPulse004Reported.verified.txt
+++ b/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenOpenGenericHandlerAnnotatedThenPulse004Reported.verified.txt
@@ -17,21 +17,11 @@
       IsWarningAsError: false,
       Location: {
         IsInMetadata: false,
-        IsInSource: true,
-        Kind: SourceFile,
+        IsInSource: false,
+        Kind: ExternalFile,
         SourceSpan: {
           Start: 140,
           Length: 290
-        },
-        SourceTree: {
-          FilePath: ,
-          HasCompilationUnitRoot: true,
-          Length: 430,
-          Options: {
-            DocumentationMode: Parse,
-            Language: C#,
-            LanguageVersion: CSharpLatest
-          }
         }
       },
       Severity: Error

--- a/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenQueryHandlerNotAnnotatedThenPulse003Reported.verified.txt
+++ b/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenQueryHandlerNotAnnotatedThenPulse003Reported.verified.txt
@@ -17,21 +17,11 @@
       IsWarningAsError: false,
       Location: {
         IsInMetadata: false,
-        IsInSource: true,
-        Kind: SourceFile,
+        IsInSource: false,
+        Kind: ExternalFile,
         SourceSpan: {
           Start: 192,
           Length: 204
-        },
-        SourceTree: {
-          FilePath: ,
-          HasCompilationUnitRoot: true,
-          Length: 396,
-          Options: {
-            DocumentationMode: Parse,
-            Language: C#,
-            LanguageVersion: CSharpLatest
-          }
         }
       },
       Severity: Info,

--- a/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenRecordHandlerNotAnnotatedThenPulse003Reported.verified.txt
+++ b/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenRecordHandlerNotAnnotatedThenPulse003Reported.verified.txt
@@ -17,21 +17,11 @@
       IsWarningAsError: false,
       Location: {
         IsInMetadata: false,
-        IsInSource: true,
-        Kind: SourceFile,
+        IsInSource: false,
+        Kind: ExternalFile,
         SourceSpan: {
           Start: 198,
           Length: 215
-        },
-        SourceTree: {
-          FilePath: ,
-          HasCompilationUnitRoot: true,
-          Length: 413,
-          Options: {
-            DocumentationMode: Parse,
-            Language: C#,
-            LanguageVersion: CSharpLatest
-          }
         }
       },
       Severity: Info,

--- a/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenStreamQueryHandlerNotAnnotatedThenPulse003Reported.verified.txt
+++ b/tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/_snapshots/PulseHandlerGeneratorTests.WhenStreamQueryHandlerNotAnnotatedThenPulse003Reported.verified.txt
@@ -17,21 +17,11 @@
       IsWarningAsError: false,
       Location: {
         IsInMetadata: false,
-        IsInSource: true,
-        Kind: SourceFile,
+        IsInSource: false,
+        Kind: ExternalFile,
         SourceSpan: {
           Start: 208,
           Length: 251
-        },
-        SourceTree: {
-          FilePath: ,
-          HasCompilationUnitRoot: true,
-          Length: 459,
-          Options: {
-            DocumentationMode: Parse,
-            Language: C#,
-            LanguageVersion: CSharpLatest
-          }
         }
       },
       Severity: Info,


### PR DESCRIPTION
HandlerInfo and ExplicitTypeError stored Microsoft.CodeAnalysis.Location,
which keeps the originating syntax tree alive in the incremental driver's
caches and was excluded from equality, so edits above a handler replayed
diagnostics with a stale pre-edit location and crashed the generator when
the referenced tree was no longer part of the compilation. Both models now
carry an equatable LocationInfo (file path, text span, line span) that is
part of equality and is converted back via Location.Create when reporting.