### PR TITLE
perf(sqlite): apply WAL journal mode once per instance instead of per connection

### DIFF
--- a/src/NetEvolve.Pulse.SQLite/Idempotency/SQLiteIdempotencyKeyRepository.cs
+++ b/src/NetEvolve.Pulse.SQLite/Idempotency/SQLiteIdempotencyKeyRepository.cs
@@ -38,8 +38,11 @@ internal sealed class SQLiteIdempotencyKeyRepository : IIdempotencyKeyRepository
     /// <summary>The SQLite connection string used to open new connections for each repository operation.</summary>
     private readonly string _connectionString;
 
-    /// <summary>Whether to apply WAL journal mode on each opened connection.</summary>
+    /// <summary>Whether to apply WAL journal mode to the database.</summary>
     private readonly bool _enableWalMode;
+
+    /// <summary>Tracks whether the persistent WAL journal mode has already been applied to the database.</summary>
+    private int _walModeApplied;
 
     /// <summary>Cached SQL statement for checking if an idempotency key exists.</summary>
     private readonly string _existsSql;
@@ -139,7 +142,9 @@ internal sealed class SQLiteIdempotencyKeyRepository : IIdempotencyKeyRepository
 
     /// <summary>
     /// Opens and returns a new <see cref="SqliteConnection"/> using the stored connection string.
-    /// Applies WAL mode when <see cref="IdempotencyKeyOptions.EnableWalMode"/> is <see langword="true"/>.
+    /// Applies WAL mode once per repository instance when <see cref="IdempotencyKeyOptions.EnableWalMode"/> is
+    /// <see langword="true"/>; the journal mode is a persistent database property and does not need
+    /// to be re-applied on subsequent connections.
     /// The caller is responsible for disposing the connection.
     /// </summary>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
@@ -149,13 +154,15 @@ internal sealed class SQLiteIdempotencyKeyRepository : IIdempotencyKeyRepository
         var connection = new SqliteConnection(_connectionString);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
-        if (_enableWalMode)
+        if (_enableWalMode && Volatile.Read(ref _walModeApplied) == 0)
         {
             var walCmd = new SqliteCommand("PRAGMA journal_mode=WAL;", connection);
             await using (walCmd.ConfigureAwait(false))
             {
                 _ = await walCmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             }
+
+            Volatile.Write(ref _walModeApplied, 1);
         }
 
         return connection;

--- a/src/NetEvolve.Pulse.SQLite/Outbox/SQLiteOutboxManagement.cs
+++ b/src/NetEvolve.Pulse.SQLite/Outbox/SQLiteOutboxManagement.cs
@@ -24,8 +24,11 @@ internal sealed class SQLiteOutboxManagement : IOutboxManagement
     /// <summary>The SQLite connection string resolved from <see cref="OutboxOptions"/>.</summary>
     private readonly string _connectionString;
 
-    /// <summary>Whether to apply WAL journal mode on each opened connection.</summary>
+    /// <summary>Whether to apply WAL journal mode to the database.</summary>
     private readonly bool _enableWalMode;
+
+    /// <summary>Tracks whether the persistent WAL journal mode has already been applied to the database.</summary>
+    private int _walModeApplied;
 
     /// <summary>The time provider used to generate consistent timestamps.</summary>
     private readonly TimeProvider _timeProvider;
@@ -295,7 +298,9 @@ internal sealed class SQLiteOutboxManagement : IOutboxManagement
 
     /// <summary>
     /// Opens and returns a new <see cref="SqliteConnection"/> using the stored connection string.
-    /// Applies WAL mode when <see cref="OutboxOptions.EnableWalMode"/> is <see langword="true"/>.
+    /// Applies WAL mode once per instance when <see cref="OutboxOptions.EnableWalMode"/> is
+    /// <see langword="true"/>; the journal mode is a persistent database property and does not need
+    /// to be re-applied on subsequent connections.
     /// The caller is responsible for disposing the connection.
     /// </summary>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
