### PR TITLE
fix(outbox): resolve outbox repository per cycle to avoid captive DbContext

### DIFF
--- a/src/NetEvolve.Pulse/Outbox/OutboxProcessorHostedService.cs
+++ b/src/NetEvolve.Pulse/Outbox/OutboxProcessorHostedService.cs
@@ -2,6 +2,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -64,8 +65,18 @@ internal sealed partial class OutboxProcessorHostedService : BackgroundService
     );
 #pragma warning restore IDE1006
 
-    /// <summary>The repository for reading and updating outbox message state.</summary>
-    private readonly IOutboxRepository _repository;
+    /// <summary>
+    /// Creates the per-cycle and per-work-item scopes used to resolve the scoped
+    /// <see cref="IOutboxRepository"/>. The processor is registered as a singleton hosted service,
+    /// while <see cref="IOutboxRepository"/> implementations are registered as scoped (they typically
+    /// wrap a <c>DbContext</c>). Resolving the repository directly
+    /// in the constructor would create a captive dependency: a single scoped instance (and its
+    /// DbContext) held for the entire process lifetime, causing unbounded change-tracker growth and
+    /// failing DI validation when <c>ValidateScopes</c>/<c>ValidateOnBuild</c> are enabled. Instead, a
+    /// fresh <see cref="IServiceScope"/> is created per polling cycle (and per parallel work item
+    /// during batch fan-out) and disposed once that unit of work completes.
+    /// </summary>
+    private readonly IServiceScopeFactory _scopeFactory;
 
     /// <summary>The transport used to deliver outbox messages to their destination.</summary>
     private readonly IMessageTransport _transport;
@@ -92,26 +103,26 @@ internal sealed partial class OutboxProcessorHostedService : BackgroundService
     /// <summary>
     /// Initializes a new instance of the <see cref="OutboxProcessorHostedService"/> class.
     /// </summary>
-    /// <param name="repository">The repository for outbox message persistence.</param>
+    /// <param name="scopeFactory">The factory used to create a scope per polling cycle from which the scoped <see cref="IOutboxRepository"/> is resolved.</param>
     /// <param name="transport">The transport for sending messages.</param>
     /// <param name="lifetime">The application lifetime for coordinating startup and shutdown.</param>
     /// <param name="options">The processor configuration options.</param>
     /// <param name="logger">The logger for diagnostic output.</param>
     public OutboxProcessorHostedService(
-        IOutboxRepository repository,
+        IServiceScopeFactory scopeFactory,
         IMessageTransport transport,
         IHostApplicationLifetime lifetime,
         IOptions<OutboxProcessorOptions> options,
         ILogger<OutboxProcessorHostedService> logger
     )
     {
-        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(scopeFactory);
         ArgumentNullException.ThrowIfNull(transport);
         ArgumentNullException.ThrowIfNull(lifetime);
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(logger);
 
-        _repository = repository;
+        _scopeFactory = scopeFactory;
         _transport = transport;
         _lifetime = lifetime;
         _options = options.Value;
@@ -160,8 +171,14 @@ internal sealed partial class OutboxProcessorHostedService : BackgroundService
                     continue;
                 }
 
+                // Resolve a fresh scope (and the scoped IOutboxRepository within it) for this single
+                // polling cycle only. The scope is disposed at the end of the cycle, ensuring any
+                // underlying DbContext is short-lived instead of being captured for the process lifetime.
+                using var cycleScope = _scopeFactory.CreateScope();
+                var repository = cycleScope.ServiceProvider.GetRequiredService<IOutboxRepository>();
+
                 // Check database health before processing
-                var isDatabaseHealthy = await _repository.IsHealthyAsync(stoppingToken).ConfigureAwait(false);
+                var isDatabaseHealthy = await repository.IsHealthyAsync(stoppingToken).ConfigureAwait(false);
                 if (!isDatabaseHealthy)
                 {
                     LogDatabaseUnhealthy(_logger);
@@ -179,7 +196,7 @@ internal sealed partial class OutboxProcessorHostedService : BackgroundService
                 }
 
                 var batchStartTime = Stopwatch.GetTimestamp();
-                var processedCount = await ProcessBatchAsync(stoppingToken).ConfigureAwait(false);
+                var processedCount = await ProcessBatchAsync(repository, stoppingToken).ConfigureAwait(false);
                 var elapsed = Stopwatch.GetElapsedTime(batchStartTime).TotalMilliseconds;
 
                 try
@@ -216,12 +233,13 @@ internal sealed partial class OutboxProcessorHostedService : BackgroundService
     /// Queries the repository for the current pending message count and updates the cached value.
     /// Exceptions are caught and logged at Warning level so that metric failures never interrupt processing.
     /// </summary>
