### PR TITLE
fix(postgresql): reclaim expired processing leases in outbox repository

### DIFF
--- a/src/NetEvolve.Pulse.PostgreSql/Outbox/PostgreSqlOutboxRepository.cs
+++ b/src/NetEvolve.Pulse.PostgreSql/Outbox/PostgreSqlOutboxRepository.cs
@@ -15,6 +15,10 @@ using Npgsql;
 /// or by using the connection with an active transaction.
 /// <para><strong>Concurrency:</strong></para>
 /// Uses FOR UPDATE SKIP LOCKED to prevent conflicts during concurrent polling.
+/// <para><strong>Claim Lease:</strong></para>
+/// Each pending poll also reclaims messages that remain in <see cref="OutboxMessageStatus.Processing"/>
+/// longer than <see cref="OutboxOptions.ProcessingLeaseTimeout"/> (for example, after a worker crash,
+/// cancellation, or unhandled exception during dispatch), preserving at-least-once delivery.
 /// <para><strong>Performance:</strong></para>
 /// Leverages stored functions for efficient batch operations and index utilization.
 /// </remarks>
@@ -43,6 +47,9 @@ internal sealed class PostgreSqlOutboxRepository : IOutboxRepository
 
     /// <summary>The time provider used to generate consistent timestamps for cutoff calculations.</summary>
     private readonly TimeProvider _timeProvider;
+
+    /// <summary>The maximum duration a claimed message may remain in the Processing status before it is reclaimed.</summary>
+    private readonly TimeSpan _processingLeaseTimeout;
 
     /// <summary>Cached SQL for calling the get_pending_outbox_messages function.</summary>
     private readonly string _getPendingSql;
@@ -83,16 +90,18 @@ internal sealed class PostgreSqlOutboxRepository : IOutboxRepository
         ArgumentNullException.ThrowIfNull(options);
         ArgumentException.ThrowIfNullOrWhiteSpace(options.Value.ConnectionString);
         ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(options.Value.ProcessingLeaseTimeout, TimeSpan.Zero);
 
         _connectionString = options.Value.ConnectionString;
         _timeProvider = timeProvider;
         _transactionScope = transactionScope;
+        _processingLeaseTimeout = options.Value.ProcessingLeaseTimeout;
 
         var schema = string.IsNullOrWhiteSpace(options.Value.Schema)
             ? OutboxMessageSchema.DefaultSchema
             : options.Value.Schema;
         SqlIdentifier.Validate(schema, nameof(options.Value.Schema));
-        _getPendingSql = $"SELECT * FROM \"{schema}\".get_pending_outbox_messages(@batch_size)";
+        _getPendingSql = $"SELECT * FROM \"{schema}\".get_pending_outbox_messages(@batch_size, @lease_expired_before)";
         _getFailedForRetrySql =
             $"SELECT * FROM \"{schema}\".get_failed_outbox_messages_for_retry(@max_retry_count, @batch_size, @now_utc)";
         _markCompletedSql =
