### PR TITLE
chore(stryker): sync test-projects list with actual test tree

### DIFF
--- a/stryker-config.json
+++ b/stryker-config.json
@@ -19,12 +19,7 @@
     "test-projects": [
       "tests/NetEvolve.Pulse.Tests.Unit/NetEvolve.Pulse.Tests.Unit.csproj",
       "tests/NetEvolve.Pulse.Tests.Integration/NetEvolve.Pulse.Tests.Integration.csproj",
-      "tests/NetEvolve.Pulse.EntityFramework.Tests.Unit/NetEvolve.Pulse.EntityFramework.Tests.Unit.csproj",
-      "tests/NetEvolve.Pulse.EntityFramework.Tests.Integration/NetEvolve.Pulse.EntityFramework.Tests.Integration.csproj",
-      "tests/NetEvolve.Pulse.Polly.Tests.Unit/NetEvolve.Pulse.Polly.Tests.Unit.csproj",
-      "tests/NetEvolve.Pulse.Polly.Tests.Integration/NetEvolve.Pulse.Polly.Tests.Integration.csproj",
-      "tests/NetEvolve.Pulse.SqlServer.Tests.Unit/NetEvolve.Pulse.SqlServer.Tests.Unit.csproj",
-      "tests/NetEvolve.Pulse.SqlServer.Tests.Integration/NetEvolve.Pulse.SqlServer.Tests.Integration.csproj"
+      "tests/NetEvolve.Pulse.SourceGeneration.Tests.Unit/NetEvolve.Pulse.SourceGeneration.Tests.Unit.csproj"
     ],
     "coverage-analysis": "perTest",
     "mutate": [


### PR DESCRIPTION
## Summary
- Removed test-project entries for EntityFramework, Polly, and SqlServer — those projects no longer exist in the repo.
- Added the missing `NetEvolve.Pulse.SourceGeneration.Tests.Unit` project.

## Test plan
- [ ] Trigger the mutation workflow manually to confirm Stryker picks up the correct test projects.