+    /// <param name="repository">The repository resolved for the current polling cycle.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
-    private async Task RefreshPendingCountAsync(CancellationToken cancellationToken)
+    private async Task RefreshPendingCountAsync(IOutboxRepository repository, CancellationToken cancellationToken)
     {
         try
         {
-            var count = await _repository.GetPendingCountAsync(cancellationToken).ConfigureAwait(false);
+            var count = await repository.GetPendingCountAsync(cancellationToken).ConfigureAwait(false);
             Volatile.Write(ref _pendingCount, count);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -253,23 +271,24 @@ internal sealed partial class OutboxProcessorHostedService : BackgroundService
     /// Event type groups are processed in parallel to maximize throughput. However, messages within
     /// a group are processed according to the group's <see cref="OutboxProcessorOptions.EnableBatchSending"/> setting.
     /// </remarks>
+    /// <param name="repository">The repository resolved for the current polling cycle.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>The number of messages processed in this batch; <c>0</c> when no messages are available.</returns>
-    private async Task<int> ProcessBatchAsync(CancellationToken cancellationToken)
+    private async Task<int> ProcessBatchAsync(IOutboxRepository repository, CancellationToken cancellationToken)
     {
         var batchSize = _options.BatchSize;
         // Refresh the pending count gauge before processing. The gauge is purely observational;
         // dispatch must never depend on it because GetPendingCountAsync is an optional-to-override
         // default interface member and its failures are swallowed by RefreshPendingCountAsync.
-        await RefreshPendingCountAsync(cancellationToken).ConfigureAwait(false);
+        await RefreshPendingCountAsync(repository, cancellationToken).ConfigureAwait(false);
 
-        var messages = await _repository.GetPendingAsync(batchSize, cancellationToken).ConfigureAwait(false);
+        var messages = await repository.GetPendingAsync(batchSize, cancellationToken).ConfigureAwait(false);
         batchSize -= messages.Count;
 
         if (batchSize > 0)
         {
             // Also check for failed messages eligible for retry
-            var failedMessages = await _repository
+            var failedMessages = await repository
                 .GetFailedForRetryAsync(_options.MaxRetryCount, batchSize, cancellationToken)
                 .ConfigureAwait(false);
             messages = [.. messages, .. failedMessages];
@@ -296,13 +315,19 @@ internal sealed partial class OutboxProcessorHostedService : BackgroundService
                         return;
                     }
 
+                    // Resolve a dedicated scope (and repository instance) per parallel work item so
+                    // concurrent branches never share a single scoped repository/DbContext instance.
+                    using var workItemScope = _scopeFactory.CreateScope();
+                    var workItemRepository = workItemScope.ServiceProvider.GetRequiredService<IOutboxRepository>();
+
                     if (!_options.GetEffectiveEnableBatchSending(messageGroup.Key))
                     {
-                        await ProcessIndividuallyAsync(messageGroup.Value, token).ConfigureAwait(false);
+                        await ProcessIndividuallyAsync(workItemRepository, messageGroup.Value, token)
+                            .ConfigureAwait(false);
                         return;
                     }
 
-                    await ProcessBatchSendAsync(messageGroup.Value, token).ConfigureAwait(false);
+                    await ProcessBatchSendAsync(workItemRepository, messageGroup.Value, token).ConfigureAwait(false);
                 }
             )
             .ConfigureAwait(false);
@@ -310,7 +335,7 @@ internal sealed partial class OutboxProcessorHostedService : BackgroundService
         // Refresh the pending count gauge after processing so the observed value reflects the
         // post-batch state. Without this, observers may continue to see the pre-batch count
         // until the next polling cycle runs RefreshPendingCountAsync, which races with shutdown.
-        await RefreshPendingCountAsync(cancellationToken).ConfigureAwait(false);
+        await RefreshPendingCountAsync(repository, cancellationToken).ConfigureAwait(false);
 
         return messages.Count;
     }
@@ -328,10 +353,15 @@ internal sealed partial class OutboxProcessorHostedService : BackgroundService
     /// Processing stops immediately when the cancellation token is triggered, leaving
     /// remaining messages unprocessed. These messages will be re-polled and processed in subsequent cycles.
     /// </remarks>
+    /// <param name="repository">The repository resolved for this work item.</param>
     /// <param name="messages">The ordered array of outbox messages to process sequentially.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    private async Task ProcessIndividuallyAsync(OutboxMessage[] messages, CancellationToken cancellationToken)