@@ -305,13 +310,15 @@ internal sealed class SQLiteOutboxManagement : IOutboxManagement
         var connection = new SqliteConnection(_connectionString);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
-        if (_enableWalMode)
+        if (_enableWalMode && Volatile.Read(ref _walModeApplied) == 0)
         {
             var walCmd = new SqliteCommand("PRAGMA journal_mode=WAL;", connection);
             await using (walCmd.ConfigureAwait(false))
             {
                 _ = await walCmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             }
+
+            Volatile.Write(ref _walModeApplied, 1);
         }
 
         return connection;

--- a/src/NetEvolve.Pulse.SQLite/Outbox/SQLiteOutboxRepository.cs
+++ b/src/NetEvolve.Pulse.SQLite/Outbox/SQLiteOutboxRepository.cs
@@ -20,8 +20,8 @@ using NetEvolve.Pulse.Extensibility.Outbox;
 /// pending-message claims to prevent duplicate processing by concurrent workers.
 /// <para><strong>WAL Mode:</strong></para>
 /// When <see cref="OutboxOptions.EnableWalMode"/> is <see langword="true"/>, the
-/// <c>PRAGMA journal_mode=WAL</c> command is applied on each connection to allow concurrent
-/// read access during writes.
+/// <c>PRAGMA journal_mode=WAL</c> command is applied once per repository instance to allow concurrent
+/// read access during writes; WAL is a persistent database property.
 /// <para><strong>Claim Lease:</strong></para>
 /// Each claim records the claim timestamp in <c>UpdatedAt</c>. Messages that remain in the
 /// <c>Processing</c> status longer than <see cref="OutboxOptions.ProcessingLeaseTimeout"/> (for
@@ -48,8 +48,11 @@ internal sealed class SQLiteOutboxRepository : IOutboxRepository
     /// <summary>The SQLite connection string resolved from <see cref="OutboxOptions"/>.</summary>
     private readonly string _connectionString;
 
-    /// <summary>Whether to apply WAL journal mode on each opened connection.</summary>
+    /// <summary>Whether to apply WAL journal mode to the database.</summary>
     private readonly bool _enableWalMode;
+
+    /// <summary>Tracks whether the persistent WAL journal mode has already been applied to the database.</summary>
+    private int _walModeApplied;
 
     /// <summary>The optional transaction scope providing an ambient <see cref="SqliteTransaction"/> for <see cref="AddAsync"/>.</summary>
     private readonly IOutboxTransactionScope? _transactionScope;
@@ -489,7 +492,9 @@ internal sealed class SQLiteOutboxRepository : IOutboxRepository
 
     /// <summary>
     /// Opens and returns a new <see cref="SqliteConnection"/> using the stored connection string.
-    /// Applies WAL mode when <see cref="OutboxOptions.EnableWalMode"/> is <see langword="true"/>.
+    /// Applies WAL mode once per repository instance when <see cref="OutboxOptions.EnableWalMode"/> is
+    /// <see langword="true"/>; the journal mode is a persistent database property and does not need
+    /// to be re-applied on subsequent connections.
     /// The caller is responsible for disposing the connection.
     /// </summary>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
@@ -499,13 +504,15 @@ internal sealed class SQLiteOutboxRepository : IOutboxRepository
         var connection = new SqliteConnection(_connectionString);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
-        if (_enableWalMode)
+        if (_enableWalMode && Volatile.Read(ref _walModeApplied) == 0)
         {
             var walCmd = new SqliteCommand("PRAGMA journal_mode=WAL;", connection);
             await using (walCmd.ConfigureAwait(false))
             {
                 _ = await walCmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             }
+
+            Volatile.Write(ref _walModeApplied, 1);
         }
 
         return connection;

--- a/tests/NetEvolve.Pulse.Tests.Unit/SQLite/SQLiteOutboxRepositoryDatabaseTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/SQLite/SQLiteOutboxRepositoryDatabaseTests.cs
@@ -353,6 +353,115 @@ public sealed class SQLiteOutboxRepositoryDatabaseTests : IAsyncDisposable
         }
     }
 
