### PR TITLE
perf(cosmosdb): parallelize cross-partition management queries

### DIFF
--- a/src/NetEvolve.Pulse.CosmosDb/Outbox/CosmosDbOutboxManagement.cs
+++ b/src/NetEvolve.Pulse.CosmosDb/Outbox/CosmosDbOutboxManagement.cs
@@ -22,6 +22,14 @@ using NetEvolve.Pulse.Extensibility.Outbox;
 )]
 internal sealed class CosmosDbOutboxManagement : IOutboxManagement
 {
+    /// <summary>
+    /// Shared <see cref="QueryRequestOptions"/> for the cross-partition management and dashboard
+    /// queries in this class. With the default partition key path <c>/id</c> these queries cannot
+    /// target a single partition and fan out to every physical partition; enabling maximum
+    /// parallelism keeps latency from scaling linearly with the partition count.
+    /// </summary>
+    private static readonly QueryRequestOptions ParallelQueryOptions = new() { MaxConcurrency = -1 };
+
     private readonly Container _container;
     private readonly TimeProvider _timeProvider;
 
@@ -95,7 +103,7 @@ internal sealed class CosmosDbOutboxManagement : IOutboxManagement
     {
         var query = new QueryDefinition("SELECT VALUE COUNT(1) FROM c WHERE c.status = 4");
 
-        using var iterator = _container.GetItemQueryIterator<long>(query);
+        using var iterator = _container.GetItemQueryIterator<long>(query, requestOptions: ParallelQueryOptions);
 
         var count = 0L;
 
@@ -155,7 +163,10 @@ internal sealed class CosmosDbOutboxManagement : IOutboxManagement
         var query = new QueryDefinition("SELECT * FROM c WHERE c.status = 4");
         var replayed = 0;
 
-        using var iterator = _container.GetItemQueryIterator<CosmosDbOutboxDocument>(query);
+        using var iterator = _container.GetItemQueryIterator<CosmosDbOutboxDocument>(
+            query,
+            requestOptions: ParallelQueryOptions
+        );
 
         while (iterator.HasMoreResults)
         {
@@ -221,7 +232,7 @@ internal sealed class CosmosDbOutboxManagement : IOutboxManagement
 
         var counts = new Dictionary<int, long>();
 
-        using var iterator = _container.GetItemQueryIterator<StatusCount>(query);
+        using var iterator = _container.GetItemQueryIterator<StatusCount>(query, requestOptions: ParallelQueryOptions);
 
         while (iterator.HasMoreResults)
         {
@@ -253,7 +264,10 @@ internal sealed class CosmosDbOutboxManagement : IOutboxManagement
     {
         var messages = new List<OutboxMessage>();
 
-        using var iterator = _container.GetItemQueryIterator<CosmosDbOutboxDocument>(query);
+        using var iterator = _container.GetItemQueryIterator<CosmosDbOutboxDocument>(
+            query,
+            requestOptions: ParallelQueryOptions
+        );
 
         while (iterator.HasMoreResults)
         {

--- a/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxManagementQueryOptionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxManagementQueryOptionsTests.cs
@@ -1,0 +1,115 @@
+namespace NetEvolve.Pulse.Tests.Unit.CosmosDb;
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("CosmosDb")]
+public sealed class CosmosDbOutboxManagementQueryOptionsTests
+{
+    [Test]
+    public async Task GetDeadLetterCountAsync_PassesParallelQueryRequestOptions(CancellationToken cancellationToken)
+    {
+        var container = new FakeCosmosContainer
+        {
+            OnQueryIterator = (_, _, _) =>
+                new FakeFeedIterator<long>([
+                    [0L],
+                ]),
+        };
+
+        var management = CreateManagement(container);
+
+        _ = await management.GetDeadLetterCountAsync(cancellationToken).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(container.CapturedQueryRequestOptions.Count).IsEqualTo(1);
+            _ = await Assert.That(container.CapturedQueryRequestOptions[0]?.MaxConcurrency).IsEqualTo(-1);
+        }
+    }
+
+    [Test]
+    public async Task GetStatisticsAsync_PassesParallelQueryRequestOptions(CancellationToken cancellationToken)
+    {
+        var container = new FakeCosmosContainer { OnQueryIterator = (itemType, _, _) => CreateEmptyIterator(itemType) };
+
+        var management = CreateManagement(container);
+
+        _ = await management.GetStatisticsAsync(cancellationToken).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(container.CapturedQueryRequestOptions.Count).IsEqualTo(1);
+            _ = await Assert.That(container.CapturedQueryRequestOptions[0]?.MaxConcurrency).IsEqualTo(-1);
+        }
+    }
+
+    [Test]
+    public async Task ReplayAllDeadLetterAsync_PassesParallelQueryRequestOptions(CancellationToken cancellationToken)
+    {
+        var container = new FakeCosmosContainer
+        {
+            OnQueryIterator = (_, _, _) => new FakeFeedIterator<CosmosDbOutboxDocument>([]),
+        };
+
+        var management = CreateManagement(container);
+
+        _ = await management.ReplayAllDeadLetterAsync(cancellationToken).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(container.CapturedQueryRequestOptions.Count).IsEqualTo(1);
+            _ = await Assert.That(container.CapturedQueryRequestOptions[0]?.MaxConcurrency).IsEqualTo(-1);
+        }
+    }
+
+    [Test]
+    public async Task GetDeadLetterMessagesAsync_PassesParallelQueryRequestOptions(CancellationToken cancellationToken)
+    {
+        var container = new FakeCosmosContainer
+        {
+            OnQueryIterator = (_, _, _) => new FakeFeedIterator<CosmosDbOutboxDocument>([]),
+        };
+
+        var management = CreateManagement(container);
+
+        _ = await management.GetDeadLetterMessagesAsync(50, 0, cancellationToken).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(container.CapturedQueryRequestOptions.Count).IsEqualTo(1);
+            _ = await Assert.That(container.CapturedQueryRequestOptions[0]?.MaxConcurrency).IsEqualTo(-1);
+        }
+    }
+
+    /// <summary>
+    /// Creates an empty <see cref="FakeFeedIterator{T}"/> for the requested item type via reflection,
+    /// since some management queries use a private projection type that is inaccessible here.
+    /// </summary>
+    private static object CreateEmptyIterator(Type itemType)
+    {
+        var pageType = typeof(IReadOnlyList<>).MakeGenericType(itemType);
+        var pagesListType = typeof(List<>).MakeGenericType(pageType);
+        var pages = Activator.CreateInstance(pagesListType);
+        var iteratorType = typeof(FakeFeedIterator<>).MakeGenericType(itemType);
+
+        return Activator.CreateInstance(iteratorType, pages)!;
+    }
+
+    private static CosmosDbOutboxManagement CreateManagement(FakeCosmosContainer container)
+    {
+        using var client = new FakeCosmosClient(container);
+
+        return new CosmosDbOutboxManagement(
+            client,
+            Options.Create(new CosmosDbOutboxOptions { DatabaseName = "TestDb" }),
+            TimeProvider.System
+        );
+    }
+}


### PR DESCRIPTION
## Problem

`CosmosDbOutboxManagement` runs several queries that filter on `c.status` without a partition key. Because the container's default partition key path is `/id`, every document forms its own logical partition, so these queries fan out to every physical partition. `CosmosDbOutboxRepository` already issues its equivalent cross-partition queries with `QueryRequestOptions { MaxConcurrency = -1 }` to run that fan-out in parallel, but `CosmosDbOutboxManagement` created its iterators with no `QueryRequestOptions` at all. The Cosmos SDK default for `MaxConcurrency` is `0` (serial), so `GetDeadLetterCountAsync`, `ReplayAllDeadLetterAsync`, `GetStatisticsAsync`, and the dead-letter listing query (`ExecuteQueryAsync`, used by `GetDeadLetterMessagesAsync`) queried physical partitions one at a time. Latency for these management/dashboard queries scales linearly with partition count, and `GetStatisticsAsync` is polled repeatedly, making the cost recurring.

## Fix

Added a shared `private static readonly QueryRequestOptions ParallelQueryOptions = new() { MaxConcurrency = -1 };` field to `CosmosDbOutboxManagement` and passed it to all four `GetItemQueryIterator<T>` call sites, mirroring the pattern already used in `CosmosDbOutboxRepository`. No query text or other behavior changed.

## Testing

- Added `CosmosDbOutboxManagementQueryOptionsTests` (TUnit, using the existing `FakeCosmosContainer`/`FakeCosmosClient` test doubles) covering `GetDeadLetterCountAsync`, `GetStatisticsAsync`, `ReplayAllDeadLetterAsync`, and `GetDeadLetterMessagesAsync`, asserting the captured `QueryRequestOptions.MaxConcurrency == -1`.
- Confirmed RED against the unmodified code: 12 failures (4 tests x 3 target frameworks), each `Expected to be equal to -1` because the captured options were `null`.
- After the fix: `dotnet build Pulse.slnx -c Release` succeeds with 0 errors; `dotnet test tests/NetEvolve.Pulse.Tests.Unit/NetEvolve.Pulse.Tests.Unit.csproj -c Release` passes for all three target frameworks (net8.0, net9.0, net10.0), 4290 total tests, 0 failed.
- Integration tests were not run (require Docker).