+    private async Task ProcessIndividuallyAsync(
+        IOutboxRepository repository,
+        OutboxMessage[] messages,
+        CancellationToken cancellationToken
+    )
     {
         foreach (var message in messages)
         {
@@ -340,7 +370,7 @@ internal sealed partial class OutboxProcessorHostedService : BackgroundService
                 break;
             }
 
-            await ProcessMessageAsync(message, cancellationToken).ConfigureAwait(false);
+            await ProcessMessageAsync(repository, message, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -349,10 +379,15 @@ internal sealed partial class OutboxProcessorHostedService : BackgroundService
     /// based on the outcome. Applies a per-message processing timeout using a linked
     /// <see cref="CancellationTokenSource"/>.
     /// </summary>
+    /// <param name="repository">The repository resolved for this work item.</param>
     /// <param name="message">The outbox message to process.</param>
     /// <param name="cancellationToken">A token to monitor for external cancellation requests.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    private async Task ProcessMessageAsync(OutboxMessage message, CancellationToken cancellationToken)
+    private async Task ProcessMessageAsync(
+        IOutboxRepository repository,
+        OutboxMessage message,
+        CancellationToken cancellationToken
+    )
     {
         var maxRetryCount = _options.GetEffectiveMaxRetryCount(message.EventType);
         var processingTimeout = _options.GetEffectiveProcessingTimeout(message.EventType);
@@ -363,7 +398,7 @@ internal sealed partial class OutboxProcessorHostedService : BackgroundService
             timeoutCts.CancelAfter(processingTimeout);
 
             await _transport.SendAsync(message, timeoutCts.Token).ConfigureAwait(false);
-            await _repository.MarkAsCompletedAsync(message.Id, cancellationToken).ConfigureAwait(false);
+            await repository.MarkAsCompletedAsync(message.Id, cancellationToken).ConfigureAwait(false);
 
             LogMessageProcessed(_logger, message.Id, message.EventType.Name);
 
@@ -386,9 +421,7 @@ internal sealed partial class OutboxProcessorHostedService : BackgroundService
 
             if (message.RetryCount + 1 >= maxRetryCount)
             {
-                await _repository
-                    .MarkAsDeadLetterAsync(message.Id, ex.Message, cancellationToken)
-                    .ConfigureAwait(false);
+                await repository.MarkAsDeadLetterAsync(message.Id, ex.Message, cancellationToken).ConfigureAwait(false);
                 LogMessageMovedToDeadLetter(_logger, message.Id, maxRetryCount);
 
                 try
@@ -408,7 +441,7 @@ internal sealed partial class OutboxProcessorHostedService : BackgroundService
                     nextRetryAt = _options.ComputeNextRetryAt(DateTimeOffset.UtcNow, message.RetryCount);
                 }
 
-                await _repository
+                await repository
                     .MarkAsFailedAsync(message.Id, ex.Message, nextRetryAt, cancellationToken)
                     .ConfigureAwait(false);
 
@@ -446,10 +479,15 @@ internal sealed partial class OutboxProcessorHostedService : BackgroundService
     /// A per-batch timeout is applied using the global <see cref="OutboxProcessorOptions.ProcessingTimeout"/>,
     /// not per-message timeouts.
     /// </remarks>
+    /// <param name="repository">The repository resolved for this work item.</param>
     /// <param name="messages">The ordered array of outbox messages to send as a batch.</param>
     /// <param name="cancellationToken">A token to monitor for external cancellation requests.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    private async Task ProcessBatchSendAsync(OutboxMessage[] messages, CancellationToken cancellationToken)
+    private async Task ProcessBatchSendAsync(
+        IOutboxRepository repository,
+        OutboxMessage[] messages,
+        CancellationToken cancellationToken
+    )
     {
         try
         {
@@ -460,7 +498,7 @@ internal sealed partial class OutboxProcessorHostedService : BackgroundService
 
             // Mark all as completed in a single batch operation
             var ids = messages.Select(static m => m.Id).ToArray();
-            await _repository.MarkAsCompletedAsync(ids, cancellationToken).ConfigureAwait(false);
+            await repository.MarkAsCompletedAsync(ids, cancellationToken).ConfigureAwait(false);
 
             LogBatchProcessed(_logger, messages.Length);
 
@@ -509,7 +547,7 @@ internal sealed partial class OutboxProcessorHostedService : BackgroundService
                         failedWithRetryTime,
                         cancellationToken,
                         async (item, token) =>
-                            await _repository
+                            await repository
                                 .MarkAsFailedAsync(item.messageId, ex.Message, item.nextRetryAt, token)
                                 .ConfigureAwait(false)
                     )
@@ -518,13 +556,13 @@ internal sealed partial class OutboxProcessorHostedService : BackgroundService
             else
             {
                 // Mark failed messages without backoff scheduling
-                await _repository
+                await repository
                     .MarkAsFailedAsync(failedMessageIds, ex.Message, cancellationToken)
                     .ConfigureAwait(false);
             }
 
             await Task.WhenAll(
-                    _repository.MarkAsDeadLetterAsync(deadLetterMessages, ex.Message, cancellationToken),
+                    repository.MarkAsDeadLetterAsync(deadLetterMessages, ex.Message, cancellationToken),
                     Parallel.ForEachAsync(
                         messages.Where(m => m.RetryCount + 1 >= _options.GetEffectiveMaxRetryCount(m.EventType)),
                         cancellationToken,

--- a/src/NetEvolve.Pulse/Outbox/OutboxProcessorOptions.cs
+++ b/src/NetEvolve.Pulse/Outbox/OutboxProcessorOptions.cs
@@ -104,7 +104,7 @@ public sealed class OutboxProcessorOptions
     /// <remarks>
     /// <para><strong>Concurrency Guarantees:</strong></para>
     /// The property uses <see cref="ConcurrentDictionary{TKey,TValue}"/> for thread-safe access.
-    /// This is required because the dictionary may be read concurrently during <see cref="OutboxProcessorHostedService.ProcessBatchAsync(CancellationToken)"/>
+    /// This is required because the dictionary may be read concurrently during <see cref="OutboxProcessorHostedService.ProcessBatchAsync(IOutboxRepository, CancellationToken)"/>
     /// while being modified externally through code or dependency injection configuration.
     /// <para><strong>Dictionary Key Format:</strong></para>
     /// The dictionary key must match the <see cref="OutboxMessage.EventType"/> value of the messages

--- a/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorHostedServiceDbContextLifetimeTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorHostedServiceDbContextLifetimeTests.cs
@@ -1,0 +1,91 @@
+namespace NetEvolve.Pulse.Tests.Unit.Outbox;
+
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility.Outbox;
+using NetEvolve.Pulse.Tests.Unit.EntityFramework;
+using TUnit.Core;
+
+/// <summary>
+/// Verifies that <see cref="OutboxProcessorHostedService"/>, which is registered as a singleton
+/// hosted service, does not directly capture the scoped <see cref="IOutboxRepository"/>
+/// registered by the Entity Framework outbox provider. A captive dependency of this kind causes
+/// <see cref="ServiceProviderOptions.ValidateScopes"/> to throw at build time and, when validation
+/// is disabled, pins a single <see cref="DbContext"/> for the lifetime of the process.
+/// </summary>
+[TestGroup("Outbox")]
+public sealed class OutboxProcessorHostedServiceDbContextLifetimeTests
+{
+    [Test]
+    public async Task BuildServiceProvider_WithValidateScopesAndEntityFrameworkOutbox_DoesNotThrow()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddLogging();
+        _ = services.AddSingleton<IHostApplicationLifetime>(new FakeHostApplicationLifetime());
+        _ = services.AddDbContext<TestDbContext>(o =>
+            o.UseInMemoryDatabase(nameof(BuildServiceProvider_WithValidateScopesAndEntityFrameworkOutbox_DoesNotThrow))
+        );
+        _ = services.AddPulse(config => config.AddOutbox().AddEntityFrameworkOutbox<TestDbContext>());
+
+        ServiceProvider? provider = null;
+        try
+        {
+            provider = services.BuildServiceProvider(
+                new ServiceProviderOptions { ValidateScopes = true, ValidateOnBuild = true }
+            );
+        }
+        finally
+        {
+            if (provider is not null)
+            {
+                await provider.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+    }
+
+    [Test]
+    public async Task ExecuteAsync_AcrossMultipleCycles_ResolvesFreshRepositoryPerCycle()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddLogging();
+        _ = services.AddSingleton<IHostApplicationLifetime>(new FakeHostApplicationLifetime());
+        _ = services.AddDbContext<TestDbContext>(o =>
+            o.UseInMemoryDatabase(nameof(ExecuteAsync_AcrossMultipleCycles_ResolvesFreshRepositoryPerCycle))
+        );
+        _ = services.AddPulse(config => config.AddOutbox().AddEntityFrameworkOutbox<TestDbContext>());
+
+        await using var provider = services.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateScopes = true, ValidateOnBuild = true }
+        );
+
+        var hostedServices = provider.GetServices<IHostedService>().ToList();
+        var processor = hostedServices.OfType<OutboxProcessorHostedService>().Single();
+
+        using var cts = new CancellationTokenSource();
+        await processor.StartAsync(cts.Token).ConfigureAwait(false);
+        // Allow a couple of polling cycles to run; the important assertion is that starting and
+        // stopping the singleton hosted service against a scoped-repository registration does not
+        // throw, which it would if the repository (and its DbContext) were captured for the whole
+        // process lifetime while ValidateScopes is enabled at resolution time.
+        await Task.Delay(150, cts.Token).ConfigureAwait(false);
+        await cts.CancelAsync().ConfigureAwait(false);
+        await processor.StopAsync(CancellationToken.None).ConfigureAwait(false);
+    }
+
+    private sealed class FakeHostApplicationLifetime : IHostApplicationLifetime
+    {
+        // A pre-cancelled token signals that the application has already started, causing
+        // ExecuteAsync to proceed immediately without waiting for a real host startup sequence.
+        private static readonly CancellationToken s_startedToken = new(canceled: true);
+
+        public CancellationToken ApplicationStarted => s_startedToken;
+        public CancellationToken ApplicationStopping => CancellationToken.None;
+        public CancellationToken ApplicationStopped => CancellationToken.None;
+
+        public void StopApplication() { }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorHostedServiceTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorHostedServiceTests.cs
@@ -19,16 +19,16 @@ using TUnit.Core;
 public sealed class OutboxProcessorHostedServiceTests
 {
     [Test]
-    public async Task Constructor_WithNullRepository_ThrowsArgumentNullException()
+    public async Task Constructor_WithNullScopeFactory_ThrowsArgumentNullException()
     {
-        IOutboxRepository? repository = null;
+        IServiceScopeFactory? scopeFactory = null;
         var transport = new InMemoryMessageTransport();
         var options = Options.Create(new OutboxProcessorOptions());
         var logger = CreateLogger();
 
         _ = Assert.Throws<ArgumentNullException>(
-            "repository",
-            () => _ = new OutboxProcessorHostedService(repository!, transport, CreateLifetime(), options, logger)
+            "scopeFactory",
+            () => _ = new OutboxProcessorHostedService(scopeFactory!, transport, CreateLifetime(), options, logger)
         );
     }
 
@@ -42,7 +42,14 @@ public sealed class OutboxProcessorHostedServiceTests
 
         _ = Assert.Throws<ArgumentNullException>(
             "transport",
-            () => _ = new OutboxProcessorHostedService(repository, transport!, CreateLifetime(), options, logger)
+            () =>
+                _ = new OutboxProcessorHostedService(
+                    CreateScopeFactory(repository),
+                    transport!,
+                    CreateLifetime(),
+                    options,
+                    logger
+                )
         );
     }
 
@@ -56,7 +63,14 @@ public sealed class OutboxProcessorHostedServiceTests
 
         _ = Assert.Throws<ArgumentNullException>(
             "options",
-            () => _ = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options!, logger)
+            () =>
+                _ = new OutboxProcessorHostedService(
+                    CreateScopeFactory(repository),
+                    transport,
+                    CreateLifetime(),
+                    options!,
+                    logger
+                )
         );
     }
 
@@ -70,7 +84,14 @@ public sealed class OutboxProcessorHostedServiceTests
 
         _ = Assert.Throws<ArgumentNullException>(
             "logger",
-            () => _ = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger!)
+            () =>
+                _ = new OutboxProcessorHostedService(
+                    CreateScopeFactory(repository),
+                    transport,
+                    CreateLifetime(),
+                    options,
+                    logger!
+                )
         );
     }
 
@@ -85,7 +106,14 @@ public sealed class OutboxProcessorHostedServiceTests
 
         _ = Assert.Throws<ArgumentNullException>(
             "lifetime",
-            () => _ = new OutboxProcessorHostedService(repository, transport, lifetime!, options, logger)
+            () =>
+                _ = new OutboxProcessorHostedService(
+                    CreateScopeFactory(repository),
+                    transport,
+                    lifetime!,
+                    options,
+                    logger
+                )
         );
     }
 
@@ -97,7 +125,13 @@ public sealed class OutboxProcessorHostedServiceTests
         var options = Options.Create(new OutboxProcessorOptions());
         var logger = CreateLogger();
 
-        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+        using var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            CreateLifetime(),
+            options,
+            logger
+        );
 
         _ = await Assert.That(service).IsNotNull();
     }
