### PR TITLE
test: close low-coverage gaps in outbox, idempotency, and EF configuration types

### DIFF
--- a/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/BulkOutboxManagementExecutorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/BulkOutboxManagementExecutorTests.cs
@@ -1,0 +1,407 @@
+namespace NetEvolve.Pulse.Tests.Unit.EntityFramework;
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility.Outbox;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("EntityFramework")]
+public sealed class BulkOutboxManagementExecutorTests
+{
+    [Test]
+    public async Task GetDeadLetterMessages_ReturnsOnlyDeadLetterRows_OrderedAndPaged(
+        CancellationToken cancellationToken
+    )
+    {
+        var connectionString =
+            "Data Source=BulkOutboxMgmtGetDeadLetterMessages;Mode=Memory;Cache=Shared;Foreign Keys=False;Pooling=False";
+
+        var keeperConnection = new SqliteConnection(connectionString);
+        await using (keeperConnection.ConfigureAwait(false))
+        {
+            await keeperConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            var options = new DbContextOptionsBuilder<TestDbContext>().UseSqlite(connectionString).Options;
+            var context = new TestDbContext(options);
+            await using (context.ConfigureAwait(false))
+            {
+                _ = await context.Database.EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+
+                var baseTime = DateTimeOffset.UtcNow.AddMinutes(-30);
+
+                var deadLetter1 = CreateMessage(OutboxMessageStatus.DeadLetter, baseTime.AddMinutes(1));
+                var deadLetter2 = CreateMessage(OutboxMessageStatus.DeadLetter, baseTime.AddMinutes(2));
+                var deadLetter3 = CreateMessage(OutboxMessageStatus.DeadLetter, baseTime.AddMinutes(3));
+                var pending = CreateMessage(OutboxMessageStatus.Pending, baseTime.AddMinutes(4));
+
+                await context
+                    .OutboxMessages.AddRangeAsync([deadLetter1, deadLetter2, deadLetter3, pending], cancellationToken)
+                    .ConfigureAwait(false);
+                _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                context.ChangeTracker.Clear();
+
+                var executor = new BulkOutboxManagementExecutor<TestDbContext>(context);
+
+                var allDeadLetter = await executor
+                    .GetDeadLetterMessages(0, 10)
+                    .ToListAsync(cancellationToken)
+                    .ConfigureAwait(false);
+
+                var paged = await executor
+                    .GetDeadLetterMessages(1, 1)
+                    .ToListAsync(cancellationToken)
+                    .ConfigureAwait(false);
+
+                using (Assert.Multiple())
+                {
+                    _ = await Assert.That(allDeadLetter).HasCount().EqualTo(3);
+                    _ = await Assert.That(allDeadLetter[0].Id).IsEqualTo(deadLetter3.Id);
+                    _ = await Assert.That(allDeadLetter[1].Id).IsEqualTo(deadLetter2.Id);
+                    _ = await Assert.That(allDeadLetter[2].Id).IsEqualTo(deadLetter1.Id);
+                    _ = await Assert.That(paged).HasCount().EqualTo(1);
+                    _ = await Assert.That(paged[0].Id).IsEqualTo(deadLetter2.Id);
+                }
+            }
+        }
+    }
+
+    [Test]
+    public async Task GetDeadLetterMessageAsync_WhenDeadLetter_ReturnsMessage(CancellationToken cancellationToken)
+    {
+        var connectionString =
+            "Data Source=BulkOutboxMgmtGetDeadLetterMessageFound;Mode=Memory;Cache=Shared;Foreign Keys=False;Pooling=False";
+
+        var keeperConnection = new SqliteConnection(connectionString);
+        await using (keeperConnection.ConfigureAwait(false))
+        {
+            await keeperConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            var options = new DbContextOptionsBuilder<TestDbContext>().UseSqlite(connectionString).Options;
+            var context = new TestDbContext(options);
+            await using (context.ConfigureAwait(false))
+            {
+                _ = await context.Database.EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+
+                var message = CreateMessage(OutboxMessageStatus.DeadLetter, DateTimeOffset.UtcNow);
+                _ = await context.OutboxMessages.AddAsync(message, cancellationToken).ConfigureAwait(false);
+                _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                context.ChangeTracker.Clear();
+
+                var executor = new BulkOutboxManagementExecutor<TestDbContext>(context);
+
+                var result = await executor
+                    .GetDeadLetterMessageAsync(message.Id, cancellationToken)
+                    .ConfigureAwait(false);
+
+                using (Assert.Multiple())
+                {
+                    _ = await Assert.That(result).IsNotNull();
+                    _ = await Assert.That(result!.Id).IsEqualTo(message.Id);
+                    _ = await Assert.That(result.Status).IsEqualTo(OutboxMessageStatus.DeadLetter);
+                }
+            }
+        }
+    }
+
+    [Test]
+    public async Task GetDeadLetterMessageAsync_WhenIdDoesNotExist_ReturnsNull(CancellationToken cancellationToken)
+    {
+        var connectionString =
+            "Data Source=BulkOutboxMgmtGetDeadLetterMessageMissing;Mode=Memory;Cache=Shared;Foreign Keys=False;Pooling=False";
+
+        var keeperConnection = new SqliteConnection(connectionString);
+        await using (keeperConnection.ConfigureAwait(false))
+        {
+            await keeperConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            var options = new DbContextOptionsBuilder<TestDbContext>().UseSqlite(connectionString).Options;
+            var context = new TestDbContext(options);
+            await using (context.ConfigureAwait(false))
+            {
+                _ = await context.Database.EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+
+                var executor = new BulkOutboxManagementExecutor<TestDbContext>(context);
+
+                var result = await executor
+                    .GetDeadLetterMessageAsync(Guid.NewGuid(), cancellationToken)
+                    .ConfigureAwait(false);
+
+                _ = await Assert.That(result).IsNull();
+            }
+        }
+    }
+
+    [Test]
+    public async Task GetDeadLetterMessageAsync_WhenMessageNotDeadLetter_ReturnsNull(
+        CancellationToken cancellationToken
+    )
+    {
+        var connectionString =
+            "Data Source=BulkOutboxMgmtGetDeadLetterMessageWrongStatus;Mode=Memory;Cache=Shared;Foreign Keys=False;Pooling=False";
+
+        var keeperConnection = new SqliteConnection(connectionString);
+        await using (keeperConnection.ConfigureAwait(false))
+        {
+            await keeperConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            var options = new DbContextOptionsBuilder<TestDbContext>().UseSqlite(connectionString).Options;
+            var context = new TestDbContext(options);
+            await using (context.ConfigureAwait(false))
+            {
+                _ = await context.Database.EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+
+                var message = CreateMessage(OutboxMessageStatus.Pending, DateTimeOffset.UtcNow);
+                _ = await context.OutboxMessages.AddAsync(message, cancellationToken).ConfigureAwait(false);
+                _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                context.ChangeTracker.Clear();
+
+                var executor = new BulkOutboxManagementExecutor<TestDbContext>(context);
+
+                var result = await executor
+                    .GetDeadLetterMessageAsync(message.Id, cancellationToken)
+                    .ConfigureAwait(false);
+
+                _ = await Assert.That(result).IsNull();
+            }
+        }
+    }
+
+    [Test]
+    public async Task ReplayByIdAsync_WhenDeadLetter_ResetsMessageAndReturnsTrue(CancellationToken cancellationToken)
+    {
+        var connectionString =
+            "Data Source=BulkOutboxMgmtReplayByIdFound;Mode=Memory;Cache=Shared;Foreign Keys=False;Pooling=False";
+
+        var keeperConnection = new SqliteConnection(connectionString);
+        await using (keeperConnection.ConfigureAwait(false))
+        {
+            await keeperConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            var options = new DbContextOptionsBuilder<TestDbContext>().UseSqlite(connectionString).Options;
+            var context = new TestDbContext(options);
+            await using (context.ConfigureAwait(false))
+            {
+                _ = await context.Database.EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+
+                var message = CreateMessage(OutboxMessageStatus.DeadLetter, DateTimeOffset.UtcNow.AddMinutes(-10));
+                message.RetryCount = 5;
+                message.Error = "boom";
+                _ = await context.OutboxMessages.AddAsync(message, cancellationToken).ConfigureAwait(false);
+                _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                context.ChangeTracker.Clear();
+
+                var executor = new BulkOutboxManagementExecutor<TestDbContext>(context);
+
+                var updatedAt = DateTimeOffset.UtcNow;
+                var replayed = await executor
+                    .ReplayByIdAsync(message.Id, updatedAt, cancellationToken)
+                    .ConfigureAwait(false);
+
+                var stored = await context
+                    .OutboxMessages.AsNoTracking()
+                    .SingleAsync(m => m.Id == message.Id, cancellationToken)
+                    .ConfigureAwait(false);
+
+                using (Assert.Multiple())
+                {
+                    _ = await Assert.That(replayed).IsTrue();
+                    _ = await Assert.That(stored.Status).IsEqualTo(OutboxMessageStatus.Pending);
+                    _ = await Assert.That(stored.RetryCount).IsEqualTo(0);
+                    _ = await Assert.That(stored.Error).IsNull();
+                    _ = await Assert.That(stored.UpdatedAt).IsEqualTo(updatedAt);
+                }
+            }
+        }
+    }
+
+    [Test]
+    public async Task ReplayByIdAsync_WhenIdDoesNotExist_ReturnsFalse(CancellationToken cancellationToken)
+    {
+        var connectionString =
+            "Data Source=BulkOutboxMgmtReplayByIdMissing;Mode=Memory;Cache=Shared;Foreign Keys=False;Pooling=False";
+
+        var keeperConnection = new SqliteConnection(connectionString);
+        await using (keeperConnection.ConfigureAwait(false))
+        {
+            await keeperConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            var options = new DbContextOptionsBuilder<TestDbContext>().UseSqlite(connectionString).Options;
+            var context = new TestDbContext(options);
+            await using (context.ConfigureAwait(false))
+            {
+                _ = await context.Database.EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+
+                var executor = new BulkOutboxManagementExecutor<TestDbContext>(context);
+
+                var replayed = await executor
+                    .ReplayByIdAsync(Guid.NewGuid(), DateTimeOffset.UtcNow, cancellationToken)
+                    .ConfigureAwait(false);
+
+                _ = await Assert.That(replayed).IsFalse();
+            }
+        }
+    }
+
+    [Test]
+    public async Task ReplayByIdAsync_WhenMessageNotDeadLetter_ReturnsFalseAndDoesNotChange(
+        CancellationToken cancellationToken
+    )
+    {
+        var connectionString =
+            "Data Source=BulkOutboxMgmtReplayByIdWrongStatus;Mode=Memory;Cache=Shared;Foreign Keys=False;Pooling=False";
+
+        var keeperConnection = new SqliteConnection(connectionString);
+        await using (keeperConnection.ConfigureAwait(false))
+        {
+            await keeperConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            var options = new DbContextOptionsBuilder<TestDbContext>().UseSqlite(connectionString).Options;
+            var context = new TestDbContext(options);
+            await using (context.ConfigureAwait(false))
+            {
+                _ = await context.Database.EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+
+                var message = CreateMessage(OutboxMessageStatus.Completed, DateTimeOffset.UtcNow.AddMinutes(-10));
+                message.RetryCount = 2;
+                _ = await context.OutboxMessages.AddAsync(message, cancellationToken).ConfigureAwait(false);
+                _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                context.ChangeTracker.Clear();
+
+                var executor = new BulkOutboxManagementExecutor<TestDbContext>(context);
+
+                var replayed = await executor
+                    .ReplayByIdAsync(message.Id, DateTimeOffset.UtcNow, cancellationToken)
+                    .ConfigureAwait(false);
+
+                var stored = await context
+                    .OutboxMessages.AsNoTracking()
+                    .SingleAsync(m => m.Id == message.Id, cancellationToken)
+                    .ConfigureAwait(false);
+
+                using (Assert.Multiple())
+                {
+                    _ = await Assert.That(replayed).IsFalse();
+                    _ = await Assert.That(stored.Status).IsEqualTo(OutboxMessageStatus.Completed);
+                    _ = await Assert.That(stored.RetryCount).IsEqualTo(2);
+                }
+            }
+        }
+    }
+
+    [Test]
+    public async Task ReplayAllAsync_ResetsAllDeadLetterMessages_AndReturnsCount(CancellationToken cancellationToken)
+    {
+        var connectionString =
+            "Data Source=BulkOutboxMgmtReplayAllFound;Mode=Memory;Cache=Shared;Foreign Keys=False;Pooling=False";
+
+        var keeperConnection = new SqliteConnection(connectionString);
+        await using (keeperConnection.ConfigureAwait(false))
+        {
+            await keeperConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            var options = new DbContextOptionsBuilder<TestDbContext>().UseSqlite(connectionString).Options;
+            var context = new TestDbContext(options);
+            await using (context.ConfigureAwait(false))
+            {
+                _ = await context.Database.EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+
+                var deadLetter1 = CreateMessage(OutboxMessageStatus.DeadLetter, DateTimeOffset.UtcNow.AddMinutes(-10));
+                deadLetter1.RetryCount = 3;
+                deadLetter1.Error = "err1";
+                var deadLetter2 = CreateMessage(OutboxMessageStatus.DeadLetter, DateTimeOffset.UtcNow.AddMinutes(-5));
+                deadLetter2.RetryCount = 7;
+                deadLetter2.Error = "err2";
+                var pending = CreateMessage(OutboxMessageStatus.Pending, DateTimeOffset.UtcNow);
+
+                await context
+                    .OutboxMessages.AddRangeAsync([deadLetter1, deadLetter2, pending], cancellationToken)
+                    .ConfigureAwait(false);
+                _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                context.ChangeTracker.Clear();
+
+                var executor = new BulkOutboxManagementExecutor<TestDbContext>(context);
+
+                var updatedAt = DateTimeOffset.UtcNow;
+                var replayedCount = await executor.ReplayAllAsync(updatedAt, cancellationToken).ConfigureAwait(false);
+
+                var stored = await context
+                    .OutboxMessages.AsNoTracking()
+                    .OrderBy(m => m.Id)
+                    .ToListAsync(cancellationToken)
+                    .ConfigureAwait(false);
+
+                var storedDeadLetter1 = stored.Single(m => m.Id == deadLetter1.Id);
+                var storedDeadLetter2 = stored.Single(m => m.Id == deadLetter2.Id);
+                var storedPending = stored.Single(m => m.Id == pending.Id);
+
+                using (Assert.Multiple())
+                {
+                    _ = await Assert.That(replayedCount).IsEqualTo(2);
+
+                    _ = await Assert.That(storedDeadLetter1.Status).IsEqualTo(OutboxMessageStatus.Pending);
+                    _ = await Assert.That(storedDeadLetter1.RetryCount).IsEqualTo(0);
+                    _ = await Assert.That(storedDeadLetter1.Error).IsNull();
+                    _ = await Assert.That(storedDeadLetter1.UpdatedAt).IsEqualTo(updatedAt);
+
+                    _ = await Assert.That(storedDeadLetter2.Status).IsEqualTo(OutboxMessageStatus.Pending);
+                    _ = await Assert.That(storedDeadLetter2.RetryCount).IsEqualTo(0);
+                    _ = await Assert.That(storedDeadLetter2.Error).IsNull();
+                    _ = await Assert.That(storedDeadLetter2.UpdatedAt).IsEqualTo(updatedAt);
+
+                    _ = await Assert.That(storedPending.Status).IsEqualTo(OutboxMessageStatus.Pending);
+                    _ = await Assert.That(storedPending.UpdatedAt).IsNotEqualTo(updatedAt);
+                }
+            }
+        }
+    }
+
+    [Test]
+    public async Task ReplayAllAsync_WhenNoDeadLetterMessages_ReturnsZero(CancellationToken cancellationToken)
+    {
+        var connectionString =
+            "Data Source=BulkOutboxMgmtReplayAllNone;Mode=Memory;Cache=Shared;Foreign Keys=False;Pooling=False";
+
+        var keeperConnection = new SqliteConnection(connectionString);
+        await using (keeperConnection.ConfigureAwait(false))
+        {
+            await keeperConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            var options = new DbContextOptionsBuilder<TestDbContext>().UseSqlite(connectionString).Options;
+            var context = new TestDbContext(options);
+            await using (context.ConfigureAwait(false))
+            {
+                _ = await context.Database.EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+
+                var pending = CreateMessage(OutboxMessageStatus.Pending, DateTimeOffset.UtcNow);
+                _ = await context.OutboxMessages.AddAsync(pending, cancellationToken).ConfigureAwait(false);
+                _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                context.ChangeTracker.Clear();
+
+                var executor = new BulkOutboxManagementExecutor<TestDbContext>(context);
+
+                var replayedCount = await executor
+                    .ReplayAllAsync(DateTimeOffset.UtcNow, cancellationToken)
+                    .ConfigureAwait(false);
+
+                _ = await Assert.That(replayedCount).IsEqualTo(0);
+            }
+        }
+    }
+
+    private static OutboxMessage CreateMessage(OutboxMessageStatus status, DateTimeOffset updatedAt) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            EventType = typeof(string),
+            Payload = "{}",
+            CreatedAt = updatedAt,
+            UpdatedAt = updatedAt,
+            Status = status,
+        };
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/EntityFrameworkOutboxTransactionScopeTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/EntityFrameworkOutboxTransactionScopeTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility.Outbox;
 using NetEvolve.Pulse.Outbox;
 using TUnit.Core;
 
