### PR TITLE
fix(sqlite): normalize DateTimeOffset values to UTC before persisting outbox timestamps

### DIFF
--- a/src/NetEvolve.Pulse.SQLite/Outbox/SQLiteOutboxRepository.cs
+++ b/src/NetEvolve.Pulse.SQLite/Outbox/SQLiteOutboxRepository.cs
@@ -27,6 +27,9 @@ using NetEvolve.Pulse.Extensibility.Outbox;
 /// <c>Processing</c> status longer than <see cref="OutboxOptions.ProcessingLeaseTimeout"/> (for
 /// example, after a worker crash, cancellation, or unhandled exception during dispatch) are
 /// reclaimed by subsequent pending polls, preserving at-least-once delivery.
+/// <para><strong>Timestamp Normalization:</strong></para>
+/// All <see cref="DateTimeOffset"/> values are normalized to UTC before persistence, because SQLite
+/// stores them as TEXT and compares them lexicographically; mixed offsets would break chronological ordering.
 /// </remarks>
 [SuppressMessage(
     "Reliability",
@@ -420,7 +423,7 @@ internal sealed class SQLiteOutboxRepository : IOutboxRepository
                 _ = command.Parameters.AddWithValue("@error", (object?)errorMessage ?? DBNull.Value);
                 _ = command.Parameters.AddWithValue(
                     "@nextRetryAt",
-                    nextRetryAt.HasValue ? (object)nextRetryAt.Value : DBNull.Value
+                    nextRetryAt.HasValue ? (object)nextRetryAt.Value.ToUniversalTime() : DBNull.Value
                 );
 
                 _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
@@ -532,15 +535,15 @@ internal sealed class SQLiteOutboxRepository : IOutboxRepository
         _ = command.Parameters.AddWithValue("@Payload", message.Payload);
         _ = command.Parameters.AddWithValue("@CorrelationId", (object?)message.CorrelationId ?? DBNull.Value);
         _ = command.Parameters.AddWithValue("@CausationId", (object?)message.CausationId ?? DBNull.Value);
-        _ = command.Parameters.AddWithValue("@CreatedAt", message.CreatedAt);
-        _ = command.Parameters.AddWithValue("@UpdatedAt", message.UpdatedAt);
+        _ = command.Parameters.AddWithValue("@CreatedAt", message.CreatedAt.ToUniversalTime());
+        _ = command.Parameters.AddWithValue("@UpdatedAt", message.UpdatedAt.ToUniversalTime());
         _ = command.Parameters.AddWithValue(
             "@ProcessedAt",
-            message.ProcessedAt.HasValue ? (object)message.ProcessedAt.Value : DBNull.Value
+            message.ProcessedAt.HasValue ? (object)message.ProcessedAt.Value.ToUniversalTime() : DBNull.Value
         );
         _ = command.Parameters.AddWithValue(
             "@NextRetryAt",
-            message.NextRetryAt.HasValue ? (object)message.NextRetryAt.Value : DBNull.Value
+            message.NextRetryAt.HasValue ? (object)message.NextRetryAt.Value.ToUniversalTime() : DBNull.Value
         );
         _ = command.Parameters.AddWithValue("@RetryCount", message.RetryCount);
         _ = command.Parameters.AddWithValue("@Error", (object?)message.Error ?? DBNull.Value);

--- a/tests/NetEvolve.Pulse.Tests.Unit/SQLite/SQLiteOutboxRepositoryDatabaseTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/SQLite/SQLiteOutboxRepositoryDatabaseTests.cs
@@ -324,6 +324,48 @@ public sealed class SQLiteOutboxRepositoryDatabaseTests : IAsyncDisposable
     }
 
     [Test]
+    public async Task GetFailedForRetryAsync_WithDueNonUtcNextRetryAt_ReturnsMessage(
+        CancellationToken cancellationToken
+    )
+    {
+        var repository = CreateRepository();
+        var message = CreateMessage();
+        await repository.AddAsync(message, cancellationToken).ConfigureAwait(false);
+
+        var nextRetry = DateTimeOffset.UtcNow.AddMinutes(-30).ToOffset(TimeSpan.FromHours(2));
+        await repository
+            .MarkAsFailedAsync(message.Id, "Failure with offset retry", nextRetry, cancellationToken)
+            .ConfigureAwait(false);
+
+        var forRetry = await repository
+            .GetFailedForRetryAsync(maxRetryCount: 3, batchSize: 10, cancellationToken)
+            .ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(forRetry.Count).IsEqualTo(1);
+            _ = await Assert.That(forRetry).All(m => m.Id == message.Id);
+        }
+    }
+
+    [Test]
+    public async Task GetPendingAsync_WithDueNonUtcNextRetryAt_ReturnsMessage(CancellationToken cancellationToken)
+    {
+        var repository = CreateRepository();
+        var message = CreateMessage();
+        message.NextRetryAt = DateTimeOffset.UtcNow.AddMinutes(-30).ToOffset(TimeSpan.FromHours(2));
+        await repository.AddAsync(message, cancellationToken).ConfigureAwait(false);
+
+        var pending = await repository.GetPendingAsync(10, cancellationToken).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(pending.Count).IsEqualTo(1);
+            _ = await Assert.That(pending).All(m => m.Id == message.Id);
+        }
+    }
+
+    [Test]
     public async Task AddAsync_UsesAmbientTransactionScope(CancellationToken cancellationToken)
     {
         var connection = new SqliteConnection(_connectionString);


### PR DESCRIPTION
SQLite stores DateTimeOffset as offset-preserving TEXT, while pending and retry queries compare NextRetryAt lexicographically against an always-UTC parameter. A non-UTC nextRetryAt therefore delayed or prematurely triggered retries. All write paths now convert timestamps to UTC before binding, keeping TEXT comparisons chronologically correct while remaining readable alongside existing rows.