### PR TITLE
fix(mysql-outbox): reclaim expired processing leases in pending poll

### DIFF
--- a/src/NetEvolve.Pulse.MySql/Outbox/MySqlOutboxRepository.cs
+++ b/src/NetEvolve.Pulse.MySql/Outbox/MySqlOutboxRepository.cs
@@ -28,6 +28,11 @@ using NetEvolve.Pulse.Extensibility.Outbox;
 /// <c>REPEATABLE READ</c> transaction, issue a <c>SELECT … FOR UPDATE SKIP LOCKED</c> to
 /// atomically claim a batch of rows, update their status to Processing, and then commit.
 /// Concurrent workers skip locked rows and each receive a distinct batch.
+/// <para><strong>Claim Lease:</strong></para>
+/// Each claim records the claim timestamp in the <c>UpdatedAt</c> column. Rows that remain in the
+/// Processing status longer than <see cref="OutboxOptions.ProcessingLeaseTimeout"/> (for example,
+/// after a worker crash, cancellation, or unhandled exception during dispatch) are reclaimed by
+/// subsequent calls to <see cref="GetPendingAsync"/>, preserving at-least-once delivery.
 /// <para><strong>Transaction Support:</strong></para>
 /// <see cref="AddAsync"/> participates in ambient transactions via <see cref="IOutboxTransactionScope"/>
 /// when one is registered; otherwise it opens its own connection.
@@ -57,6 +62,9 @@ internal sealed class MySqlOutboxRepository : IOutboxRepository
 
     /// <summary>The time provider used to generate consistent timestamps for cutoff calculations.</summary>
     private readonly TimeProvider _timeProvider;
+
+    /// <summary>The maximum duration a claimed message may remain in the Processing status before it is reclaimed.</summary>
+    private readonly TimeSpan _processingLeaseTimeout;
 
     /// <summary>Cached backtick-quoted table name, e.g. <c>`OutboxMessage`</c>.</summary>
     // Cached SQL for simple single-row operations
@@ -89,20 +97,26 @@ internal sealed class MySqlOutboxRepository : IOutboxRepository
         ArgumentNullException.ThrowIfNull(options);
         ArgumentException.ThrowIfNullOrWhiteSpace(options.Value.ConnectionString);
         ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(options.Value.ProcessingLeaseTimeout, TimeSpan.Zero);
 
         _connectionString = options.Value.ConnectionString;
         _timeProvider = timeProvider;
         _transactionScope = transactionScope;
+        _processingLeaseTimeout = options.Value.ProcessingLeaseTimeout;
 
         var tableName = options.Value.FullTableName;
 