@@ -166,6 +175,8 @@ internal sealed class PostgreSqlOutboxRepository : IOutboxRepository
         CancellationToken cancellationToken = default
     )
     {
+        var leaseExpiredBefore = _timeProvider.GetUtcNow() - _processingLeaseTimeout;
+
         var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
         await using (connection.ConfigureAwait(false))
         {
@@ -173,6 +184,7 @@ internal sealed class PostgreSqlOutboxRepository : IOutboxRepository
             await using (command.ConfigureAwait(false))
             {
                 _ = command.Parameters.AddWithValue("batch_size", batchSize);
+                _ = command.Parameters.AddWithValue("lease_expired_before", leaseExpiredBefore);
 
                 return await ReadMessagesAsync(command, cancellationToken).ConfigureAwait(false);
             }

--- a/src/NetEvolve.Pulse.PostgreSql/Scripts/OutboxMessage.sql
+++ b/src/NetEvolve.Pulse.PostgreSql/Scripts/OutboxMessage.sql
@@ -53,10 +53,17 @@ WHERE "Status" = 2;
 -- Stored Functions
 -- ============================================================================
 
--- get_pending_outbox_messages: Retrieves and locks pending messages for processing
--- Uses FOR UPDATE SKIP LOCKED for concurrent polling safety
+-- get_pending_outbox_messages: Retrieves and locks pending messages for processing.
+-- Also reclaims messages stuck in Processing whose lease (based on UpdatedAt) has expired,
+-- e.g. after a worker crash, cancellation, or unhandled exception during dispatch.
+-- Uses FOR UPDATE SKIP LOCKED for concurrent polling safety.
+-- The single-argument overload from earlier versions of this script is dropped first: PostgreSQL
+-- overloads functions by argument types, so CREATE OR REPLACE with an added parameter would
+-- otherwise leave both signatures behind and make a one-argument call ambiguous.
+DROP FUNCTION IF EXISTS ":schema_name".get_pending_outbox_messages(INTEGER);
 CREATE OR REPLACE FUNCTION ":schema_name".get_pending_outbox_messages(
-    batch_size INTEGER
+    batch_size INTEGER,
+    lease_expired_before TIMESTAMPTZ DEFAULT NULL
 )
 RETURNS TABLE (
     "Id"            UUID,
@@ -80,6 +87,11 @@ BEGIN
         SELECT om."Id"
         FROM ":schema_name".":table_name" om
         WHERE om."Status" = 0 -- Pending
+           OR ( -- Processing, but the claim lease has expired (stuck after a crash/cancellation)
+                om."Status" = 1
+                AND lease_expired_before IS NOT NULL
+                AND om."UpdatedAt" <= lease_expired_before
+              )
         ORDER BY om."CreatedAt"
         LIMIT batch_size
         FOR UPDATE SKIP LOCKED

--- a/tests/NetEvolve.Pulse.Tests.Integration/Outbox/PostgreSqlOutboxRepositoryLeaseTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Outbox/PostgreSqlOutboxRepositoryLeaseTests.cs
@@ -1,0 +1,271 @@
+namespace NetEvolve.Pulse.Tests.Integration.Outbox;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse;
+using NetEvolve.Pulse.Extensibility.Outbox;
+using NetEvolve.Pulse.Outbox;
+using NetEvolve.Pulse.Tests.Integration.Internals;
+using Npgsql;
+using TUnit.Core;
+
+[SuppressMessage(
+    "Security",
+    "CA2100:Review SQL queries for security vulnerabilities",
+    Justification = "The setup script is read from a checked-in .sql file with schema/table names substituted from test-generated GUID values, not external user input."
+)]
+[TestGroup("PostgreSql")]
+public sealed partial class PostgreSqlOutboxRepositoryLeaseTests
+{
+    [ClassDataSource<PostgreSqlContainerFixture>(Shared = SharedType.PerTestSession)]
+    public required PostgreSqlContainerFixture Container { get; init; }
+
+    private static readonly string _scriptPath = Path.Combine(
+        AppContext.BaseDirectory,
+        "Scripts",
+        "PostgreSql",
+        "OutboxMessage.sql"
+    );
+
+    private static OutboxMessage CreateMessage(DateTimeOffset createdAt) =>
+        new OutboxMessage
+        {
+            Id = Guid.NewGuid(),
+            EventType = typeof(LeaseTestEvent),
+            Payload = "{}",
+            CreatedAt = createdAt,
+            UpdatedAt = createdAt,
+            Status = OutboxMessageStatus.Pending,
+        };
+
+    private sealed record LeaseTestEvent;
+
+    private async Task<(PostgreSqlOutboxRepository Repository, OutboxOptions Options)> CreateRepositoryAsync(
+        TimeSpan processingLeaseTimeout,
+        CancellationToken cancellationToken
+    )
+    {
+        var databaseName = $"lease{Guid.NewGuid():N}";
+        var schema = $"lease{Guid.NewGuid():N}";
+
+        await using (var adminConnection = new NpgsqlConnection(Container.ConnectionString))
+        {
+            await adminConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
+#pragma warning disable CA2100 // DatabaseName is test-controlled, not user input
+            var createDbCommand = new NpgsqlCommand($"CREATE DATABASE \"{databaseName}\"", adminConnection);
+#pragma warning restore CA2100
+            await using (createDbCommand.ConfigureAwait(false))
+            {
+                _ = await createDbCommand.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        var builder = new NpgsqlConnectionStringBuilder(Container.ConnectionString) { Database = databaseName };
+        var connectionString = builder.ToString();
+
+        var script = await File.ReadAllTextAsync(_scriptPath, cancellationToken).ConfigureAwait(false);
+        script = SearchSetVar().Replace(script, string.Empty);
+        script = script
+            .Replace(":schema_name", schema, StringComparison.Ordinal)
+            .Replace(":table_name", "OutboxMessage", StringComparison.Ordinal);
+
+        await using (var connection = new NpgsqlConnection(connectionString))
+        {
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            var command = new NpgsqlCommand(script, connection);
+            await using (command.ConfigureAwait(false))
+            {
+                _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        var options = new OutboxOptions
+        {
+            ConnectionString = connectionString,
+            Schema = schema,
+            TableName = "OutboxMessage",
+            ProcessingLeaseTimeout = processingLeaseTimeout,
+        };
+
+        var repository = new PostgreSqlOutboxRepository(Options.Create(options), TimeProvider.System);
+
+        return (repository, options);
+    }
+
+    private static async Task SetUpdatedAtInThePastAsync(OutboxOptions options, Guid messageId, TimeSpan age)
+    {
+        await using var connection = new NpgsqlConnection(options.ConnectionString);
+        await connection.OpenAsync().ConfigureAwait(false);
+
+#pragma warning disable CA2100 // Schema/TableName are test-controlled, not user input
+        var command = new NpgsqlCommand(
+            $"""
+            UPDATE "{options.Schema}"."{options.TableName}"
+            SET "UpdatedAt" = NOW() - INTERVAL '1 second' * @age_seconds
+            WHERE "Id" = @id
+            """,
+            connection
+        );
+#pragma warning restore CA2100
+        await using (command.ConfigureAwait(false))
+        {
+            _ = command.Parameters.AddWithValue("age_seconds", age.TotalSeconds);
+            _ = command.Parameters.AddWithValue("id", messageId);
+            _ = await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+        }
+    }
+
+    [Test]
+    public async Task GetPendingAsync_WhenProcessingLeaseExpired_ReclaimsClaimedMessage(
+        CancellationToken cancellationToken
+    )
+    {
+        var (repository, options) = await CreateRepositoryAsync(TimeSpan.FromMinutes(5), cancellationToken)
+            .ConfigureAwait(false);
+
+        var message = CreateMessage(DateTimeOffset.UtcNow);
+        await repository.AddAsync(message, cancellationToken).ConfigureAwait(false);
+
+        var claimed = await repository.GetPendingAsync(10, cancellationToken).ConfigureAwait(false);
+        _ = await Assert.That(claimed).Count().IsEqualTo(1);
+
+        // Simulate a crashed worker: the message stays claimed (Processing) far beyond the lease.
+        await SetUpdatedAtInThePastAsync(options, message.Id, TimeSpan.FromMinutes(10)).ConfigureAwait(false);
+
+        var reclaimed = await repository.GetPendingAsync(10, cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(reclaimed).Count().IsEqualTo(1);
+        _ = await Assert.That(reclaimed[0].Id).IsEqualTo(message.Id);
+    }
+
+    [Test]
+    public async Task GetPendingAsync_WhileProcessingLeaseActive_DoesNotReclaimClaimedMessage(
+        CancellationToken cancellationToken
+    )
+    {
+        var (repository, options) = await CreateRepositoryAsync(TimeSpan.FromMinutes(5), cancellationToken)
+            .ConfigureAwait(false);
+
+        var message = CreateMessage(DateTimeOffset.UtcNow);
+        await repository.AddAsync(message, cancellationToken).ConfigureAwait(false);
+
+        var claimed = await repository.GetPendingAsync(10, cancellationToken).ConfigureAwait(false);
+        _ = await Assert.That(claimed).Count().IsEqualTo(1);
+
+        // Only a minute has passed - well within the 5-minute lease.
+        await SetUpdatedAtInThePastAsync(options, message.Id, TimeSpan.FromMinutes(1)).ConfigureAwait(false);
+
+        var reclaimed = await repository.GetPendingAsync(10, cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(reclaimed).IsEmpty();
+    }
+
+    [Test]
+    public async Task ScriptRedeploy_OverPreExistingSingleArgumentFunction_LeavesCallableUnambiguousFunction(
+        CancellationToken cancellationToken
+    )
+    {
+        var databaseName = $"lease{Guid.NewGuid():N}";
+        var schema = $"lease{Guid.NewGuid():N}";
+
+        await using (var adminConnection = new NpgsqlConnection(Container.ConnectionString))
+        {
+            await adminConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            var createDbCommand = new NpgsqlCommand($"CREATE DATABASE \"{databaseName}\"", adminConnection);
+            await using (createDbCommand.ConfigureAwait(false))
+            {
+                _ = await createDbCommand.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        var builder = new NpgsqlConnectionStringBuilder(Container.ConnectionString) { Database = databaseName };
+        var connectionString = builder.ToString();
+
+        await using (var connection = new NpgsqlConnection(connectionString))
+        {
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            // Simulate a database provisioned by a version of this script that predates the lease-reclaim fix:
+            // the table exists and get_pending_outbox_messages has only the single-parameter signature.
+            var setupCommand = new NpgsqlCommand(
+                $"""
+                CREATE SCHEMA "{schema}";
+                CREATE TABLE "{schema}"."OutboxMessage" (
+                    "Id"            UUID            NOT NULL,
+                    "EventType"     VARCHAR(500)    NOT NULL,
+                    "Payload"       TEXT            NOT NULL,
+                    "CorrelationId" VARCHAR(100)    NULL,
+                    "CausationId"   VARCHAR(100)    NULL,
+                    "CreatedAt"     TIMESTAMPTZ     NOT NULL,
+                    "UpdatedAt"     TIMESTAMPTZ     NOT NULL,
+                    "ProcessedAt"   TIMESTAMPTZ     NULL,
+                    "NextRetryAt"   TIMESTAMPTZ     NULL,
+                    "RetryCount"    INTEGER         NOT NULL DEFAULT 0,
+                    "Error"         TEXT            NULL,
+                    "Status"        INTEGER         NOT NULL DEFAULT 0,
+                    CONSTRAINT "PK_{schema}" PRIMARY KEY ("Id")
+                );
+                CREATE FUNCTION "{schema}".get_pending_outbox_messages(
+                    batch_size INTEGER
+                )
+                RETURNS TABLE ("Id" UUID)
+                LANGUAGE plpgsql
+                AS $body$
+                BEGIN
+                    RETURN QUERY
+                    SELECT om."Id"
+                    FROM "{schema}"."OutboxMessage" om
+                    WHERE om."Status" = 0
+                    LIMIT batch_size;
+                END;
+                $body$;
+                """,
+                connection
+            );
+            await using (setupCommand.ConfigureAwait(false))
+            {
+                _ = await setupCommand.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        // Redeploy the current (fixed) script over the pre-existing installation.
+        var script = await File.ReadAllTextAsync(_scriptPath, cancellationToken).ConfigureAwait(false);
+        script = SearchSetVar().Replace(script, string.Empty);
+        script = script
+            .Replace(":schema_name", schema, StringComparison.Ordinal)
+            .Replace(":table_name", "OutboxMessage", StringComparison.Ordinal);
+
+        await using (var connection = new NpgsqlConnection(connectionString))
+        {
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            var command = new NpgsqlCommand(script, connection);
+            await using (command.ConfigureAwait(false))
+            {
+                _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        // A one-argument call must resolve unambiguously (via the new parameter's default),
+        // instead of failing with "function ... is not unique" because two overloads exist.
+        await using (var connection = new NpgsqlConnection(connectionString))
+        {
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            var callCommand = new NpgsqlCommand(
+                $"SELECT * FROM \"{schema}\".get_pending_outbox_messages(10)",
+                connection
+            );
+            await using (callCommand.ConfigureAwait(false))
+            {
+                await using var reader = await callCommand.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                // No rows expected (table is empty); reaching this line without an exception is the assertion.
+            }
+        }
+    }
+
+    [GeneratedRegex(@"^\\set\s+\w+\s+.*$", RegexOptions.Multiline, 10000)]
+    private static partial Regex SearchSetVar();
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/PostgreSql/PostgreSqlOutboxRepositoryTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/PostgreSql/PostgreSqlOutboxRepositoryTests.cs
@@ -98,6 +98,40 @@ public sealed class PostgreSqlOutboxRepositoryTests
     }
 
     [Test]
+    public async Task Constructor_WithZeroProcessingLeaseTimeout_ThrowsArgumentOutOfRangeException() =>
+        _ = await Assert
+            .That(() =>
+                new PostgreSqlOutboxRepository(
+                    Options.Create(
+                        new OutboxOptions
+                        {
+                            ConnectionString = ValidConnectionString,
+                            ProcessingLeaseTimeout = TimeSpan.Zero,
+                        }
+                    ),
+                    TimeProvider.System
+                )
+            )
+            .Throws<ArgumentOutOfRangeException>();
+
+    [Test]
+    public async Task Constructor_WithNegativeProcessingLeaseTimeout_ThrowsArgumentOutOfRangeException() =>
+        _ = await Assert
+            .That(() =>
+                new PostgreSqlOutboxRepository(
+                    Options.Create(
+                        new OutboxOptions
+                        {
+                            ConnectionString = ValidConnectionString,
+                            ProcessingLeaseTimeout = TimeSpan.FromSeconds(-1),
+                        }
+                    ),
+                    TimeProvider.System
+                )
+            )
+            .Throws<ArgumentOutOfRangeException>();
+
+    [Test]
     public async Task Constructor_WithNullSchema_CreatesInstance()
     {
         var options = new OutboxOptions { ConnectionString = ValidConnectionString, Schema = null };


### PR DESCRIPTION
Messages flipped from Pending to Processing were never selected again after
a worker crash, cancellation, or unhandled exception during dispatch, leaving
them stuck in Processing forever. get_pending_outbox_messages now also
reclaims Processing rows whose UpdatedAt is older than a configurable lease
(OutboxOptions.ProcessingLeaseTimeout, default 5 minutes), computed in C# and
passed as a new optional parameter. The single-argument overload from earlier
script versions is dropped first so redeploying over an existing installation
does not leave an ambiguous function signature behind.