### PR TITLE
fix(sqlite): reclaim expired processing leases in outbox repository

### DIFF
--- a/src/NetEvolve.Pulse.SQLite/Outbox/SQLiteOutboxRepository.cs
+++ b/src/NetEvolve.Pulse.SQLite/Outbox/SQLiteOutboxRepository.cs
@@ -22,6 +22,11 @@ using NetEvolve.Pulse.Extensibility.Outbox;
 /// When <see cref="OutboxOptions.EnableWalMode"/> is <see langword="true"/>, the
 /// <c>PRAGMA journal_mode=WAL</c> command is applied on each connection to allow concurrent
 /// read access during writes.
+/// <para><strong>Claim Lease:</strong></para>
+/// Each claim records the claim timestamp in <c>UpdatedAt</c>. Messages that remain in the
+/// <c>Processing</c> status longer than <see cref="OutboxOptions.ProcessingLeaseTimeout"/> (for
+/// example, after a worker crash, cancellation, or unhandled exception during dispatch) are
+/// reclaimed by subsequent pending polls, preserving at-least-once delivery.
 /// </remarks>
 [SuppressMessage(
     "Reliability",
@@ -52,6 +57,9 @@ internal sealed class SQLiteOutboxRepository : IOutboxRepository
     /// <summary>The time provider used to generate consistent timestamps.</summary>
     private readonly TimeProvider _timeProvider;
 
+    /// <summary>The maximum duration a claimed message may remain in the Processing status before it is reclaimed.</summary>
+    private readonly TimeSpan _processingLeaseTimeout;
+
     // Cached SQL statements
     private readonly string _getPendingSql;
     private readonly string _getFailedForRetrySql;
@@ -80,11 +88,13 @@ internal sealed class SQLiteOutboxRepository : IOutboxRepository
 
         var opts = options.Value;
         ArgumentException.ThrowIfNullOrWhiteSpace(opts.ConnectionString);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(opts.ProcessingLeaseTimeout, TimeSpan.Zero);
 
         _connectionString = opts.ConnectionString;
         _enableWalMode = opts.EnableWalMode;
         _timeProvider = timeProvider;
         _transactionScope = transactionScope;
+        _processingLeaseTimeout = opts.ProcessingLeaseTimeout;
 
         var table = opts.FullTableName;
 
@@ -95,9 +105,15 @@ internal sealed class SQLiteOutboxRepository : IOutboxRepository
             WHERE "{OutboxMessageSchema.Columns.Id}" IN (
                 SELECT "{OutboxMessageSchema.Columns.Id}"
                 FROM {table}
-                WHERE "{OutboxMessageSchema.Columns.Status}" = 0
-                  AND ("{OutboxMessageSchema.Columns.NextRetryAt}" IS NULL
-                       OR "{OutboxMessageSchema.Columns.NextRetryAt}" <= @nowUtc)
+                WHERE (
+                    "{OutboxMessageSchema.Columns.Status}" = 0
+                    AND ("{OutboxMessageSchema.Columns.NextRetryAt}" IS NULL
+                         OR "{OutboxMessageSchema.Columns.NextRetryAt}" <= @nowUtc)
+                  )
+                  OR (
+                    "{OutboxMessageSchema.Columns.Status}" = 1
+                    AND "{OutboxMessageSchema.Columns.UpdatedAt}" <= @leaseExpiredBeforeUtc
+                  )
                 ORDER BY "{OutboxMessageSchema.Columns.CreatedAt}"
                 LIMIT @batchSize
             )
@@ -255,6 +271,7 @@ internal sealed class SQLiteOutboxRepository : IOutboxRepository
     )
     {
         var now = _timeProvider.GetUtcNow();
+        var leaseExpiredBefore = now.ToUniversalTime() - _processingLeaseTimeout;
 
         var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
         await using (connection.ConfigureAwait(false))
@@ -275,6 +292,7 @@ internal sealed class SQLiteOutboxRepository : IOutboxRepository
                     {
                         _ = command.Parameters.AddWithValue("@batchSize", batchSize);
                         _ = command.Parameters.AddWithValue("@nowUtc", now);
+                        _ = command.Parameters.AddWithValue("@leaseExpiredBeforeUtc", leaseExpiredBefore);
 
                         var messages = await ReadMessagesAsync(command, cancellationToken).ConfigureAwait(false);
 

--- a/src/NetEvolve.Pulse/Outbox/OutboxOptions.cs
+++ b/src/NetEvolve.Pulse/Outbox/OutboxOptions.cs
@@ -39,4 +39,19 @@ public sealed class OutboxOptions
     /// Default: <see langword="true"/>.
     /// </remarks>
     public bool EnableWalMode { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the maximum duration a claimed message may remain in the
+    /// <see cref="Extensibility.Outbox.OutboxMessageStatus.Processing"/> status before it becomes
+    /// eligible for reclaiming by a subsequent pending poll.
+    /// Default: 5 minutes.
+    /// </summary>
+    /// <remarks>
+    /// This setting is used by the SQLite provider. When a worker crashes or is cancelled after
+    /// claiming a message but before completing it, the message stays in the <c>Processing</c> status.
+    /// Once this lease expires, the next pending poll claims the message again, preserving
+    /// at-least-once delivery. Choose a value comfortably larger than the longest expected message
+    /// dispatch duration to avoid duplicate publishing.
+    /// </remarks>
+    public TimeSpan ProcessingLeaseTimeout { get; set; } = TimeSpan.FromMinutes(5);
 }

--- a/tests/NetEvolve.Pulse.Tests.Unit/SQLite/SQLiteOutboxRepositoryDatabaseTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/SQLite/SQLiteOutboxRepositoryDatabaseTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.Pulse.Extensibility;
 using NetEvolve.Pulse.Extensibility.Outbox;
@@ -61,6 +62,19 @@ public sealed class SQLiteOutboxRepositoryDatabaseTests : IAsyncDisposable
     {
         var options = Options.Create(new OutboxOptions { ConnectionString = _connectionString, EnableWalMode = false });
         return new SQLiteOutboxRepository(options, TimeProvider.System);
+    }
+
+    private SQLiteOutboxRepository CreateRepository(TimeProvider timeProvider, TimeSpan? processingLeaseTimeout = null)
+    {
+        var options = Options.Create(
+            new OutboxOptions
+            {
+                ConnectionString = _connectionString,
+                EnableWalMode = false,
+                ProcessingLeaseTimeout = processingLeaseTimeout ?? TimeSpan.FromMinutes(5),
+            }
+        );
+        return new SQLiteOutboxRepository(options, timeProvider);
     }
 
     private SQLiteOutboxRepository CreateRepositoryWithScope(IOutboxTransactionScope scope)
@@ -126,6 +140,52 @@ public sealed class SQLiteOutboxRepositoryDatabaseTests : IAsyncDisposable
         var pending = await repository.GetPendingAsync(10, cancellationToken).ConfigureAwait(false);
 
         _ = await Assert.That(pending.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task GetPendingAsync_WhenProcessingLeaseExpired_ReclaimsStuckMessage(
+        CancellationToken cancellationToken
+    )
+    {
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2025, 6, 1, 12, 0, 0, TimeSpan.Zero));
+        var repository = CreateRepository(timeProvider, TimeSpan.FromMinutes(5));
+        var message = CreateMessage();
+        await repository.AddAsync(message, cancellationToken).ConfigureAwait(false);
+
+        var claimed = await repository.GetPendingAsync(10, cancellationToken).ConfigureAwait(false);
+        _ = await Assert.That(claimed.Count).IsEqualTo(1);
+
+        // Simulate a crashed worker: the message stays in Processing and is never completed or failed.
+        timeProvider.Advance(TimeSpan.FromMinutes(10));
+
+        var reclaimed = await repository.GetPendingAsync(10, cancellationToken).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(reclaimed.Count).IsEqualTo(1);
+            _ = await Assert.That(reclaimed[0].Id).IsEqualTo(message.Id);
+            _ = await Assert.That(reclaimed[0].Status).IsEqualTo(OutboxMessageStatus.Processing);
+        }
+    }
+
+    [Test]
+    public async Task GetPendingAsync_WhileProcessingLeaseActive_DoesNotReclaimMessage(
+        CancellationToken cancellationToken
+    )
+    {
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2025, 6, 1, 12, 0, 0, TimeSpan.Zero));
+        var repository = CreateRepository(timeProvider, TimeSpan.FromMinutes(5));
+        var message = CreateMessage();
+        await repository.AddAsync(message, cancellationToken).ConfigureAwait(false);
+
+        var claimed = await repository.GetPendingAsync(10, cancellationToken).ConfigureAwait(false);
+        _ = await Assert.That(claimed.Count).IsEqualTo(1);
+
+        timeProvider.Advance(TimeSpan.FromMinutes(1));
+
+        var reclaimed = await repository.GetPendingAsync(10, cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(reclaimed).IsEmpty();
     }
 
     [Test]


### PR DESCRIPTION
Messages flipped from Pending to Processing were never selected again after
a worker crash, cancellation, or unhandled exception during dispatch, silently
losing events. The pending-claim query now also reclaims Processing rows whose
UpdatedAt lease (OutboxOptions.ProcessingLeaseTimeout, default 5 minutes) has
expired, in addition to the existing Pending claim semantics.