### PR TITLE
perf(aspnetcore): stream ndjson items without per-item byte array

### DIFF
--- a/src/NetEvolve.Pulse.AspNetCore/EndpointRouteBuilderExtensions.cs
+++ b/src/NetEvolve.Pulse.AspNetCore/EndpointRouteBuilderExtensions.cs
@@ -21,6 +21,11 @@ public static class EndpointRouteBuilderExtensions
 
     private static readonly byte[] NdjsonNewLine = [(byte)'\n'];
 
+#if !NET10_0_OR_GREATER
+    private static readonly byte[] SseDataPrefix = Encoding.UTF8.GetBytes("data: ");
+    private static readonly byte[] SseSuffix = Encoding.UTF8.GetBytes("\n\n");
+#endif
+
     /// <summary>
     /// Maps a command to an HTTP endpoint. The command is bound from the request body,
     /// dispatched via <see cref="IMediatorSendOnly.SendAsync{TCommand, TResponse}"/>, and the result
@@ -238,8 +243,11 @@ public static class EndpointRouteBuilderExtensions
             {
                 await foreach (var item in items.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var line = Encoding.UTF8.GetBytes($"data: {JsonSerializer.Serialize(item)}\n\n");
-                    await outputStream.WriteAsync(line, cancellationToken).ConfigureAwait(false);
+                    await outputStream.WriteAsync(SseDataPrefix, cancellationToken).ConfigureAwait(false);
+                    await JsonSerializer
+                        .SerializeAsync(outputStream, item, cancellationToken: cancellationToken)
+                        .ConfigureAwait(false);
+                    await outputStream.WriteAsync(SseSuffix, cancellationToken).ConfigureAwait(false);
                     await outputStream.FlushAsync(cancellationToken).ConfigureAwait(false);
                 }
             }
@@ -260,8 +268,9 @@ public static class EndpointRouteBuilderExtensions
             {
                 await foreach (var item in items.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var json = JsonSerializer.SerializeToUtf8Bytes(item);
-                    await outputStream.WriteAsync(json, cancellationToken).ConfigureAwait(false);
+                    await JsonSerializer
+                        .SerializeAsync(outputStream, item, cancellationToken: cancellationToken)
+                        .ConfigureAwait(false);
                     await outputStream.WriteAsync(NdjsonNewLine, cancellationToken).ConfigureAwait(false);
                     await outputStream.FlushAsync(cancellationToken).ConfigureAwait(false);
                 }


### PR DESCRIPTION
## Problem
`MapStreamQuery`'s streaming writers allocated an intermediate buffer per streamed item before writing it to the response body:
- The NDJSON writer called `JsonSerializer.SerializeToUtf8Bytes(item)`, allocating a new `byte[]` for every item before writing it and the newline delimiter.
- The legacy (`!NET10_0_OR_GREATER`) SSE fallback built a `data: {json}\n\n` string via string interpolation, then converted it to UTF-8 bytes with `Encoding.UTF8.GetBytes`, allocating both a string and a byte array per item.

For high-throughput streaming endpoints, this adds avoidable per-item allocation and GC pressure.

## Fix
Serialize directly to the response stream instead of through an intermediate buffer:
- NDJSON: `JsonSerializer.SerializeAsync(outputStream, item, cancellationToken: cancellationToken)` followed by the existing static newline write.
- Legacy SSE fallback: write the static `data: ` prefix bytes, `SerializeAsync` the item directly to the stream, then write the static `\n\n` suffix bytes.

Both changes preserve behavior exactly: same content type, same per-item JSON encoding (default `JsonSerializerOptions`), same delimiters, same cancellation-token flow, and the same flush-per-item behavior. Response bytes are unchanged.

## Testing
- `dotnet build Pulse.slnx -c Release` — 0 errors.
- `dotnet test tests/NetEvolve.Pulse.Tests.Unit/NetEvolve.Pulse.Tests.Unit.csproj -c Release` — all TFMs (net8.0, net9.0, net10.0) green: 4278/4278 passed, 0 failed.
- Existing `EndpointRouteBuilderExtensionsTests` in `tests/NetEvolve.Pulse.Tests.Unit/AspNetCore/EndpointRouteBuilderExtensionsTests.cs` already assert byte/line-exact NDJSON and SSE bodies via `WebApplicationFactory`-style `TestServer` hosts (e.g. `MapStreamQuery_WithMultipleItems_WritesExactlyOneNewlinePerItem`, `MapStreamQuery_WithItems_WritesSSEFormatByDefault`), guarding response-byte identity before and after this change.