@@ -45,6 +46,23 @@ public sealed class EntityFrameworkOutboxTransactionScopeTests
             var result = scope.GetCurrentTransaction();
 
             _ = await Assert.That(result).IsNull();
+        }
+    }
+
+    [Test]
+    public async Task HasActiveTransaction_WithNoActiveTransaction_ReturnsFalse()
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase(nameof(HasActiveTransaction_WithNoActiveTransaction_ReturnsFalse))
+            .Options;
+        var context = new TestDbContext(options);
+        await using (context.ConfigureAwait(false))
+        {
+            IOutboxTransactionScope scope = new EntityFrameworkOutboxTransactionScope<TestDbContext>(context);
+
+            var result = scope.HasActiveTransaction;
+
+            _ = await Assert.That(result).IsFalse();
         }
     }
 }

--- a/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/InMemoryIdempotencyKeyConfigurationTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/InMemoryIdempotencyKeyConfigurationTests.cs
@@ -1,0 +1,47 @@
+namespace NetEvolve.Pulse.Tests.Unit.EntityFramework;
+
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Configurations;
+using NetEvolve.Pulse.Idempotency;
+using TUnit.Core;
+
+[TestGroup("EntityFramework")]
+public sealed class InMemoryIdempotencyKeyConfigurationTests
+{
+    [Test]
+    public async Task Constructor_Parameterless_AppliesDefaultOptions()
+    {
+        var configuration = new InMemoryIdempotencyKeyConfiguration();
+        var modelBuilder = new ModelBuilder();
+
+        _ = modelBuilder.ApplyConfiguration(configuration);
+        var entityType = modelBuilder.Model.FindEntityType(typeof(IdempotencyKey));
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(entityType).IsNotNull();
+            _ = await Assert.That(entityType!.GetTableName()).IsEqualTo(new IdempotencyKeyOptions().TableName);
+        }
+    }
+
+    [Test]
+    public async Task Constructor_WithOptions_AppliesConfiguredOptions()
+    {
+        var options = Options.Create(new IdempotencyKeyOptions { Schema = "custom", TableName = "CustomKeys" });
+        var configuration = new InMemoryIdempotencyKeyConfiguration(options);
+        var modelBuilder = new ModelBuilder();
+
+        _ = modelBuilder.ApplyConfiguration(configuration);
+        var entityType = modelBuilder.Model.FindEntityType(typeof(IdempotencyKey));
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(entityType).IsNotNull();
+            _ = await Assert.That(entityType!.GetSchema()).IsEqualTo("custom");
+            _ = await Assert.That(entityType.GetTableName()).IsEqualTo("CustomKeys");
+        }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/InMemoryOutboxMessageConfigurationTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/InMemoryOutboxMessageConfigurationTests.cs
@@ -1,0 +1,48 @@
+namespace NetEvolve.Pulse.Tests.Unit.EntityFramework;
+
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Configurations;
+using NetEvolve.Pulse.Extensibility.Outbox;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("EntityFramework")]
+public sealed class InMemoryOutboxMessageConfigurationTests
+{
+    [Test]
+    public async Task Constructor_Parameterless_AppliesDefaultOptions()
+    {
+        var configuration = new InMemoryOutboxMessageConfiguration();
+        var modelBuilder = new ModelBuilder();
+
+        _ = modelBuilder.ApplyConfiguration(configuration);
+        var entityType = modelBuilder.Model.FindEntityType(typeof(OutboxMessage));
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(entityType).IsNotNull();
+            _ = await Assert.That(entityType!.GetTableName()).IsEqualTo(new OutboxOptions().TableName);
+        }
+    }
+
+    [Test]
+    public async Task Constructor_WithOptions_AppliesConfiguredOptions()
+    {
+        var options = Options.Create(new OutboxOptions { Schema = "custom", TableName = "CustomOutbox" });
+        var configuration = new InMemoryOutboxMessageConfiguration(options);
+        var modelBuilder = new ModelBuilder();
+
+        _ = modelBuilder.ApplyConfiguration(configuration);
+        var entityType = modelBuilder.Model.FindEntityType(typeof(OutboxMessage));
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(entityType).IsNotNull();
+            _ = await Assert.That(entityType!.GetSchema()).IsEqualTo("custom");
+            _ = await Assert.That(entityType.GetTableName()).IsEqualTo("CustomOutbox");
+        }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/TypeValueConverterTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/TypeValueConverterTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace NetEvolve.Pulse.Tests.Unit.EntityFramework;
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.Pulse.Configurations;
@@ -87,5 +88,29 @@ public sealed class TypeValueConverterTests
                 .That(() => fromProvider("Invalid.Repeated.Type, InvalidAssembly"))
                 .Throws<InvalidOperationException>();
         }