@@ -109,7 +143,13 @@ public sealed class OutboxProcessorHostedServiceTests
         var transport = new InMemoryMessageTransport();
         var options = Options.Create(new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50) });
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+        using var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            CreateLifetime(),
+            options,
+            logger
+        );
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
@@ -134,7 +174,13 @@ public sealed class OutboxProcessorHostedServiceTests
         var transport = new InMemoryMessageTransport();
         var options = Options.Create(new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50) });
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+        using var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            CreateLifetime(),
+            options,
+            logger
+        );
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
@@ -159,7 +205,13 @@ public sealed class OutboxProcessorHostedServiceTests
         var transport = new InMemoryMessageTransport();
         var options = Options.Create(new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50) });
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+        using var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            CreateLifetime(),
+            options,
+            logger
+        );
 
         // Add a pending message
         var message = CreateMessage();
@@ -185,7 +237,13 @@ public sealed class OutboxProcessorHostedServiceTests
         var transport = new InMemoryMessageTransport();
         var options = Options.Create(new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50) });
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+        using var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            CreateLifetime(),
+            options,
+            logger
+        );
 
         // Add multiple messages
         var message1 = CreateMessage();
@@ -214,7 +272,13 @@ public sealed class OutboxProcessorHostedServiceTests
         var transport = new InMemoryMessageTransport();
         var options = Options.Create(new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(200) });
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+        using var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            CreateLifetime(),
+            options,
+            logger
+        );
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
@@ -237,7 +301,13 @@ public sealed class OutboxProcessorHostedServiceTests
             new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50), MaxRetryCount = 3 }
         );
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+        using var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            CreateLifetime(),
+            options,
+            logger
+        );
 
         var message = CreateMessage();
         await repository.AddAsync(message, cancellationToken).ConfigureAwait(false);
