### PR TITLE
perf(cosmosdb): delete completed outbox documents with bounded concurrency

### DIFF
--- a/src/NetEvolve.Pulse.CosmosDb/Outbox/CosmosDbOutboxRepository.cs
+++ b/src/NetEvolve.Pulse.CosmosDb/Outbox/CosmosDbOutboxRepository.cs
@@ -258,6 +258,13 @@ internal sealed class CosmosDbOutboxRepository : IOutboxRepository
         return count;
     }
 
+    /// <summary>
+    /// Upper bound on the number of concurrent <c>DeleteItemAsync</c> calls issued by
+    /// <see cref="DeleteCompletedAsync"/>. Kept small and conservative to avoid overwhelming the
+    /// container's provisioned throughput while still avoiding fully sequential round trips.
+    /// </summary>
+    private const int MaxDeleteConcurrency = 8;
+
     /// <inheritdoc />
     public async Task<int> DeleteCompletedAsync(TimeSpan olderThan, CancellationToken cancellationToken = default)
     {
@@ -278,25 +285,35 @@ internal sealed class CosmosDbOutboxRepository : IOutboxRepository
         {
             var page = await iterator.ReadNextAsync(cancellationToken).ConfigureAwait(false);
 
-            foreach (var itemId in page.Select(x => x.Id))
-            {
-                try
-                {
-                    _ = await _container
-                        .DeleteItemAsync<CosmosDbOutboxDocument>(
-                            itemId,
-                            new PartitionKey(itemId),
-                            cancellationToken: cancellationToken
-                        )
-                        .ConfigureAwait(false);
+            await Parallel
+                .ForEachAsync(
+                    page.Select(x => x.Id),
+                    new ParallelOptions
+                    {
+                        MaxDegreeOfParallelism = MaxDeleteConcurrency,
+                        CancellationToken = cancellationToken,
+                    },
+                    async (itemId, itemCancellationToken) =>
+                    {
+                        try
+                        {
+                            _ = await _container
+                                .DeleteItemAsync<CosmosDbOutboxDocument>(
+                                    itemId,
+                                    new PartitionKey(itemId),
+                                    cancellationToken: itemCancellationToken
+                                )
+                                .ConfigureAwait(false);
 
-                    deleted++;
-                }
-                catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
-                {
-                    // Already deleted by another worker — ignore.
-                }
-            }
+                            _ = Interlocked.Increment(ref deleted);
+                        }
+                        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+                        {
+                            // Already deleted by another worker — ignore.
+                        }
+                    }
+                )
+                .ConfigureAwait(false);
         }
 
         return deleted;
@@ -409,7 +426,11 @@ internal sealed class CosmosDbOutboxRepository : IOutboxRepository
     /// <summary>
     /// Minimal projection used when querying only the document <c>id</c> field.
     /// </summary>
-    private sealed class IdProjection
+    /// <remarks>
+    /// Internal (rather than private) so unit tests can construct fake query results of this
+    /// exact shape without going through a live Cosmos DB query.
+    /// </remarks>
+    internal sealed class IdProjection
     {
         [System.Text.Json.Serialization.JsonPropertyName("id")]
         [JsonProperty("id")]

--- a/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxRepositoryDeleteCompletedTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxRepositoryDeleteCompletedTests.cs
@@ -1,0 +1,133 @@
+namespace NetEvolve.Pulse.Tests.Unit.CosmosDb;
+
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("CosmosDb")]
+public sealed class CosmosDbOutboxRepositoryDeleteCompletedTests
+{
+    [Test]
+    public async Task DeleteCompletedAsync_WithMultipleCandidates_DeletesEachQualifyingDocument(
+        CancellationToken cancellationToken
+    )
+    {
+        var expectedIds = Enumerable.Range(0, 25).Select(_ => Guid.NewGuid().ToString()).ToList();
+        var deletedIds = new ConcurrentBag<string>();
+
+        var container = new FakeCosmosContainer
+        {
+            OnQueryIterator = (_, _, _) =>
+                new FakeFeedIterator<CosmosDbOutboxRepository.IdProjection>([
+                    [.. expectedIds.Select(id => new CosmosDbOutboxRepository.IdProjection { Id = id })],
+                ]),
+            OnDeleteItem = (id, _) =>
+            {
+                deletedIds.Add(id);
+                return new FakeItemResponse<CosmosDbOutboxDocument>(CreateDocument(id));
+            },
+        };
+
+        var repository = CreateRepository(container);
+
+        var deletedCount = await repository
+            .DeleteCompletedAsync(TimeSpan.Zero, cancellationToken)
+            .ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(deletedCount).IsEqualTo(expectedIds.Count);
+            _ = await Assert.That(deletedIds.Count).IsEqualTo(expectedIds.Count);
+            _ = await Assert.That(deletedIds.Distinct().Count()).IsEqualTo(expectedIds.Count);
+            _ = await Assert.That(deletedIds.OrderBy(x => x)).IsEquivalentTo(expectedIds.OrderBy(x => x));
+        }
+    }
+
+    [Test]
+    public async Task DeleteCompletedAsync_WithNoCandidates_ReturnsZeroWithoutDeleting(
+        CancellationToken cancellationToken
+    )
+    {
+        var deleteCalls = 0;
+
+        var container = new FakeCosmosContainer
+        {
+            OnQueryIterator = (_, _, _) => new FakeFeedIterator<CosmosDbOutboxRepository.IdProjection>([]),
+            OnDeleteItem = (id, partitionKey) =>
+            {
+                _ = Interlocked.Increment(ref deleteCalls);
+                return new FakeItemResponse<CosmosDbOutboxDocument>(CreateDocument(id));
+            },
+        };
+
+        var repository = CreateRepository(container);
+
+        var deletedCount = await repository
+            .DeleteCompletedAsync(TimeSpan.Zero, cancellationToken)
+            .ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(deletedCount).IsEqualTo(0);
+            _ = await Assert.That(deleteCalls).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task DeleteCompletedAsync_WithCanceledToken_ThrowsOperationCanceledException()
+    {
+        var deleteCalls = 0;
+
+        var container = new FakeCosmosContainer
+        {
+            OnQueryIterator = (_, _, _) =>
+                new FakeFeedIterator<CosmosDbOutboxRepository.IdProjection>([
+                    [new CosmosDbOutboxRepository.IdProjection { Id = Guid.NewGuid().ToString() }],
+                ]),
+            OnDeleteItem = (id, partitionKey) =>
+            {
+                _ = Interlocked.Increment(ref deleteCalls);
+                return new FakeItemResponse<CosmosDbOutboxDocument>(CreateDocument(id));
+            },
+        };
+
+        var repository = CreateRepository(container);
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        _ = await Assert
+            .That(() => repository.DeleteCompletedAsync(TimeSpan.Zero, cts.Token))
+            .Throws<OperationCanceledException>();
+
+        _ = await Assert.That(deleteCalls).IsEqualTo(0);
+    }
+
+    private static CosmosDbOutboxDocument CreateDocument(string id) =>
+        new CosmosDbOutboxDocument
+        {
+            Id = id,
+            EventType = typeof(string).AssemblyQualifiedName!,
+            Payload = "{}",
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Status = 2,
+        };
+
+    private static CosmosDbOutboxRepository CreateRepository(FakeCosmosContainer container)
+    {
+        using var client = new FakeCosmosClient(container);
+
+        return new CosmosDbOutboxRepository(
+            client,
+            Options.Create(new CosmosDbOutboxOptions { DatabaseName = "TestDb" }),
+            TimeProvider.System
+        );
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/FakeCosmosContainer.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/FakeCosmosContainer.cs
@@ -142,10 +142,14 @@ internal sealed class FakeCosmosContainer : Container
         PartitionKey partitionKey,
         ItemRequestOptions? requestOptions = null,
         CancellationToken cancellationToken = default
-    ) =>
-        OnDeleteItem is null
+    )
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return OnDeleteItem is null
             ? throw new NotImplementedException()
             : Task.FromResult((ItemResponse<T>)OnDeleteItem(id, partitionKey));
+    }
 
     public override Task<ResponseMessage> CreateItemStreamAsync(
         Stream streamPayload,


### PR DESCRIPTION
## Problem

`CosmosDbOutboxRepository.DeleteCompletedAsync` deleted qualifying completed outbox documents one at a time in a sequential loop, fully awaiting each `DeleteItemAsync` round trip before starting the next. When TTL-based cleanup is disabled, this is the only pruning path for completed documents, so a large backlog serializes thousands of Cosmos DB round trips.

## Fix

Delete documents with bounded concurrency using `Parallel.ForEachAsync` with a conservative `MaxDegreeOfParallelism` of 8, instead of a purely sequential `foreach`. Behavior is preserved exactly:

- Same document set is deleted (the `olderThan`/status filter and query are unchanged).
- Same partition-key usage per delete (`new PartitionKey(itemId)`).
- Same not-found handling (a `CosmosException` with `HttpStatusCode.NotFound` is swallowed per item, treated as already deleted by another worker).
- The provided `CancellationToken` is respected, both for the per-item delete and by `Parallel.ForEachAsync`'s own cancellation check.
- Method signature and return value (`Task<int>` count of deleted documents) are unchanged.

The `IdProjection` nested type was widened from `private` to `internal` so unit tests can construct fake query results of the exact shape the repository queries for, without needing a live Cosmos DB connection.

## Testing

Added `CosmosDbOutboxRepositoryDeleteCompletedTests` in `tests/NetEvolve.Pulse.Tests.Unit/CosmosDb`, reusing the existing `FakeCosmosContainer`/`FakeCosmosClient`/`FakeFeedIterator` test doubles:

- `DeleteCompletedAsync_WithMultipleCandidates_DeletesEachQualifyingDocument` — asserts a `DeleteItemAsync` call is issued for every qualifying document, with the correct count and correct ids (no duplicates, no omissions).
- `DeleteCompletedAsync_WithNoCandidates_ReturnsZeroWithoutDeleting` — asserts no deletes are issued when there are no candidates.
- `DeleteCompletedAsync_WithCanceledToken_ThrowsOperationCanceledException` — asserts an already-cancelled token is honored and no delete is issued.

Also updated the shared `FakeCosmosContainer.DeleteItemAsync` test double to honor `CancellationToken.ThrowIfCancellationRequested()`, matching real Cosmos SDK behavior; this makes the cancellation test a genuine behavior guard (it fails against the prior sequential implementation too, not just a change detector for the new concurrent code).

- [x] `dotnet build Pulse.slnx -c Release` — 0 errors, 0 warnings
- [x] `dotnet test tests/NetEvolve.Pulse.Tests.Unit/NetEvolve.Pulse.Tests.Unit.csproj -c Release` — all three TFMs (net8.0, net9.0, net10.0) green, 4287 total tests passed, 0 failed