+    }
+
+    [Test]
+    public async Task ConvertToProvider_With_type_whose_assembly_qualified_name_exceeds_max_length_throws_InvalidOperationException()
+    {
+        var converter = new TypeValueConverter();
+        var toProvider = converter.ConvertToProvider;
+        var type = typeof(Dictionary<Dictionary<string, string>, List<Dictionary<string, List<string>>>>);
+
+        _ = await Assert.That(type.AssemblyQualifiedName!.Length).IsGreaterThan(500);
+
+        _ = await Assert.That(() => toProvider(type)).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task ConvertToProvider_With_open_generic_parameter_type_throws_InvalidOperationException()
+    {
+        var converter = new TypeValueConverter();
+        var toProvider = converter.ConvertToProvider;
+        var type = typeof(List<>).GetGenericArguments()[0];
+
+        _ = await Assert.That(type.AssemblyQualifiedName).IsNull();
+
+        _ = await Assert.That(() => toProvider(type)).Throws<InvalidOperationException>();
     }
 }

--- a/tests/NetEvolve.Pulse.Tests.Unit/Idempotency/IdempotencyConflictExceptionTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Idempotency/IdempotencyConflictExceptionTests.cs
@@ -1,0 +1,86 @@
+namespace NetEvolve.Pulse.Tests.Unit.Idempotency;
+
+using System;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Idempotency;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
+
+[TestGroup("Idempotency")]
+public sealed class IdempotencyConflictExceptionTests
+{
+    [Test]
+    public async Task Constructor_Parameterless_SetsDefaultMessageAndEmptyKey()
+    {
+        var exception = new IdempotencyConflictException();
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert
+                .That(exception.Message)
+                .IsEqualTo("A command with the given idempotency key has already been processed.");
+            _ = await Assert.That(exception.IdempotencyKey).IsEqualTo(string.Empty);
+            _ = await Assert.That(exception.InnerException).IsNull();
+        }
+    }
+
+    [Test]
+    public async Task Constructor_WithIdempotencyKey_SetsMessageAndKey()
+    {
+        var exception = new IdempotencyConflictException("key-123");
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert
+                .That(exception.Message)
+                .IsEqualTo("A command with idempotency key 'key-123' has already been processed.");
+            _ = await Assert.That(exception.IdempotencyKey).IsEqualTo("key-123");
+            _ = await Assert.That(exception.InnerException).IsNull();
+        }
+    }
+
+    [Test]
+    public async Task Constructor_WithIdempotencyKey_NullKey_ThrowsArgumentNullException() =>
+        _ = await Assert.That(() => new IdempotencyConflictException((string)null!)).Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Constructor_WithKeyMessageAndInnerException_SetsAllProperties()
+    {
+        var innerException = new InvalidOperationException("inner");
+
+        var exception = new IdempotencyConflictException("key-456", "custom message", innerException);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(exception.Message).IsEqualTo("custom message");
+            _ = await Assert.That(exception.IdempotencyKey).IsEqualTo("key-456");
+            _ = await Assert.That(exception.InnerException).IsSameReferenceAs(innerException);
+        }
+    }
+
+    [Test]
+    public async Task Constructor_WithKeyMessageAndInnerException_NullKey_ThrowsArgumentNullException()
+    {
+        var innerException = new InvalidOperationException("inner");
+
+        _ = await Assert
+            .That(() => new IdempotencyConflictException(null!, "custom message", innerException))
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Constructor_WithMessageAndInnerException_SetsMessageAndEmptyKey()
+    {
+        var innerException = new InvalidOperationException("inner");
+
+        var exception = new IdempotencyConflictException("custom message", innerException);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(exception.Message).IsEqualTo("custom message");
+            _ = await Assert.That(exception.IdempotencyKey).IsEqualTo(string.Empty);
+            _ = await Assert.That(exception.InnerException).IsSameReferenceAs(innerException);
+        }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxExtensionsTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using NetEvolve.Extensions.TUnit;
@@ -87,5 +88,129 @@ public sealed class OutboxExtensionsTests
             _ = await Assert.That(descriptor).IsNotNull();
             _ = await Assert.That(descriptor!.Lifetime).IsEqualTo(ServiceLifetime.Scoped);
         }