@@ -259,7 +329,13 @@ public sealed class OutboxProcessorHostedServiceTests
             new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50), MaxRetryCount = 2 }
         );
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+        using var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            CreateLifetime(),
+            options,
+            logger
+        );
 
         // Add a message that has already been retried once
         var message = CreateMessage();
@@ -283,7 +359,13 @@ public sealed class OutboxProcessorHostedServiceTests
             new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50), MaxRetryCount = 3 }
         );
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+        using var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            CreateLifetime(),
+            options,
+            logger
+        );
 
         var message = CreateMessage();
         await repository.AddAsync(message, cancellationToken).ConfigureAwait(false);
@@ -306,7 +388,13 @@ public sealed class OutboxProcessorHostedServiceTests
             new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50), EnableBatchSending = true }
         );
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+        using var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            CreateLifetime(),
+            options,
+            logger
+        );
 
         var message1 = CreateMessage();
         var message2 = CreateMessage();
@@ -334,7 +422,13 @@ public sealed class OutboxProcessorHostedServiceTests
             new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50), EnableBatchSending = true }
         );
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+        using var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            CreateLifetime(),
+            options,
+            logger
+        );
 
         var message1 = CreateMessage();
         var message2 = CreateMessage();
@@ -372,7 +466,13 @@ public sealed class OutboxProcessorHostedServiceTests
             new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50), BatchSize = 2 }
         );
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+        using var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            CreateLifetime(),
+            options,
+            logger
+        );
 
         // Add more messages than batch size
         for (var i = 0; i < 5; i++)
