### PR TITLE
fix(outbox): reclaim expired processing leases in SQL Server repository

### DIFF
--- a/src/NetEvolve.Pulse.SqlServer/Outbox/SqlServerOutboxRepository.cs
+++ b/src/NetEvolve.Pulse.SqlServer/Outbox/SqlServerOutboxRepository.cs
@@ -16,6 +16,12 @@ using NetEvolve.Pulse.Extensibility.Outbox;
 /// or by using the connection with an active transaction.
 /// <para><strong>Concurrency:</strong></para>
 /// Uses ROWLOCK and READPAST hints to prevent conflicts during concurrent polling.
+/// <para><strong>Claim Lease:</strong></para>
+/// Each claim records the claim timestamp in <c>UpdatedAt</c>. Messages that remain in
+/// <see cref="OutboxMessageStatus.Processing"/> longer than
+/// <see cref="OutboxOptions.ProcessingLeaseTimeout"/> (for example, after a worker crash,
+/// cancellation, or unhandled exception during dispatch) are reclaimed by subsequent pending
+/// polls, preserving at-least-once delivery.
 /// <para><strong>Performance:</strong></para>
 /// Leverages stored procedures for efficient batch operations and index utilization.
 /// </remarks>
@@ -44,6 +50,9 @@ internal sealed class SqlServerOutboxRepository : IOutboxRepository
 
     /// <summary>The time provider used to generate consistent timestamps for cutoff calculations.</summary>
     private readonly TimeProvider _timeProvider;
+
+    /// <summary>The maximum duration a claimed message may remain in the Processing status before it is reclaimed.</summary>
+    private readonly TimeSpan _processingLeaseTimeout;
 
     /// <summary>Cached stored procedure name for retrieving pending outbox messages.</summary>
     private readonly string _getPendingSql;
@@ -84,10 +93,12 @@ internal sealed class SqlServerOutboxRepository : IOutboxRepository
         ArgumentNullException.ThrowIfNull(options);
         ArgumentException.ThrowIfNullOrWhiteSpace(options.Value.ConnectionString);
         ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(options.Value.ProcessingLeaseTimeout, TimeSpan.Zero);
 
         _connectionString = options.Value.ConnectionString;
         _timeProvider = timeProvider;
         _transactionScope = transactionScope;
+        _processingLeaseTimeout = options.Value.ProcessingLeaseTimeout;
 
         var schema = string.IsNullOrWhiteSpace(options.Value.Schema)
             ? OutboxMessageSchema.DefaultSchema
@@ -184,6 +195,7 @@ internal sealed class SqlServerOutboxRepository : IOutboxRepository
     )
     {
         var now = _timeProvider.GetUtcNow();
+        var leaseExpiredBefore = now - _processingLeaseTimeout;
 
         var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
         await using (connection.ConfigureAwait(false))
@@ -193,6 +205,7 @@ internal sealed class SqlServerOutboxRepository : IOutboxRepository
             {
                 _ = command.Parameters.AddWithValue("@batchSize", batchSize);
                 _ = command.Parameters.AddWithValue("@nowUtc", now);
+                _ = command.Parameters.AddWithValue("@leaseExpiredBeforeUtc", leaseExpiredBefore);
 
                 return await ReadMessagesAsync(command, cancellationToken).ConfigureAwait(false);
             }

--- a/src/NetEvolve.Pulse.SqlServer/Scripts/OutboxMessage.sql
+++ b/src/NetEvolve.Pulse.SqlServer/Scripts/OutboxMessage.sql
@@ -72,7 +72,8 @@ GO
 
 CREATE PROCEDURE [$(SchemaName)].[usp_GetPendingOutboxMessages]
     @batchSize INT,
-    @nowUtc DATETIMEOFFSET
+    @nowUtc DATETIMEOFFSET,
+    @leaseExpiredBeforeUtc DATETIMEOFFSET = NULL
 AS
 BEGIN
     SET NOCOUNT ON;
@@ -92,8 +93,10 @@ BEGIN
             [Error],
             [Status]
         FROM [$(SchemaName)].[$(TableName)] WITH (ROWLOCK, READPAST)
-        WHERE [Status] = 0 -- Pending
-          AND ([NextRetryAt] IS NULL OR [NextRetryAt] <= @nowUtc)
+        WHERE ([Status] = 0 -- Pending
+               AND ([NextRetryAt] IS NULL OR [NextRetryAt] <= @nowUtc))
+           OR ([Status] = 1 -- Processing, but the claim lease has expired (worker crash/cancellation/unhandled exception)
+               AND [UpdatedAt] <= @leaseExpiredBeforeUtc)
         ORDER BY [CreatedAt]
     )
     UPDATE CTE

