### PR TITLE
perf(mediator): build interceptor pipeline without reverse allocation

### DIFF
--- a/src/NetEvolve.Pulse/Internals/PulseMediator.cs
+++ b/src/NetEvolve.Pulse/Internals/PulseMediator.cs
@@ -187,17 +187,19 @@ internal sealed partial class PulseMediator : IMediator
         // Build the interceptor chain from innermost (dispatcher) to outermost (first interceptor)
         var next = DispatchAsync;
 
-        // Retrieve all registered event interceptors and reverse for correct pipeline order
-        var interceptors = serviceProvider.GetServices<IEventInterceptor<TEvent>>().Reverse().ToArray();
+        // Retrieve all registered event interceptors, keeping registration order
+        var interceptors = serviceProvider.GetServices<IEventInterceptor<TEvent>>().ToArray();
         if (interceptors.Length == 0)
         {
             // No interceptors registered, execute dispatcher directly
             return next(msg, cancellationToken);
         }
 
-        foreach (var interceptor in interceptors)
+        // Walk the interceptors from last-registered to first-registered so the first-registered
+        // interceptor ends up outermost, without allocating a separate reversed sequence.
+        for (var i = interceptors.Length - 1; i >= 0; i--)
         {
-            var currentInterceptor = interceptor;
+            var currentInterceptor = interceptors[i];
             var currentNext = next;
             // Wrap the next action with the current interceptor
             next = (req, token) => currentInterceptor.HandleAsync(req, currentNext, token);
@@ -225,8 +227,8 @@ internal sealed partial class PulseMediator : IMediator
     )
         where TRequest : IRequest<TResponse>
     {
-        // Retrieve all registered request interceptors and reverse for correct pipeline order
-        var interceptors = _serviceProvider.GetServices<IRequestInterceptor<TRequest, TResponse>>().Reverse().ToArray();
+        // Retrieve all registered request interceptors, keeping registration order
+        var interceptors = _serviceProvider.GetServices<IRequestInterceptor<TRequest, TResponse>>().ToArray();
 
         if (interceptors.Length == 0)
         {
@@ -237,9 +239,11 @@ internal sealed partial class PulseMediator : IMediator
         // Build the interceptor chain from innermost (handler) to outermost (first interceptor)
         var next = handler;
 
-        foreach (var interceptor in interceptors)
+        // Walk the interceptors from last-registered to first-registered so the first-registered
+        // interceptor ends up outermost, without allocating a separate reversed sequence.
+        for (var i = interceptors.Length - 1; i >= 0; i--)
         {
-            var currentInterceptor = interceptor;
+            var currentInterceptor = interceptors[i];
             var nextCopy = next;
             // Wrap the next action with the current interceptor
             next = (req, token) => currentInterceptor.HandleAsync(req, nextCopy, token);
@@ -266,11 +270,8 @@ internal sealed partial class PulseMediator : IMediator
     )
         where TQuery : IStreamQuery<TResponse>
     {
-        // Retrieve all registered stream query interceptors and reverse for correct pipeline order
-        var interceptors = _serviceProvider
-            .GetServices<IStreamQueryInterceptor<TQuery, TResponse>>()
-            .Reverse()
-            .ToArray();
+        // Retrieve all registered stream query interceptors, keeping registration order
+        var interceptors = _serviceProvider.GetServices<IStreamQueryInterceptor<TQuery, TResponse>>().ToArray();
 
         if (interceptors.Length == 0)
         {
@@ -281,9 +282,11 @@ internal sealed partial class PulseMediator : IMediator
         // Build the interceptor chain from innermost (handler) to outermost (first interceptor)
         var next = handler;
 
-        foreach (var interceptor in interceptors)
+        // Walk the interceptors from last-registered to first-registered so the first-registered
+        // interceptor ends up outermost, without allocating a separate reversed sequence.
+        for (var i = interceptors.Length - 1; i >= 0; i--)
         {
-            var currentInterceptor = interceptor;
+            var currentInterceptor = interceptors[i];
             var nextCopy = next;
             // Wrap the next action with the current interceptor
             next = (req, token) => currentInterceptor.HandleAsync(req, nextCopy, token);

--- a/tests/NetEvolve.Pulse.Tests.Unit/Internals/PulseMediatorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Internals/PulseMediatorTests.cs
@@ -703,4 +703,64 @@ public class PulseMediatorTests
             _ = await Assert.That(handler.HandledQueries).HasSingleItem();
         }
     }
+
+    [Test]
+    public async Task SendAsync_WithMultipleInterceptors_InvokesThemInRegistrationOrder(
+        CancellationToken cancellationToken
+    )
+    {
+        var log = new List<string>();
+        var handler = new TestCommandHandler("test-result");
+        var services = new ServiceCollection();
+        _ = services.AddLogging();
+        _ = services.AddSingleton<ICommandHandler<TestCommand, string>>(handler);
+        _ = services.AddSingleton<IRequestInterceptor<TestCommand, string>>(
+            new OrderTrackingCommandInterceptor("first", log)
+        );
+        _ = services.AddSingleton<IRequestInterceptor<TestCommand, string>>(
+            new OrderTrackingCommandInterceptor("second", log)
+        );
+        _ = services.AddSingleton<IRequestInterceptor<TestCommand, string>>(
+            new OrderTrackingCommandInterceptor("third", log)
+        );
+        var serviceProvider = services.BuildServiceProvider();
+        var logger = serviceProvider.GetRequiredService<ILogger<PulseMediator>>();
+        var timeProvider = TimeProvider.System;
+        var mediator = new PulseMediator(logger, serviceProvider, timeProvider);
+        var command = new TestCommand();
+
+        var result = await mediator.SendAsync<TestCommand, string>(command, cancellationToken).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(result).IsEqualTo("test-result");
+            _ = await Assert
+                .That(string.Join(",", log))
+                .IsEqualTo("first:before,second:before,third:before,third:after,second:after,first:after");
+        }
+    }
+
+    private sealed class OrderTrackingCommandInterceptor : IRequestInterceptor<TestCommand, string>
+    {
+        private readonly string _name;
+        private readonly List<string> _log;
+
+        public OrderTrackingCommandInterceptor(string name, List<string> log)
+        {
+            _name = name;
+            _log = log;
+        }
+
+        public async Task<string> HandleAsync(
+            TestCommand request,
+            Func<TestCommand, CancellationToken, Task<string>> handler,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _log.Add($"{_name}:before");
+            var result = await handler(request, cancellationToken).ConfigureAwait(false);
+            _log.Add($"{_name}:after");
+            return result;
+        }
+    }
 }


### PR DESCRIPTION
## Problem
`PulseMediator` rebuilds the interceptor pipeline on every Send/Query/StreamQuery/Publish dispatch by calling `serviceProvider.GetServices<TInterceptor>().Reverse().ToArray()`. `Reverse()` on an `IEnumerable<T>` allocates a buffering enumerator and `ToArray()` then allocates a second array, so each dispatch pays for two array-sized allocations just to get the interceptors in reverse order.

## Fix
Materialize the interceptors once with a single `GetServices<TInterceptor>().ToArray()`, then build the delegate chain by iterating that array back-to-front with an indexed `for` loop instead of calling `Reverse()`. This removes the redundant reversed-sequence allocation while preserving:
- The exact same interceptor execution order (first-registered interceptor stays outermost).
- Per-call resolution of interceptor instances from the caller's scope (no caching of instances across calls or scopes).

Applied identically to the event, request, and streaming-query pipeline builders in `src/NetEvolve.Pulse/Internals/PulseMediator.cs`.

## Testing
- Added `SendAsync_WithMultipleInterceptors_InvokesThemInRegistrationOrder` in `tests/NetEvolve.Pulse.Tests.Unit/Internals/PulseMediatorTests.cs`, which registers three interceptors that record `before`/`after` markers and asserts the exact outer-to-inner execution order via a joined string comparison (order-sensitive), guarding against a broken reversal.
- `dotnet build Pulse.slnx -c Release` — 0 errors, 0 warnings.
- `dotnet test tests/NetEvolve.Pulse.Tests.Unit/NetEvolve.Pulse.Tests.Unit.csproj -c Release` — 4281 passed, 0 failed, 0 skipped across net8.0, net9.0, and net10.0.