### PR TITLE
perf(fluentvalidation): enumerate validators without list allocation

### DIFF
--- a/src/NetEvolve.Pulse.FluentValidation/Interceptors/FluentValidationRequestInterceptor.cs
+++ b/src/NetEvolve.Pulse.FluentValidation/Interceptors/FluentValidationRequestInterceptor.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentValidation;
@@ -55,22 +54,20 @@ internal sealed class FluentValidationRequestInterceptor<TRequest, TResponse> : 
     {
         ArgumentNullException.ThrowIfNull(handler);
 
-        var validators = _serviceProvider.GetServices<IValidator<TRequest>>().ToList();
+        var validators = _serviceProvider.GetServices<IValidator<TRequest>>();
 
-        if (validators.Count == 0)
-        {
-            return await handler(request, cancellationToken).ConfigureAwait(false);
-        }
-
-        var failures = new List<ValidationFailure>();
+        List<ValidationFailure>? failures = null;
 
         foreach (var validator in validators)
         {
             var result = await validator.ValidateAsync(request, cancellationToken).ConfigureAwait(false);
-            failures.AddRange(result.Errors);
+            if (result.Errors.Count > 0)
+            {
+                (failures ??= []).AddRange(result.Errors);
+            }
         }
 
-        if (failures.Count > 0)
+        if (failures is { Count: > 0 })
         {
             throw new ValidationException(failures);
         }

--- a/src/NetEvolve.Pulse.FluentValidation/Interceptors/FluentValidationStreamQueryInterceptor.cs
+++ b/src/NetEvolve.Pulse.FluentValidation/Interceptors/FluentValidationStreamQueryInterceptor.cs
@@ -2,7 +2,6 @@ namespace NetEvolve.Pulse.Interceptors;
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -66,22 +65,22 @@ internal sealed class FluentValidationStreamQueryInterceptor<TQuery, TResponse>
         [EnumeratorCancellation] CancellationToken cancellationToken
     )
     {
-        var validators = _serviceProvider.GetServices<IValidator<TQuery>>().ToList();
+        var validators = _serviceProvider.GetServices<IValidator<TQuery>>();
 
-        if (validators.Count > 0)
+        List<ValidationFailure>? failures = null;
+
+        foreach (var validator in validators)
         {
-            var failures = new List<ValidationFailure>();
-
-            foreach (var validator in validators)
+            var result = await validator.ValidateAsync(request, cancellationToken).ConfigureAwait(false);
+            if (result.Errors.Count > 0)
             {
-                var result = await validator.ValidateAsync(request, cancellationToken).ConfigureAwait(false);
-                failures.AddRange(result.Errors);
+                (failures ??= []).AddRange(result.Errors);
             }
+        }
 
-            if (failures.Count > 0)
-            {
-                throw new ValidationException(failures);
-            }
+        if (failures is { Count: > 0 })
+        {
+            throw new ValidationException(failures);
         }
 
         await foreach (


### PR DESCRIPTION
## Problem

Both FluentValidation interceptors materialized the resolved validators via `.ToList()` on every request:

- `FluentValidationRequestInterceptor.HandleAsync`
- `FluentValidationStreamQueryInterceptor.HandleCoreAsync`

`GetServices<T>()` already returns a realized enumerable; the `.ToList()` call was an avoidable per-request allocation used only to check "any validators" before iterating.

## Fix

Enumerate the resolved validators directly with `foreach` instead of materializing a `List<T>` copy. The failures collection is now lazily allocated only when a validator actually reports failures, avoiding an unconditional `List<ValidationFailure>` allocation on the happy path as well.

Behavior is unchanged:
- No validators registered: passes through to the handler without error.
- All validators run, and their failures are aggregated.
- Any failures cause a `ValidationException` before the handler runs (or before stream enumeration starts).
- All validators pass: request/stream forwards to the handler unchanged.

## Testing

- `dotnet build Pulse.slnx -c Release` — succeeded.
- `dotnet test tests/NetEvolve.Pulse.Tests.Unit/NetEvolve.Pulse.Tests.Unit.csproj -c Release` — all TFMs (net8.0, net9.0, net10.0) green, 4278 tests passed, 0 failed.