@@ -408,7 +508,13 @@ public sealed class OutboxProcessorHostedServiceTests
             }
         );
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+        using var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            CreateLifetime(),
+            options,
+            logger
+        );
 
         // Message of type CriticalEvent should use override (MaxRetryCount = 1)
         var message = CreateMessage(typeof(CriticalEvent));
@@ -445,7 +551,13 @@ public sealed class OutboxProcessorHostedServiceTests
             }
         );
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+        using var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            CreateLifetime(),
+            options,
+            logger
+        );
 
         // SlowEvent message should time out and be marked as failed/dead-lettered
         var message = CreateMessage(typeof(SlowEvent));
@@ -485,7 +597,13 @@ public sealed class OutboxProcessorHostedServiceTests
             }
         );
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+        using var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            CreateLifetime(),
+            options,
+            logger
+        );
 
         // Add two messages of the overridden type: should be batch-sent
         var message1 = CreateMessage(typeof(BatchEvent));
@@ -616,7 +734,13 @@ public sealed class OutboxProcessorHostedServiceTests
         var transport = new InMemoryMessageTransport();
         var options = Options.Create(new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50) });
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+        using var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            CreateLifetime(),
+            options,
+            logger
+        );
 
         var message = CreateMessage();
         await repository.AddAsync(message, cancellationToken).ConfigureAwait(false);
@@ -662,7 +786,13 @@ public sealed class OutboxProcessorHostedServiceTests
             new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50), MaxRetryCount = 3 }
         );
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+        using var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            CreateLifetime(),
+            options,
+            logger
+        );
 
         var message = CreateMessage();
         await repository.AddAsync(message, cancellationToken).ConfigureAwait(false);
@@ -706,7 +836,13 @@ public sealed class OutboxProcessorHostedServiceTests
             new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50), MaxRetryCount = 2 }
         );
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+        using var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            CreateLifetime(),
+            options,
+            logger
+        );
 
         var message = CreateMessage();
         message.RetryCount = 1;