+    [Test]
+    public async Task CreateConnection_WithWalModeEnabled_AppliesJournalModePragmaOnlyOnce(
+        CancellationToken cancellationToken
+    )
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"pulse_wal_{Guid.NewGuid():N}.db");
+        var fileConnectionString = $"Data Source={dbPath};Pooling=False";
+
+        try
+        {
+            var schemaConnection = new SqliteConnection(fileConnectionString);
+            await using (schemaConnection.ConfigureAwait(false))
+            {
+                await schemaConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                var schemaCmd = new SqliteCommand(
+                    """
+                    CREATE TABLE IF NOT EXISTS "OutboxMessage"
+                    (
+                        "Id"            TEXT    NOT NULL,
+                        "EventType"     TEXT    NOT NULL,
+                        "Payload"       TEXT    NOT NULL,
+                        "CorrelationId" TEXT    NULL,
+                        "CausationId"   TEXT    NULL,
+                        "CreatedAt"     TEXT    NOT NULL,
+                        "UpdatedAt"     TEXT    NOT NULL,
+                        "ProcessedAt"   TEXT    NULL,
+                        "NextRetryAt"   TEXT    NULL,
+                        "RetryCount"    INTEGER NOT NULL DEFAULT 0,
+                        "Error"         TEXT    NULL,
+                        "Status"        INTEGER NOT NULL DEFAULT 0,
+                        CONSTRAINT "PK_OutboxMessage" PRIMARY KEY ("Id")
+                    );
+                    """,
+                    schemaConnection
+                );
+                await using (schemaCmd.ConfigureAwait(false))
+                {
+                    _ = await schemaCmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            var options = Options.Create(
+                new OutboxOptions { ConnectionString = fileConnectionString, EnableWalMode = true }
+            );
+            var repository = new SQLiteOutboxRepository(options, TimeProvider.System);
+
+            _ = await repository.GetPendingCountAsync(cancellationToken).ConfigureAwait(false);
+
+            var afterFirstUse = await SetJournalModeDeleteAsync(fileConnectionString, cancellationToken)
+                .ConfigureAwait(false);
+
+            _ = await repository.GetPendingCountAsync(cancellationToken).ConfigureAwait(false);
+
+            var afterSecondUse = await GetJournalModeAsync(fileConnectionString, cancellationToken)
+                .ConfigureAwait(false);
+
+            using (Assert.Multiple())
+            {
+                _ = await Assert.That(afterFirstUse).IsEqualTo("delete");
+                _ = await Assert.That(afterSecondUse).IsEqualTo("delete");
+            }
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            foreach (var suffix in new[] { string.Empty, "-wal", "-shm" })
+            {
+                var path = dbPath + suffix;
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+        }
+    }
+
+    private static async Task<string?> SetJournalModeDeleteAsync(
+        string connectionString,
+        CancellationToken cancellationToken
+    )
+    {
+        var connection = new SqliteConnection(connectionString);
+        await using (connection.ConfigureAwait(false))
+        {
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            var command = new SqliteCommand("PRAGMA journal_mode=DELETE;", connection);
+            await using (command.ConfigureAwait(false))
+            {
+                var result = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+                return result as string;
+            }
+        }
+    }
+
+    private static async Task<string?> GetJournalModeAsync(string connectionString, CancellationToken cancellationToken)
+    {
+        var connection = new SqliteConnection(connectionString);
+        await using (connection.ConfigureAwait(false))
+        {
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            var command = new SqliteCommand("PRAGMA journal_mode;", connection);
+            await using (command.ConfigureAwait(false))
+            {
+                var result = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+                return result as string;
+            }
+        }
+    }
+
     private sealed class StubTransactionScope(SqliteTransaction transaction) : IOutboxTransactionScope
     {
         public object? GetCurrentTransaction() => transaction;


### PR DESCRIPTION
PRAGMA journal_mode=WAL was executed on every opened connection in the outbox repository, idempotency key repository, and outbox management, although the journal mode is a persistent database property. Each instance now applies the pragma only on the first opened connection, removing a redundant command from every subsequent operation.