--- a/tests/NetEvolve.Pulse.Tests.Integration/Outbox/SqlServerOutboxLeaseTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Outbox/SqlServerOutboxLeaseTests.cs
@@ -1,0 +1,100 @@
+namespace NetEvolve.Pulse.Tests.Integration.Outbox;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.Outbox;
+using NetEvolve.Pulse.Outbox;
+using NetEvolve.Pulse.Tests.Integration.Internals;
+
+[ClassDataSource<SqlServerDatabaseServiceFixture, SqlServerAdoNetOutboxInitializer>(
+    Shared = [SharedType.None, SharedType.None]
+)]
+[TestGroup("SqlServer")]
+[TestGroup("AdoNet")]
+[Timeout(300_000)] // SQL Server containers can take a long time to cold-start in CI environments.
+public sealed class SqlServerOutboxLeaseTests(
+    IServiceFixture databaseServiceFixture,
+    IServiceInitializer databaseInitializer
+) : PulseTestsBase(databaseServiceFixture, databaseInitializer)
+{
+    [Test]
+    public async Task Should_GetPendingAsync_ReclaimExpiredProcessingLease(CancellationToken cancellationToken)
+    {
+        var timeProvider = new FakeTimeProvider();
+        timeProvider.AdjustTime(TestDateTime);
+
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var mediator = services.GetRequiredService<IMediator>();
+                    await mediator.PublishAsync(new TestEvent { Id = "Test001" }, token).ConfigureAwait(false);
+
+                    var outbox = services.GetRequiredService<IOutboxRepository>();
+
+                    // Claim the message, simulating a worker that picks it up for dispatch.
+                    var claimed = await outbox.GetPendingAsync(10, token).ConfigureAwait(false);
+                    _ = await Assert.That(claimed.Count).IsEqualTo(1);
+
+                    // Simulate a crashed/cancelled worker: the message is never completed or failed,
+                    // so it stays in Processing status. Advance past the default 5-minute lease.
+                    timeProvider.Advance(TimeSpan.FromMinutes(10));
+
+                    var reclaimed = await outbox.GetPendingAsync(10, token).ConfigureAwait(false);
+
+                    _ = await Assert.That(reclaimed.Count).IsEqualTo(1);
+                    _ = await Assert.That(reclaimed[0].Id).IsEqualTo(claimed[0].Id);
+                },
+                cancellationToken,
+                configureServices: services =>
+                    services
+                        .AddSingleton<TimeProvider>(timeProvider)
+                        .Configure<OutboxProcessorOptions>(options => options.DisableProcessing = true)
+            )
+            .ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task Should_GetPendingAsync_NotReclaim_WhileProcessingLeaseActive(CancellationToken cancellationToken)
+    {
+        var timeProvider = new FakeTimeProvider();
+        timeProvider.AdjustTime(TestDateTime);
+
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var mediator = services.GetRequiredService<IMediator>();
+                    await mediator.PublishAsync(new TestEvent { Id = "Test001" }, token).ConfigureAwait(false);
+
+                    var outbox = services.GetRequiredService<IOutboxRepository>();
+
+                    var claimed = await outbox.GetPendingAsync(10, token).ConfigureAwait(false);
+                    _ = await Assert.That(claimed.Count).IsEqualTo(1);
+
+                    // The lease (default 5 minutes) has not expired yet.
+                    timeProvider.Advance(TimeSpan.FromMinutes(1));
+
+                    var reclaimed = await outbox.GetPendingAsync(10, token).ConfigureAwait(false);
+
+                    _ = await Assert.That(reclaimed).IsEmpty();
+                },
+                cancellationToken,
+                configureServices: services =>
+                    services
+                        .AddSingleton<TimeProvider>(timeProvider)
+                        .Configure<OutboxProcessorOptions>(options => options.DisableProcessing = true)
+            )
+            .ConfigureAwait(false);
+    }
+
+    private sealed class TestEvent : IEvent
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+
+        public required string Id { get; init; }
+
+        public DateTimeOffset? PublishedAt { get; set; }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/SqlServer/SqlServerOutboxRepositoryTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/SqlServer/SqlServerOutboxRepositoryTests.cs
@@ -162,4 +162,52 @@ public sealed class SqlServerOutboxRepositoryTests
                 )
             )
             .Throws<ArgumentException>();
+
+    [Test]
+    public async Task Constructor_WithZeroProcessingLeaseTimeout_ThrowsArgumentOutOfRangeException() =>
+        _ = await Assert
+            .That(() =>
+                new SqlServerOutboxRepository(
+                    Options.Create(
+                        new OutboxOptions
+                        {
+                            ConnectionString = ValidConnectionString,
+                            ProcessingLeaseTimeout = TimeSpan.Zero,
+                        }
+                    ),
+                    TimeProvider.System
+                )
+            )
+            .Throws<ArgumentOutOfRangeException>();
+
+    [Test]
+    public async Task Constructor_WithNegativeProcessingLeaseTimeout_ThrowsArgumentOutOfRangeException() =>
+        _ = await Assert
+            .That(() =>
+                new SqlServerOutboxRepository(
+                    Options.Create(
+                        new OutboxOptions
+                        {
+                            ConnectionString = ValidConnectionString,
+                            ProcessingLeaseTimeout = TimeSpan.FromMinutes(-1),
+                        }
+                    ),
+                    TimeProvider.System
+                )
+            )
+            .Throws<ArgumentOutOfRangeException>();
+
+    [Test]
+    public async Task Constructor_WithPositiveProcessingLeaseTimeout_CreatesInstance()
+    {
+        var options = new OutboxOptions
+        {
+            ConnectionString = ValidConnectionString,
+            ProcessingLeaseTimeout = TimeSpan.FromMinutes(10),
+        };
+
+        var repository = new SqlServerOutboxRepository(Options.Create(options), TimeProvider.System);
+
+        _ = await Assert.That(repository).IsNotNull();
+    }
 }


### PR DESCRIPTION
Messages flipped from Pending to Processing on claim were never selected
again after a worker crash, cancellation, or unhandled exception during
dispatch, silently losing events. Pending polls now also reclaim
Processing rows whose claim (recorded via UpdatedAt) has exceeded a
configurable lease (OutboxOptions.ProcessingLeaseTimeout, default 5
minutes). The stored procedure's new lease parameter defaults to NULL to
remain callable by 2-argument callers during a rolling deploy.