@@ -749,7 +885,13 @@ public sealed class OutboxProcessorHostedServiceTests
         var transport = new InMemoryMessageTransport();
         var options = Options.Create(new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50) });
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+        using var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            CreateLifetime(),
+            options,
+            logger
+        );
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         await service.StartAsync(cts.Token).ConfigureAwait(false);
@@ -797,7 +939,13 @@ public sealed class OutboxProcessorHostedServiceTests
         var transport = new InMemoryMessageTransport();
         var options = Options.Create(new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50) });
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+        using var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            CreateLifetime(),
+            options,
+            logger
+        );
 
         // Add 3 pending messages before starting
         await repository.AddAsync(CreateMessage(), cancellationToken).ConfigureAwait(false);
@@ -873,7 +1021,13 @@ public sealed class OutboxProcessorHostedServiceTests
         var transport = new InMemoryMessageTransport();
         var options = Options.Create(new OutboxProcessorOptions());
         var logger = CreateLogger();
-        var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+        var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            CreateLifetime(),
+            options,
+            logger
+        );
 
         service.Dispose();
 
@@ -898,7 +1052,13 @@ public sealed class OutboxProcessorHostedServiceTests
             }
         );
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+        using var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            CreateLifetime(),
+            options,
+            logger
+        );
 
         var message = CreateMessage();
         await repository.AddAsync(message, cancellationToken).ConfigureAwait(false);
@@ -937,7 +1097,13 @@ public sealed class OutboxProcessorHostedServiceTests
             }
         );
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+        using var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            CreateLifetime(),
+            options,
+            logger
+        );
 
         var message = CreateMessage();
         await repository.AddAsync(message, cancellationToken).ConfigureAwait(false);
@@ -1035,7 +1201,13 @@ public sealed class OutboxProcessorHostedServiceTests
         var options = Options.Create(new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50) });
         var logger = CreateLogger();
         using var lifetime = new PendingStartLifetime();
-        using var service = new OutboxProcessorHostedService(repository, transport, lifetime, options, logger);
+        using var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            lifetime,
+            options,
+            logger
+        );
 
         await repository.AddAsync(CreateMessage(), cancellationToken).ConfigureAwait(false);
 
@@ -1071,7 +1243,13 @@ public sealed class OutboxProcessorHostedServiceTests
         var options = Options.Create(new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50) });
         var logger = CreateLogger();
         using var lifetime = new PendingStartLifetime();
-        using var service = new OutboxProcessorHostedService(repository, transport, lifetime, options, logger);
+        using var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            lifetime,
+            options,
+            logger
+        );
 
         // Startup never completes: ApplicationStarted is never signaled.
         await service.StartAsync(cancellationToken).ConfigureAwait(false);
@@ -1097,7 +1275,13 @@ public sealed class OutboxProcessorHostedServiceTests
         var transport = new InMemoryMessageTransport();
         var options = Options.Create(new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50) });
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+        using var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            CreateLifetime(),
+            options,
+            logger
+        );
 
         await repository.AddAsync(CreateMessage(), cancellationToken).ConfigureAwait(false);
 
@@ -1121,7 +1305,13 @@ public sealed class OutboxProcessorHostedServiceTests
         var transport = new UnhealthyMessageTransport();
         var options = Options.Create(new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50) });
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+        using var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            CreateLifetime(),
+            options,
+            logger
+        );
 
         var message = CreateMessage();
         await repository.AddAsync(message, cancellationToken).ConfigureAwait(false);
@@ -1150,7 +1340,13 @@ public sealed class OutboxProcessorHostedServiceTests
             new OutboxProcessorOptions { DisableProcessing = true, PollingInterval = TimeSpan.FromMilliseconds(50) }
         );
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+        using var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            CreateLifetime(),
+            options,
+            logger
+        );
 
         await repository.AddAsync(CreateMessage(), cancellationToken).ConfigureAwait(false);
 
@@ -1176,7 +1372,13 @@ public sealed class OutboxProcessorHostedServiceTests
         var transport = new InMemoryMessageTransport();
         var options = Options.Create(new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50) });
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+        using var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            CreateLifetime(),
+            options,
+            logger
+        );
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         await service.StartAsync(cts.Token).ConfigureAwait(false);
@@ -1196,7 +1398,13 @@ public sealed class OutboxProcessorHostedServiceTests
         var transport = new InMemoryMessageTransport();
         var options = Options.Create(new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50) });
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+        using var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            CreateLifetime(),
+            options,
+            logger
+        );
 
         var message = CreateMessage();
         await repository.AddAsync(message, cancellationToken).ConfigureAwait(false);
