### PR TITLE
perf(mediator): add single-handler fast path to event dispatchers

### DIFF
--- a/src/NetEvolve.Pulse/Dispatchers/ParallelEventDispatcher.cs
+++ b/src/NetEvolve.Pulse/Dispatchers/ParallelEventDispatcher.cs
@@ -57,6 +57,24 @@ public sealed class ParallelEventDispatcher : IEventDispatcher
         ArgumentNullException.ThrowIfNull(handlers);
         ArgumentNullException.ThrowIfNull(invoker);
 
+        if (handlers is ICollection<IEventHandler<TEvent>> { Count: 1 } singleHandlerCollection)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var handler = singleHandlerCollection.First();
+
+            try
+            {
+                await invoker(handler, message, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
+            {
+                throw new AggregateException("One or more event handlers failed.", ex);
+            }
+
+            return;
+        }
+
         var exceptions = new ConcurrentBag<Exception>();
 
         await Parallel

--- a/src/NetEvolve.Pulse/Dispatchers/PrioritizedEventDispatcher.cs
+++ b/src/NetEvolve.Pulse/Dispatchers/PrioritizedEventDispatcher.cs
@@ -76,6 +76,24 @@ public sealed class PrioritizedEventDispatcher : IEventDispatcher
         ArgumentNullException.ThrowIfNull(handlers);
         ArgumentNullException.ThrowIfNull(invoker);
 
+        if (handlers is ICollection<IEventHandler<TEvent>> { Count: 1 } singleHandlerCollection)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var handler = singleHandlerCollection.First();
+
+            try
+            {
+                await invoker(handler, message, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                throw new AggregateException("One or more event handlers failed.", ex);
+            }
+
+            return;
+        }
+
         // Sort handlers by priority, preserving order for equal priorities
         var priorityGroups = handlers
             .Select(handler => (Handler: handler, Priority: GetPriority(handler)))

--- a/src/NetEvolve.Pulse/Dispatchers/RateLimitedEventDispatcher.cs
+++ b/src/NetEvolve.Pulse/Dispatchers/RateLimitedEventDispatcher.cs
@@ -97,6 +97,24 @@ public sealed class RateLimitedEventDispatcher : IEventDispatcher
         ArgumentNullException.ThrowIfNull(handlers);
         ArgumentNullException.ThrowIfNull(invoker);
 
+        if (handlers is ICollection<IEventHandler<TEvent>> { Count: 1 } singleHandlerCollection)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var handler = singleHandlerCollection.First();
+
+            try
+            {
+                await invoker(handler, message, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
+            {
+                throw new AggregateException("One or more event handlers failed.", ex);
+            }
+
+            return;
+        }
+
         var exceptions = new ConcurrentBag<Exception>();
         var options = new ParallelOptions
         {

--- a/tests/NetEvolve.Pulse.Tests.Unit/Dispatchers/PrioritizedEventDispatcherTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Dispatchers/PrioritizedEventDispatcherTests.cs
@@ -127,6 +127,41 @@ public class PrioritizedEventDispatcherTests
     }
 
     [Test]
+    public async Task DispatchAsync_WithSingleHandler_InvokesHandlerExactlyOnce(CancellationToken cancellationToken)
+    {
+        var dispatcher = new PrioritizedEventDispatcher();
+        var message = new TestEvent();
+        var executionOrder = new ConcurrentQueue<int>();
+        var handlers = new List<IEventHandler<TestEvent>> { new PrioritizedTestHandler(1, 0, executionOrder) };
+
+        await dispatcher
+            .DispatchAsync(message, handlers, (handler, msg, ct) => handler.HandleAsync(msg, ct), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(executionOrder).HasSingleItem();
+    }
+
+    [Test]
+    public async Task DispatchAsync_WithSingleHandlerThrowing_AggregatesException(CancellationToken cancellationToken)
+    {
+        var dispatcher = new PrioritizedEventDispatcher();
+        var message = new TestEvent();
+        var handlers = new List<IEventHandler<TestEvent>> { new ThrowingSingleHandler() };
+
+        var ex = await Assert.ThrowsAsync<AggregateException>(async () =>
+            await dispatcher
+                .DispatchAsync(message, handlers, (handler, msg, ct) => handler.HandleAsync(msg, ct), cancellationToken)
+                .ConfigureAwait(false)
+        );
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(ex!.InnerExceptions).Count().IsEqualTo(1);
+            _ = await Assert.That(ex.InnerExceptions[0]).IsTypeOf<InvalidOperationException>();
+        }
+    }
+
+    [Test]
     public async Task DispatchAsync_WithEmptyHandlers_CompletesSuccessfully(CancellationToken cancellationToken)
     {
         var dispatcher = new PrioritizedEventDispatcher();
@@ -183,6 +218,12 @@ public class PrioritizedEventDispatcherTests
             _executionOrder.Enqueue(_id);
             return Task.CompletedTask;
         }
+    }
+
+    private sealed class ThrowingSingleHandler : IEventHandler<TestEvent>
+    {
+        public Task HandleAsync(TestEvent message, CancellationToken cancellationToken = default) =>
+            throw new InvalidOperationException("boom");
     }
 
     private sealed class CancellingTestHandler : IPrioritizedEventHandler<TestEvent>

--- a/tests/NetEvolve.Pulse.Tests.Unit/Dispatchers/RateLimitedEventDispatcherTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Dispatchers/RateLimitedEventDispatcherTests.cs
@@ -64,6 +64,41 @@ public class RateLimitedEventDispatcherTests
     }
 
     [Test]