+    }
+
+    [Test]
+    public async Task UseMessageTransportGeneric_WithNullConfigurator_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() => OutboxExtensions.UseMessageTransport<FakeMessageTransport>(null!))
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task UseMessageTransportGeneric_WithNoExistingRegistration_AddsTransport()
+    {
+        var services = new ServiceCollection();
+        var builder = new MediatorBuilder(services);
+
+        _ = builder.UseMessageTransport<FakeMessageTransport>();
+
+        var descriptors = services.Where(d => d.ServiceType == typeof(IMessageTransport)).ToList();
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptors).HasSingleItem();
+            _ = await Assert.That(descriptors[0].ImplementationType).IsEqualTo(typeof(FakeMessageTransport));
+            _ = await Assert.That(descriptors[0].Lifetime).IsEqualTo(ServiceLifetime.Singleton);
+        }
+    }
+
+    [Test]
+    public async Task UseMessageTransportGeneric_WithExistingRegistration_ReplacesTransport()
+    {
+        var services = new ServiceCollection();
+        var builder = new MediatorBuilder(services);
+        _ = builder.AddOutbox();
+
+        _ = builder.UseMessageTransport<FakeMessageTransport>();
+
+        var descriptors = services.Where(d => d.ServiceType == typeof(IMessageTransport)).ToList();
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptors).HasSingleItem();
+            _ = await Assert.That(descriptors[0].ImplementationType).IsEqualTo(typeof(FakeMessageTransport));
+        }
+    }
+
+    [Test]
+    public async Task UseMessageTransportGeneric_ReturnsSameBuilder()
+    {
+        var services = new ServiceCollection();
+        var builder = new MediatorBuilder(services);
+
+        var result = builder.UseMessageTransport<FakeMessageTransport>();
+
+        _ = await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    [Test]
+    public async Task UseMessageTransportFactory_WithNullConfigurator_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() => OutboxExtensions.UseMessageTransport(null!, _ => new FakeMessageTransport()))
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task UseMessageTransportFactory_WithNullFactory_ThrowsArgumentNullException()
+    {
+        var services = new ServiceCollection();
+        var builder = new MediatorBuilder(services);
+
+        _ = await Assert
+            .That(() => OutboxExtensions.UseMessageTransport(builder, null!))
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task UseMessageTransportFactory_WithNoExistingRegistration_AddsTransport()
+    {
+        var services = new ServiceCollection();
+        var builder = new MediatorBuilder(services);
+
+        _ = builder.UseMessageTransport(_ => new FakeMessageTransport());
+
+        var descriptors = services.Where(d => d.ServiceType == typeof(IMessageTransport)).ToList();
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptors).HasSingleItem();
+            _ = await Assert.That(descriptors[0].Lifetime).IsEqualTo(ServiceLifetime.Singleton);
+        }
+    }
+
+    [Test]
+    public async Task UseMessageTransportFactory_WithExistingRegistration_ReplacesTransport()
+    {
+        var services = new ServiceCollection();
+        var builder = new MediatorBuilder(services);
+        _ = builder.AddOutbox();
+
+        _ = builder.UseMessageTransport(_ => new FakeMessageTransport());
+
+        var descriptors = services.Where(d => d.ServiceType == typeof(IMessageTransport)).ToList();
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptors).HasSingleItem();
+            _ = await Assert.That(descriptors[0].ImplementationFactory).IsNotNull();
+        }
+    }
+
+    [Test]
+    public async Task UseMessageTransportFactory_ReturnsSameBuilder()
+    {
+        var services = new ServiceCollection();
+        var builder = new MediatorBuilder(services);
+
+        var result = builder.UseMessageTransport(_ => new FakeMessageTransport());
+
+        _ = await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    private sealed class FakeMessageTransport : IMessageTransport
+    {
+        public Task SendAsync(OutboxMessage message, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
+        public Task<bool> IsHealthyAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
     }
 }


### PR DESCRIPTION
## Summary
- Adds a test for the `IOutboxTransactionScope.HasActiveTransaction` default interface member, which had no direct test coverage.
- Adds `BulkOutboxManagementExecutorTests`, covering dead-letter listing/lookup and replay logic that previously had zero unit tests (it requires `ExecuteUpdateAsync`, which only real relational providers support, so the tests use a SQLite in-memory shared-cache connection).
- Extends `OutboxExtensionsTests` with the untested branches of `UseMessageTransport` (both overloads): no prior registration vs. an existing registration being replaced, plus null-argument checks.
- Adds `IdempotencyConflictExceptionTests`, covering all four constructors and the `ArgumentNullException` cases.
- Adds tests for `InMemoryIdempotencyKeyConfiguration` and `InMemoryOutboxMessageConfiguration`, covering the previously-untested parameterless constructors.
- Extends `TypeValueConverterTests` with the max-length-exceeded and null-assembly-qualified-name error branches of `TypeValueConverter`.

## Test plan
- [x] `dotnet test tests/NetEvolve.Pulse.Tests.Unit/NetEvolve.Pulse.Tests.Unit.csproj` — 1473 tests passed (net8.0/net9.0/net10.0), 0 failed
- [x] `dotnet test tests/NetEvolve.Pulse.Tests.Integration/NetEvolve.Pulse.Tests.Integration.csproj -f net10.0` — 432 tests passed, 0 failed