@@ -1222,7 +1430,13 @@ public sealed class OutboxProcessorHostedServiceTests
         var transport = new InMemoryMessageTransport();
         var options = Options.Create(new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50) });
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+        using var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            CreateLifetime(),
+            options,
+            logger
+        );
 
         var message = CreateMessage();
         await repository.AddAsync(message, cancellationToken).ConfigureAwait(false);
@@ -1254,7 +1468,13 @@ public sealed class OutboxProcessorHostedServiceTests
             }
         );
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+        using var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            CreateLifetime(),
+            options,
+            logger
+        );
 
         var message1 = CreateMessage();
         var message2 = CreateMessage();
@@ -1288,7 +1508,13 @@ public sealed class OutboxProcessorHostedServiceTests
         var transport = new InMemoryMessageTransport();
         var options = Options.Create(new OutboxProcessorOptions { PollingInterval = TimeSpan.FromMilliseconds(50) });
         var logger = CreateLogger();
-        using var service = new OutboxProcessorHostedService(repository, transport, CreateLifetime(), options, logger);
+        using var service = new OutboxProcessorHostedService(
+            CreateScopeFactory(repository),
+            transport,
+            CreateLifetime(),
+            options,
+            logger
+        );
 
         await repository.AddAsync(CreateMessage(), cancellationToken).ConfigureAwait(false);
 
@@ -1316,6 +1542,18 @@ public sealed class OutboxProcessorHostedServiceTests
             .GetRequiredService<ILogger<OutboxProcessorHostedService>>();
 
     private static FakeHostApplicationLifetime CreateLifetime() => new();
+
+    /// <summary>
+    /// Builds an <see cref="IServiceScopeFactory"/> whose scopes always resolve the given
+    /// <paramref name="repository"/> instance, mirroring how the hosted service resolves
+    /// <see cref="IOutboxRepository"/> from a fresh scope per polling cycle in production while
+    /// letting tests keep asserting against a single repository instance.
+    /// </summary>
+    private static IServiceScopeFactory CreateScopeFactory(IOutboxRepository repository) =>
+        new ServiceCollection()
+            .AddSingleton(repository)
+            .BuildServiceProvider()
+            .GetRequiredService<IServiceScopeFactory>();
 
     private static OutboxMessage CreateMessage(Type? eventType = null) =>
         new()


### PR DESCRIPTION
## Problem

`OutboxProcessorHostedService` is registered as a **singleton** hosted service (`OutboxExtensions.AddOutbox`), but its constructor injected `IOutboxRepository` directly. Every persistence provider registers `IOutboxRepository` as **Scoped** (e.g. `EntityFrameworkOutboxRepository<TContext>`, which wraps a `DbContext`). This is a captive dependency: the singleton captured a single scoped repository instance (and its `DbContext`) for the entire process lifetime.

Consequences:
- Building the service provider with `ValidateScopes`/`ValidateOnBuild` enabled throws `InvalidOperationException`.
- With validation disabled, one `DbContext` lives for the whole process. Its `ChangeTracker` accumulates tracked entities on every poll cycle, since the success path in `TrackingOutboxRepositoryExecutorBase` never detaches entities (only the concurrency-conflict branch does) — unbounded memory growth.
- The `Parallel.ForEachAsync` fan-out in `ProcessBatchAsync` dispatched concurrent branches against that same non-thread-safe `DbContext`.

## Fix

- `OutboxProcessorHostedService` now takes `IServiceScopeFactory` instead of `IOutboxRepository`.
- A fresh `IServiceScope` is created per polling cycle in `ExecuteAsync`, and `IOutboxRepository` is resolved from it; the scope is disposed at the end of the cycle.
- Each parallel work item in the batch fan-out (`Parallel.ForEachAsync` over event-type groups) resolves its own scope and repository instance, so concurrent branches never share a scoped repository/DbContext.
- `IMessageTransport` remains injected directly, since it is registered as a singleton — no change needed there.
- Public behavior, the hosted-service singleton registration, and the observable gauge/meter semantics are unchanged.

## Testing

- Added `OutboxProcessorHostedServiceDbContextLifetimeTests`: builds a `ServiceCollection` wired with the mediator + outbox + Entity Framework outbox (EF Core InMemory), then calls `BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true, ValidateOnBuild = true })` and asserts it does not throw. Confirmed this test failed with `Cannot consume scoped service 'IOutboxRepository' from singleton 'IHostedService'` before the fix, and passes after.
- Updated `OutboxProcessorHostedServiceTests` to construct the service through a small `IServiceScopeFactory` test helper instead of passing the repository directly (mechanical update since the constructor is `internal`, not public API).
- `dotnet build Pulse.slnx -c Release`: 0 errors.
- `dotnet test tests/NetEvolve.Pulse.Tests.Unit` (net8.0/net9.0/net10.0): 4284 total, 4284 passed, 0 failed.