-        // Phase 1 of pending poll: SELECT IDs with row-level locking
+        // Phase 1 of pending poll: SELECT IDs with row-level locking.
+        // Also reclaims rows stuck in Processing whose lease (UpdatedAt) has expired — for example
+        // after a worker crash, cancellation, or unhandled exception during dispatch.
         _selectPendingIdsSql = $"""
             SELECT `{OutboxMessageSchema.Columns.Id}`
             FROM {tableName}
-            WHERE `{OutboxMessageSchema.Columns.Status}` = 0
-              AND (`{OutboxMessageSchema.Columns.NextRetryAt}` IS NULL
-                   OR `{OutboxMessageSchema.Columns.NextRetryAt}` <= @nowTicks)
+            WHERE (`{OutboxMessageSchema.Columns.Status}` = 0
+                   AND (`{OutboxMessageSchema.Columns.NextRetryAt}` IS NULL
+                        OR `{OutboxMessageSchema.Columns.NextRetryAt}` <= @nowTicks))
+               OR (`{OutboxMessageSchema.Columns.Status}` = 1
+                   AND `{OutboxMessageSchema.Columns.UpdatedAt}` <= @leaseExpiredBeforeTicks)
             ORDER BY `{OutboxMessageSchema.Columns.CreatedAt}` ASC
             LIMIT @batchSize
             FOR UPDATE SKIP LOCKED
@@ -255,11 +269,23 @@ internal sealed class MySqlOutboxRepository : IOutboxRepository
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// In addition to claiming <see cref="OutboxMessageStatus.Pending"/> messages, this also reclaims
+    /// messages stuck in <see cref="OutboxMessageStatus.Processing"/> whose claim lease
+    /// (<see cref="OutboxOptions.ProcessingLeaseTimeout"/>) has expired, so that messages are not lost
+    /// forever when a worker crashes, is cancelled, or throws an unhandled exception during dispatch.
+    /// </remarks>
     public async Task<IReadOnlyList<OutboxMessage>> GetPendingAsync(
         int batchSize,
         CancellationToken cancellationToken = default
     ) =>
-        await FetchAndClaimMessagesAsync(_selectPendingIdsSql, batchSize, null, cancellationToken)
+        await FetchAndClaimMessagesAsync(
+                _selectPendingIdsSql,
+                batchSize,
+                null,
+                _processingLeaseTimeout,
+                cancellationToken
+            )
             .ConfigureAwait(false);
 
     /// <inheritdoc />
@@ -268,7 +294,7 @@ internal sealed class MySqlOutboxRepository : IOutboxRepository
         int batchSize,
         CancellationToken cancellationToken = default
     ) =>
-        await FetchAndClaimMessagesAsync(_selectFailedForRetryIdsSql, batchSize, maxRetryCount, cancellationToken)
+        await FetchAndClaimMessagesAsync(_selectFailedForRetryIdsSql, batchSize, maxRetryCount, null, cancellationToken)
             .ConfigureAwait(false);
 
     /// <inheritdoc />
@@ -418,12 +444,18 @@ internal sealed class MySqlOutboxRepository : IOutboxRepository
     /// <param name="selectIdsSql">The SQL that selects IDs with <c>FOR UPDATE SKIP LOCKED</c>.</param>
     /// <param name="batchSize">Maximum number of messages to claim.</param>
     /// <param name="maxRetryCount">When non-null, bound passed as <c>@maxRetryCount</c> for the failed-for-retry query.</param>
+    /// <param name="processingLeaseTimeout">
+    /// When non-null, bound as <c>@leaseExpiredBeforeTicks</c> so <paramref name="selectIdsSql"/> can also
+    /// reclaim rows stuck in the Processing status whose lease has expired. Pass <see langword="null"/>
+    /// when <paramref name="selectIdsSql"/> does not reference that parameter.
+    /// </param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>The claimed and updated outbox messages.</returns>
     private async Task<IReadOnlyList<OutboxMessage>> FetchAndClaimMessagesAsync(
         string selectIdsSql,
         int batchSize,
         int? maxRetryCount,
+        TimeSpan? processingLeaseTimeout,
         CancellationToken cancellationToken
     )
     {
@@ -456,6 +488,12 @@ internal sealed class MySqlOutboxRepository : IOutboxRepository
                         if (maxRetryCount.HasValue)
                         {
                             _ = selectCmd.Parameters.AddWithValue("@maxRetryCount", maxRetryCount.Value);
+                        }
+
+                        if (processingLeaseTimeout.HasValue)
+                        {
+                            var leaseExpiredBeforeTicks = nowTicks - processingLeaseTimeout.Value.Ticks;
+                            _ = selectCmd.Parameters.AddWithValue("@leaseExpiredBeforeTicks", leaseExpiredBeforeTicks);
                         }
 
                         var reader = await selectCmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);

--- a/src/NetEvolve.Pulse.MySql/Scripts/OutboxMessage.sql
+++ b/src/NetEvolve.Pulse.MySql/Scripts/OutboxMessage.sql
@@ -20,6 +20,13 @@
 --     0 = Pending    1 = Processing    2 = Completed
 --     3 = Failed     4 = DeadLetter
 --
+-- Claim lease reclaim:
+--   Each claim sets UpdatedAt to the claim timestamp. The pending-poll query (see
+--   NetEvolve.Pulse.Outbox.MySqlOutboxRepository.GetPendingAsync) also reclaims rows still in the
+--   Processing status whose UpdatedAt is older than (now - OutboxOptions.ProcessingLeaseTimeout),
+--   so messages are not lost forever when a worker crashes, is cancelled, or throws an unhandled
+--   exception during dispatch. No additional column is required — UpdatedAt is reused.
+--
 -- Usage:
 --   Run this script in the target MySQL database once before deploying the application:
 --     mysql -u <user> -p <database> < OutboxMessage.sql
@@ -60,3 +67,7 @@ CREATE INDEX `IX_OutboxMessage_Status_NextRetryAt`
 -- Index for completed message cleanup
 CREATE INDEX `IX_OutboxMessage_Status_ProcessedAt`
     ON `OutboxMessage` (`Status`, `ProcessedAt`);
+
+-- Index for reclaiming Processing messages whose claim lease has expired
+CREATE INDEX `IX_OutboxMessage_Status_UpdatedAt`
+    ON `OutboxMessage` (`Status`, `UpdatedAt`);

--- a/src/NetEvolve.Pulse/Outbox/OutboxOptions.cs
+++ b/src/NetEvolve.Pulse/Outbox/OutboxOptions.cs
@@ -42,16 +42,17 @@ public sealed class OutboxOptions
 
     /// <summary>
     /// Gets or sets the maximum duration a claimed message may remain in the
-    /// <see cref="Extensibility.Outbox.OutboxMessageStatus.Processing"/> status before it becomes
-    /// eligible for reclaiming by a subsequent pending poll.
+    /// <see cref="NetEvolve.Pulse.Extensibility.Outbox.OutboxMessageStatus.Processing"/> status
+    /// before it becomes eligible for reclaiming by a subsequent pending poll.
     /// Default: 5 minutes.
     /// </summary>
     /// <remarks>
-    /// This setting is used by the SQLite provider. When a worker crashes or is cancelled after
-    /// claiming a message but before completing it, the message stays in the <c>Processing</c> status.
-    /// Once this lease expires, the next pending poll claims the message again, preserving
-    /// at-least-once delivery. Choose a value comfortably larger than the longest expected message
-    /// dispatch duration to avoid duplicate publishing.
+    /// When a worker crashes or is cancelled after claiming a message but before completing it,
+    /// the message stays in the <c>Processing</c> status. Once this lease expires, the next pending
+    /// poll claims the message again, preserving at-least-once delivery. Choose a value comfortably
+    /// larger than the longest expected message dispatch duration to avoid duplicate publishing.
+    /// This setting is honored by providers that implement lease-based reclaim of stuck
+    /// <c>Processing</c> messages.
     /// </remarks>
     public TimeSpan ProcessingLeaseTimeout { get; set; } = TimeSpan.FromMinutes(5);
 }

--- a/tests/NetEvolve.Pulse.Tests.Integration/Outbox/MySqlOutboxRepositoryLeaseTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Outbox/MySqlOutboxRepositoryLeaseTests.cs
@@ -1,0 +1,173 @@
+namespace NetEvolve.Pulse.Tests.Integration.Outbox;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using MySql.Data.MySqlClient;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility.Outbox;
+using NetEvolve.Pulse.Outbox;
+using NetEvolve.Pulse.Tests.Integration.Internals;
+using TUnit.Core;
+
+[TestGroup("MySql")]
+[Timeout(300_000)] // MySQL Testcontainer cold-start can take a while in CI environments.
+public sealed class MySqlOutboxRepositoryLeaseTests
+{
+    [ClassDataSource<MySqlContainerFixture>(Shared = SharedType.PerTestSession)]
+    public required MySqlContainerFixture Container { get; init; }
+
+    private sealed record LeaseTestEvent;
+
+    private static OutboxMessage CreateMessage(DateTimeOffset createdAt) =>
+        new OutboxMessage
+        {
+            Id = Guid.NewGuid(),
+            EventType = typeof(LeaseTestEvent),
+            Payload = "{}",
+            CreatedAt = createdAt,
+            UpdatedAt = createdAt,
+            Status = OutboxMessageStatus.Pending,
+        };
+
+    private async Task<(MySqlOutboxRepository Repository, FakeTimeProvider TimeProvider)> CreateRepositoryAsync(
+        CancellationToken cancellationToken
+    )
+    {
+        var databaseName = $"pulse{Guid.NewGuid():N}";
+        var tableName = $"OutboxMessage_{Guid.NewGuid():N}";
+
+        var setupConnection = new MySqlConnection(Container.ConnectionString);
+        await using (setupConnection.ConfigureAwait(false))
+        {
+            await setupConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            var createDatabaseCommand = setupConnection.CreateCommand();
+            await using (createDatabaseCommand.ConfigureAwait(false))
+            {
+#pragma warning disable CA2100, S2077 // databaseName is test-controlled, not user input
+                createDatabaseCommand.CommandText = $"CREATE DATABASE `{databaseName}`";
+#pragma warning restore CA2100, S2077
+                _ = await createDatabaseCommand.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        var connectionString = Container.ConnectionString.Replace(
+            ";Database=test;",
+            $";Database={databaseName};",
+            StringComparison.Ordinal
+        );
+
+        await CreateSchemaAsync(connectionString, tableName, cancellationToken).ConfigureAwait(false);
+
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2025, 6, 1, 12, 0, 0, TimeSpan.Zero));
+        var options = Options.Create(
+            new OutboxOptions
+            {
+                ConnectionString = connectionString,
+                TableName = tableName,
+                ProcessingLeaseTimeout = TimeSpan.FromMinutes(5),
+            }
+        );
+
+        var repository = new MySqlOutboxRepository(options, timeProvider);
+        return (repository, timeProvider);
+    }
+
+    private static async Task CreateSchemaAsync(
+        string connectionString,
+        string tableName,
+        CancellationToken cancellationToken
+    )
+    {
+        var scriptPath = System.IO.Path.Combine(AppContext.BaseDirectory, "Scripts", "MySql", "OutboxMessage.sql");
+        var script = await System.IO.File.ReadAllTextAsync(scriptPath, cancellationToken).ConfigureAwait(false);
+
+        script = script.Replace("`OutboxMessage`", $"`{tableName}`", StringComparison.Ordinal);
+
+        var connection = new MySqlConnection(connectionString);
+        await using (connection.ConfigureAwait(false))
+        {
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            foreach (
+                var statement in script.Split(
+                    ';',
+                    StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
+                )
+            )
+            {
+                if (IsCommentOrEmpty(statement))
+                {
+                    continue;
+                }
+
+#pragma warning disable CA2100, S2077 // statement originates from the checked-in provider script, not user input
+                var command = new MySqlCommand(statement, connection);
+#pragma warning restore CA2100, S2077
+                await using (command.ConfigureAwait(false))
+                {
+                    _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+    }
+
+    private static bool IsCommentOrEmpty(string statement)
+    {
+        foreach (var line in statement.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var trimmed = line.Trim();
+            if (trimmed.Length > 0 && !trimmed.StartsWith("--", StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    [Test]
+    public async Task GetPendingAsync_WhenProcessingLeaseExpired_ReclaimsClaimedMessage(
+        CancellationToken cancellationToken
+    )
+    {
+        var (repository, timeProvider) = await CreateRepositoryAsync(cancellationToken).ConfigureAwait(false);
+
+        var message = CreateMessage(timeProvider.GetUtcNow());
+        await repository.AddAsync(message, cancellationToken).ConfigureAwait(false);
+
+        var claimed = await repository.GetPendingAsync(10, cancellationToken).ConfigureAwait(false);
+        _ = await Assert.That(claimed).Count().IsEqualTo(1);
+
+        // Simulate a crashed worker: the claimed message is never completed or failed.
+        timeProvider.Advance(TimeSpan.FromMinutes(10));
+
+        var reclaimed = await repository.GetPendingAsync(10, cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(reclaimed).Count().IsEqualTo(1);
+        _ = await Assert.That(reclaimed[0].Id).IsEqualTo(message.Id);
+    }
+
+    [Test]
+    public async Task GetPendingAsync_WhileProcessingLeaseActive_DoesNotReclaimClaimedMessage(
+        CancellationToken cancellationToken
+    )
+    {
+        var (repository, timeProvider) = await CreateRepositoryAsync(cancellationToken).ConfigureAwait(false);
+
+        var message = CreateMessage(timeProvider.GetUtcNow());
+        await repository.AddAsync(message, cancellationToken).ConfigureAwait(false);
+
+        var claimed = await repository.GetPendingAsync(10, cancellationToken).ConfigureAwait(false);
+        _ = await Assert.That(claimed).Count().IsEqualTo(1);
+
+        timeProvider.Advance(TimeSpan.FromMinutes(1));
+
+        var reclaimed = await repository.GetPendingAsync(10, cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(reclaimed).IsEmpty();
+    }
+}


### PR DESCRIPTION
Messages flipped from Pending to Processing on claim were never selected
again after a worker crash, cancellation, or unhandled exception during
dispatch, silently losing events. GetPendingAsync now also reclaims rows
stuck in Processing whose UpdatedAt is older than a configurable
ProcessingLeaseTimeout (default 5 minutes, added to OutboxOptions), in
addition to the existing Pending claim logic. No schema change is
required; UpdatedAt is already set on claim. The checked-in provider
script gains a supporting Status/UpdatedAt index and documents the
reclaim behavior.