### PR TITLE
perf(sqlserver): cache Type.GetType lookups in outbox row mapping

### DIFF
--- a/src/NetEvolve.Pulse.SqlServer/Outbox/OutboxEventTypeResolver.cs
+++ b/src/NetEvolve.Pulse.SqlServer/Outbox/OutboxEventTypeResolver.cs
@@ -1,0 +1,35 @@
+namespace NetEvolve.Pulse.Outbox;
+
+using System.Collections.Concurrent;
+
+/// <summary>
+/// Resolves and caches <see cref="Type"/> lookups from assembly-qualified event type names
+/// stored in the outbox table, avoiding repeated <see cref="Type.GetType(string)"/> parsing
+/// and loader lookups on every row mapped in the polling hot path.
+/// </summary>
+internal static class OutboxEventTypeResolver
+{
+    private static readonly ConcurrentDictionary<string, Type> _cache = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Resolves <paramref name="typeName"/> to a <see cref="Type"/>, memoizing successful
+    /// resolutions in a process-wide cache keyed by the assembly-qualified name.
+    /// </summary>
+    /// <param name="typeName">The assembly-qualified type name read from storage.</param>
+    /// <returns>The resolved <see cref="Type"/>, or <see langword="null"/> if it cannot be resolved.</returns>
+    public static Type? Resolve(string typeName)
+    {
+        if (_cache.TryGetValue(typeName, out var cached))
+        {
+            return cached;
+        }
+
+        var resolved = Type.GetType(typeName);
+        if (resolved is null)
+        {
+            return null;
+        }
+
+        return _cache[typeName] = resolved;
+    }
+}

--- a/src/NetEvolve.Pulse.SqlServer/Outbox/SqlServerOutboxManagement.cs
+++ b/src/NetEvolve.Pulse.SqlServer/Outbox/SqlServerOutboxManagement.cs
@@ -331,7 +331,7 @@ internal sealed class SqlServerOutboxManagement : IOutboxManagement
         {
             Id = reader.GetGuid(ordId),
             EventType =
-                Type.GetType(reader.GetString(ordEventType))
+                OutboxEventTypeResolver.Resolve(reader.GetString(ordEventType))
                 ?? throw new InvalidOperationException(
                     $"Cannot resolve event type '{reader.GetString(ordEventType)}'."
                 ),

--- a/src/NetEvolve.Pulse.SqlServer/Outbox/SqlServerOutboxRepository.cs
+++ b/src/NetEvolve.Pulse.SqlServer/Outbox/SqlServerOutboxRepository.cs
@@ -505,7 +505,7 @@ internal sealed class SqlServerOutboxRepository : IOutboxRepository
         {
             Id = reader.GetGuid(ordId),
             EventType =
-                Type.GetType(reader.GetString(ordEventType))
+                OutboxEventTypeResolver.Resolve(reader.GetString(ordEventType))
                 ?? throw new InvalidOperationException(
                     $"Cannot resolve event type '{reader.GetString(ordEventType)}'."
                 ),

--- a/tests/NetEvolve.Pulse.Tests.Unit/SqlServer/OutboxEventTypeResolverTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/SqlServer/OutboxEventTypeResolverTests.cs
@@ -1,0 +1,39 @@
+namespace NetEvolve.Pulse.Tests.Unit.SqlServer;
+
+using System.Threading.Tasks;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("SqlServer")]
+public sealed class OutboxEventTypeResolverTests
+{
+    [Test]
+    public async Task Resolve_WithKnownTypeName_ReturnsExpectedType()
+    {
+        var typeName = typeof(OutboxEventTypeResolverTests).AssemblyQualifiedName!;
+
+        var resolved = OutboxEventTypeResolver.Resolve(typeName);
+
+        _ = await Assert.That(resolved).IsEqualTo(typeof(OutboxEventTypeResolverTests));
+    }
+
+    [Test]
+    public async Task Resolve_CalledTwiceWithSameName_ReturnsCachedSameInstance()
+    {
+        var typeName = typeof(OutboxEventTypeResolverTests).AssemblyQualifiedName!;
+
+        var first = OutboxEventTypeResolver.Resolve(typeName);
+        var second = OutboxEventTypeResolver.Resolve(typeName);
+
+        _ = await Assert.That(second).IsSameReferenceAs(first!);
+    }
+
+    [Test]
+    public async Task Resolve_WithUnresolvableTypeName_ReturnsNull()
+    {
+        var resolved = OutboxEventTypeResolver.Resolve("NetEvolve.Pulse.DoesNotExist, NetEvolve.Pulse.NoSuchAssembly");
+
+        _ = await Assert.That(resolved).IsNull();
+    }
+}


### PR DESCRIPTION
MapToMessage in both SqlServerOutboxRepository and SqlServerOutboxManagement
called Type.GetType(string) for every row read from the poll hot path,
re-parsing the assembly-qualified name and repeating loader lookups even
though an outbox typically has few distinct event types. Add a shared
OutboxEventTypeResolver backed by a static ConcurrentDictionary that
memoizes successful resolutions, and use it from both mapping methods.