### PR TITLE
perf(cosmosdb): cache event type resolution in document mapping

### DIFF
--- a/src/NetEvolve.Pulse.CosmosDb/Outbox/CosmosDbOutboxDocument.cs
+++ b/src/NetEvolve.Pulse.CosmosDb/Outbox/CosmosDbOutboxDocument.cs
@@ -1,5 +1,6 @@
 ﻿namespace NetEvolve.Pulse.Outbox;
 
+using System.Collections.Concurrent;
 using System.Text.Json.Serialization;
 using NetEvolve.Pulse.Extensibility.Outbox;
 using Newtonsoft.Json;
@@ -15,6 +16,13 @@ using Newtonsoft.Json;
 /// </remarks>
 internal sealed class CosmosDbOutboxDocument
 {
+    /// <summary>
+    /// Caches resolved event types by their persisted type name, since <see cref="Type.GetType(string, bool)"/>
+    /// parses the assembly-qualified name and probes loaded assemblies on every call. Only successful
+    /// resolutions are cached; unresolvable names keep failing on each encounter.
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, Type> _eventTypeCache = new(StringComparer.Ordinal);
+
     /// <summary>
     /// Gets or sets the Cosmos DB document identifier, mapped from <see cref="OutboxMessage.Id"/>.
     /// </summary>
@@ -126,7 +134,7 @@ internal sealed class CosmosDbOutboxDocument
         new OutboxMessage
         {
             Id = Guid.Parse(Id),
-            EventType = Type.GetType(EventType, throwOnError: false) ?? typeof(object),
+            EventType = ResolveEventType(EventType),
             Payload = Payload,
             CorrelationId = CorrelationId,
             CausationId = CausationId,
@@ -138,6 +146,29 @@ internal sealed class CosmosDbOutboxDocument
             Error = Error,
             Status = (OutboxMessageStatus)Status,
         };
+
+    /// <summary>
+    /// Resolves the event <see cref="Type"/> for the given persisted type name, using a cache to avoid
+    /// repeated reflection lookups for the same name. Falls back to <see cref="object"/> when the type
+    /// name cannot be resolved.
+    /// </summary>
+    /// <param name="eventTypeName">The persisted, assembly-qualified event type name.</param>
+    /// <returns>The resolved event <see cref="Type"/>, or <see cref="object"/> when unresolvable.</returns>
+    private static Type ResolveEventType(string eventTypeName)
+    {
+        if (_eventTypeCache.TryGetValue(eventTypeName, out var eventType))
+        {
+            return eventType;
+        }
+
+        var resolved = Type.GetType(eventTypeName, throwOnError: false);
+        if (resolved is null)
+        {
+            return typeof(object);
+        }
+
+        return _eventTypeCache.GetOrAdd(eventTypeName, resolved);
+    }
 
     /// <summary>
     /// Creates a <see cref="CosmosDbOutboxDocument"/> from an <see cref="OutboxMessage"/>.

--- a/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxDocumentTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxDocumentTests.cs
@@ -121,4 +121,42 @@ public sealed class CosmosDbOutboxDocumentTests
         // DeadLetter = 4
         _ = await Assert.That(json).Contains("\"status\":4");
     }
+
+    // INVARIANT: ToOutboxMessage resolves a known, assembly-qualified event type name to the
+    // actual Type. Called twice with the same input to exercise the cached lookup path and
+    // ensure both calls agree on the resolved Type.
+    [Test]
+    public async Task ToOutboxMessage_Resolves_Known_EventType()
+    {
+        var doc = CosmosDbOutboxDocument.FromOutboxMessage(CreateMessage());
+
+        var first = doc.ToOutboxMessage();
+        var second = doc.ToOutboxMessage();
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(first.EventType).IsEqualTo(typeof(SampleEvent));
+            _ = await Assert.That(second.EventType).IsEqualTo(typeof(SampleEvent));
+            _ = await Assert.That(second.EventType).IsEqualTo(first.EventType);
+        }
+    }
+
+    // INVARIANT: An unresolvable/garbage event type name falls back to typeof(object), both
+    // on first lookup and on any subsequent lookup for the same garbage name (unresolvable
+    // names are never cached, so this must keep failing gracefully every time).
+    [Test]
+    public async Task ToOutboxMessage_With_Unknown_EventType_Falls_Back_To_Object()
+    {
+        var doc = CosmosDbOutboxDocument.FromOutboxMessage(CreateMessage());
+        doc.EventType = "Totally.Bogus.Type, Totally.Bogus.Assembly";
+
+        var first = doc.ToOutboxMessage();
+        var second = doc.ToOutboxMessage();
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(first.EventType).IsEqualTo(typeof(object));
+            _ = await Assert.That(second.EventType).IsEqualTo(typeof(object));
+        }
+    }
 }


### PR DESCRIPTION
## Problem

`CosmosDbOutboxDocument.ToOutboxMessage()` called `Type.GetType(EventType, throwOnError: false)` uncached on every document conversion, once per document per page for pending/failed/claim/management reads. This repeats assembly-qualified name parsing and assembly probing for the same event-type strings on every read.

The MongoDB outbox mapper already avoids this via a `ConcurrentDictionary<string, Type>` cache (`OutboxDocumentMapper.ResolveEventType`).

## Fix

Added a static `ConcurrentDictionary<string, Type>` cache to `CosmosDbOutboxDocument`, mirroring the MongoDB mapper's pattern, and route `EventType` resolution in `ToOutboxMessage()` through a new `ResolveEventType` helper. Behavior is preserved exactly:
- Resolvable type names are resolved once and cached for subsequent lookups.
- Unresolvable/garbage type names fall back to `typeof(object)`, same as before, and are never cached (so they keep being re-attempted, matching prior behavior).

No change to the outbox message shape or any other logic.

## Testing

Added two deterministic unit tests in `tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxDocumentTests.cs`:
- `ToOutboxMessage_Resolves_Known_EventType` — resolves a known event type name to the correct `Type`, called twice to exercise the cache path.
- `ToOutboxMessage_With_Unknown_EventType_Falls_Back_To_Object` — asserts a garbage type name falls back to `typeof(object)` consistently across repeated calls.

`dotnet build Pulse.slnx -c Release` and `dotnet test tests/NetEvolve.Pulse.Tests.Unit/NetEvolve.Pulse.Tests.Unit.csproj -c Release` both pass: 4287 tests, 0 failed, across net8.0/net9.0/net10.0.