+    public async Task DispatchAsync_WithSingleHandler_InvokesHandlerExactlyOnce(CancellationToken cancellationToken)
+    {
+        var dispatcher = new RateLimitedEventDispatcher(maxConcurrency: 2);
+        var message = new TestEvent();
+        var invokedHandlers = new ConcurrentBag<int>();
+        var handlers = new List<IEventHandler<TestEvent>> { new TestEventHandler(1, invokedHandlers) };
+
+        await dispatcher
+            .DispatchAsync(message, handlers, (handler, msg, ct) => handler.HandleAsync(msg, ct), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(invokedHandlers).HasSingleItem();
+    }
+
+    [Test]
+    public async Task DispatchAsync_WithSingleHandlerThrowing_AggregatesException(CancellationToken cancellationToken)
+    {
+        var dispatcher = new RateLimitedEventDispatcher(maxConcurrency: 2);
+        var message = new TestEvent();
+        var handlers = new List<IEventHandler<TestEvent>> { new ThrowingTestEventHandler() };
+
+        var ex = await Assert.ThrowsAsync<AggregateException>(async () =>
+            await dispatcher
+                .DispatchAsync(message, handlers, (handler, msg, ct) => handler.HandleAsync(msg, ct), cancellationToken)
+                .ConfigureAwait(false)
+        );
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(ex!.InnerExceptions).Count().IsEqualTo(1);
+            _ = await Assert.That(ex.InnerExceptions[0]).IsTypeOf<InvalidOperationException>();
+        }
+    }
+
+    [Test]
     public async Task DispatchAsync_LimitsConcurrency(CancellationToken cancellationToken)
     {
         var dispatcher = new RateLimitedEventDispatcher(maxConcurrency: 2);
@@ -133,6 +168,12 @@ public class RateLimitedEventDispatcherTests
             _invokedHandlers.Add(_id);
             return Task.CompletedTask;
         }
+    }
+
+    private sealed class ThrowingTestEventHandler : IEventHandler<TestEvent>
+    {
+        public Task HandleAsync(TestEvent message, CancellationToken cancellationToken = default) =>
+            throw new InvalidOperationException("boom");
     }
 
     private sealed class ConcurrencyTrackingHandler : IEventHandler<TestEvent>


### PR DESCRIPTION
## Problem
`ParallelEventDispatcher`, `RateLimitedEventDispatcher`, and `PrioritizedEventDispatcher` always allocated parallel-execution machinery (`ConcurrentBag<Exception>`, `Parallel.ForEachAsync`, `ParallelOptions`) even for the common case of a single registered handler. `PrioritizedEventDispatcher` additionally ran `Select` + `GroupBy` + `OrderBy` LINQ on every dispatch regardless of handler count.

## Fix
Added a fast path in each dispatcher: when the handlers collection is an `ICollection<T>` with exactly one element, the single handler's invoker is awaited directly, skipping the parallel machinery (and, for `PrioritizedEventDispatcher`, the grouping/sorting). Non-`ICollection<T>` enumerables and collections with zero or multiple handlers fall through unchanged to the existing multi-handler path.

Exception aggregation, cancellation behavior, and handler ordering are preserved exactly:
- `ParallelEventDispatcher` / `RateLimitedEventDispatcher`: a failure is wrapped in an `AggregateException` unless the token was already cancelled, matching the existing `catch (Exception ex) when (!token.IsCancellationRequested)` filter.
- `PrioritizedEventDispatcher`: any failure (including cancellation-related) is wrapped in an `AggregateException`, matching the existing unconditional `catch` in the multi-handler path.
- A pre-cancelled token throws `OperationCanceledException` before the handler is invoked, matching current behavior.

## Testing
- Added single-handler invocation and exception-aggregation tests for `RateLimitedEventDispatcher` and `PrioritizedEventDispatcher` (mirroring the existing coverage already present for `ParallelEventDispatcher`).
- `dotnet build Pulse.slnx -c Release` — 0 errors.
- `dotnet test tests/NetEvolve.Pulse.Tests.Unit` — 1430/1430 passing on net8.0, net9.0, and net10.0.