### PR TITLE
perf(sqlserver): use single connection for batch outbox status updates

### DIFF
--- a/src/NetEvolve.Pulse.SqlServer/Outbox/SqlServerOutboxRepository.cs
+++ b/src/NetEvolve.Pulse.SqlServer/Outbox/SqlServerOutboxRepository.cs
@@ -260,30 +260,6 @@ internal sealed class SqlServerOutboxRepository : IOutboxRepository
     }
 
     /// <inheritdoc />
-    public async Task MarkAsFailedAsync(
-        Guid messageId,
-        string errorMessage,
-        CancellationToken cancellationToken = default
-    )
-    {
-        var now = _timeProvider.GetUtcNow();
-
-        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
-        await using (connection.ConfigureAwait(false))
-        {
-            var command = new SqlCommand(_markFailedSql, connection) { CommandType = CommandType.StoredProcedure };
-            await using (command.ConfigureAwait(false))
-            {
-                _ = command.Parameters.AddWithValue("@messageId", messageId);
-                _ = command.Parameters.AddWithValue("@error", (object?)errorMessage ?? DBNull.Value);
-                _ = command.Parameters.AddWithValue("@nowUtc", now);
-
-                _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-            }
-        }
-    }
-
-    /// <inheritdoc />
     public async Task MarkAsCompletedAsync(
         IReadOnlyCollection<Guid> messageIds,
         CancellationToken cancellationToken = default
@@ -315,6 +291,30 @@ internal sealed class SqlServerOutboxRepository : IOutboxRepository
 
                     _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
                 }
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task MarkAsFailedAsync(
+        Guid messageId,
+        string errorMessage,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var now = _timeProvider.GetUtcNow();
+
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var command = new SqlCommand(_markFailedSql, connection) { CommandType = CommandType.StoredProcedure };
+            await using (command.ConfigureAwait(false))
+            {
+                _ = command.Parameters.AddWithValue("@messageId", messageId);
+                _ = command.Parameters.AddWithValue("@error", (object?)errorMessage ?? DBNull.Value);
+                _ = command.Parameters.AddWithValue("@nowUtc", now);
+
+                _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             }
         }
     }

--- a/src/NetEvolve.Pulse.SqlServer/Outbox/SqlServerOutboxRepository.cs
+++ b/src/NetEvolve.Pulse.SqlServer/Outbox/SqlServerOutboxRepository.cs
@@ -284,18 +284,74 @@ internal sealed class SqlServerOutboxRepository : IOutboxRepository
     }
 
     /// <inheritdoc />
+    public async Task MarkAsCompletedAsync(
+        IReadOnlyCollection<Guid> messageIds,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(messageIds);
+
+        if (messageIds.Count == 0)
+        {
+            return;
+        }
+
+        var now = _timeProvider.GetUtcNow();
+
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            foreach (var messageId in messageIds)
+            {
+                var command = new SqlCommand(_markCompletedSql, connection)
+                {
+                    CommandType = CommandType.StoredProcedure,
+                };
+                await using (command.ConfigureAwait(false))
+                {
+                    _ = command.Parameters.AddWithValue("@messageId", messageId);
+                    _ = command.Parameters.AddWithValue("@processedAtUtc", now);
+                    _ = command.Parameters.AddWithValue("@updatedAtUtc", now);
+
+                    _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc />
     public async Task MarkAsFailedAsync(
         IReadOnlyCollection<Guid> messageIds,
         string errorMessage,
         CancellationToken cancellationToken = default
-    ) =>
-        await Parallel
-            .ForEachAsync(
-                messageIds,
-                cancellationToken,
-                async (id, token) => await MarkAsFailedAsync(id, errorMessage, token).ConfigureAwait(false)
-            )
-            .ConfigureAwait(false);
+    )
+    {
+        ArgumentNullException.ThrowIfNull(messageIds);
+
+        if (messageIds.Count == 0)
+        {
+            return;
+        }
+
+        var now = _timeProvider.GetUtcNow();
+
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            foreach (var messageId in messageIds)
+            {
+                var command = new SqlCommand(_markFailedSql, connection) { CommandType = CommandType.StoredProcedure };
+                await using (command.ConfigureAwait(false))
+                {
+                    _ = command.Parameters.AddWithValue("@messageId", messageId);
+                    _ = command.Parameters.AddWithValue("@error", (object?)errorMessage ?? DBNull.Value);
+                    _ = command.Parameters.AddWithValue("@nowUtc", now);
+
+                    _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+    }
 
     /// <inheritdoc />
     public async Task MarkAsFailedAsync(
@@ -346,6 +402,43 @@ internal sealed class SqlServerOutboxRepository : IOutboxRepository
                 _ = command.Parameters.AddWithValue("@nowUtc", now);
 
                 _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task MarkAsDeadLetterAsync(
+        IReadOnlyCollection<Guid> messageIds,
+        string errorMessage,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(messageIds);
+
+        if (messageIds.Count == 0)
+        {
+            return;
+        }
+
+        var now = _timeProvider.GetUtcNow();
+
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            foreach (var messageId in messageIds)
+            {
+                var command = new SqlCommand(_markDeadLetterSql, connection)
+                {
+                    CommandType = CommandType.StoredProcedure,
+                };
+                await using (command.ConfigureAwait(false))
+                {
+                    _ = command.Parameters.AddWithValue("@messageId", messageId);
+                    _ = command.Parameters.AddWithValue("@error", (object?)errorMessage ?? DBNull.Value);
+                    _ = command.Parameters.AddWithValue("@nowUtc", now);
+
+                    _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+                }
             }
         }
     }


### PR DESCRIPTION
MarkAsFailedAsync(collection) relied on the IOutboxRepository default that
runs Parallel.ForEachAsync over the ids, opening one pooled SqlConnection
and one stored procedure call per id concurrently. Under sustained failure
load this could consume up to ProcessorCount pooled connections at once.
Override MarkAsCompletedAsync, MarkAsFailedAsync, and MarkAsDeadLetterAsync
for IReadOnlyCollection<Guid> to open a single connection and update each
id sequentially, preserving the exact per-row stored procedure semantics.