### PR TITLE
fix: correct broken interceptor registrations and align coverage with per-package targets

### DIFF
--- a/src/NetEvolve.Pulse/ConcurrentCommandGuardExtensions.cs
+++ b/src/NetEvolve.Pulse/ConcurrentCommandGuardExtensions.cs
@@ -1,6 +1,7 @@
 namespace NetEvolve.Pulse;
 
 using System;
+using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using NetEvolve.Pulse.Extensibility;
@@ -101,7 +102,26 @@ public static class ConcurrentCommandGuardExtensions
 
         var services = configurator.Services;
 
-        services.TryAdd(ServiceDescriptor.Singleton(typeof(ConcurrentCommandGuardInterceptor<,>)));
+        // If the open-generic overload (AddConcurrentCommandGuard()) is already registered, it already
+        // resolves this closed TRequest/TResponse pair (singleton open-generic registrations are cached
+        // per closed type by the container) — adding a second, closed registration here would cause the
+        // command to be guarded by two independent interceptor instances instead of one shared instance.
+        var openGenericAlreadyRegistered = services.Any(d =>
+            d.ServiceType == typeof(IRequestInterceptor<,>)
+            && d.ImplementationType == typeof(ConcurrentCommandGuardInterceptor<,>)
+        );
+
+        if (openGenericAlreadyRegistered)
+        {
+            return configurator;
+        }
+
+        services.TryAdd(
+            ServiceDescriptor.Singleton(
+                typeof(ConcurrentCommandGuardInterceptor<,>),
+                typeof(ConcurrentCommandGuardInterceptor<,>)
+            )
+        );
         services.TryAddSingleton<IRequestInterceptor<TRequest, TResponse>>(sp =>
             sp.GetRequiredService<ConcurrentCommandGuardInterceptor<TRequest, TResponse>>()
         );

--- a/src/NetEvolve.Pulse/HandlerRegistrationExtensions.cs
+++ b/src/NetEvolve.Pulse/HandlerRegistrationExtensions.cs
@@ -319,7 +319,7 @@ public static class HandlerRegistrationExtensions
         ArgumentNullException.ThrowIfNull(configurator);
 
         configurator.Services.Add(
-            new ServiceDescriptor(typeof(ICommandInterceptor<TCommand, TResponse>), typeof(TInterceptor), lifetime)
+            new ServiceDescriptor(typeof(IRequestInterceptor<TCommand, TResponse>), typeof(TInterceptor), lifetime)
         );
 
         return configurator;
@@ -371,7 +371,7 @@ public static class HandlerRegistrationExtensions
         ArgumentNullException.ThrowIfNull(configurator);
 
         configurator.Services.Add(
-            new ServiceDescriptor(typeof(IQueryInterceptor<TQuery, TResponse>), typeof(TInterceptor), lifetime)
+            new ServiceDescriptor(typeof(IRequestInterceptor<TQuery, TResponse>), typeof(TInterceptor), lifetime)
         );
 
         return configurator;

--- a/tests/NetEvolve.Pulse.Tests.Integration/AspNetCore/EndpointRouteBuilderIntegrationTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/AspNetCore/EndpointRouteBuilderIntegrationTests.cs
@@ -1,0 +1,247 @@
+namespace NetEvolve.Pulse.Tests.Integration.AspNetCore;
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility;
+
+/// <summary>
+/// End-to-end integration tests exercising <see cref="EndpointRouteBuilderExtensions"/> through a real
+/// <see cref="TestServer"/> HTTP round-trip: an actual <see cref="HttpClient"/> (from <c>server.CreateClient()</c>)
+/// sends requests over the ASP.NET Core pipeline (routing, model binding, JSON (de)serialization) into the
+/// Pulse mediator and back, rather than invoking the mapped delegates directly.
+/// </summary>
+[TestGroup("AspNetCore")]
+public sealed class EndpointRouteBuilderIntegrationTests
+{
+    [Test]
+    public async Task MapCommand_WithResponse_PostsCommand_ReturnsOkWithHandlerResult(
+        CancellationToken cancellationToken
+    )
+    {
+        using var host = await CreateHostAsync(
+                app => app.MapCommand<EchoCommand, EchoResult>("/echo"),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        using var client = host.GetTestServer().CreateClient();
+
+        using var response = await client
+            .PostAsJsonAsync(new Uri("/echo", UriKind.Relative), new EchoCommand("hello"), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<EchoResult>(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(result).IsNotNull();
+        _ = await Assert.That(result!.Message).IsEqualTo("hello");
+        _ = await Assert.That(result.Reversed).IsEqualTo("olleh");
+    }
+
+    [Test]
+    public async Task MapCommand_Void_PostsCommand_ReturnsNoContent_AndInvokesHandler(
+        CancellationToken cancellationToken
+    )
+    {
+        var counter = new PingCounter();
+
+        using var host = await CreateHostAsync(
+                app => app.MapCommand<PingCommand>("/ping"),
+                cancellationToken,
+                services => services.AddSingleton(counter)
+            )
+            .ConfigureAwait(false);
+
+        using var client = host.GetTestServer().CreateClient();
+
+        using var response = await client
+            .PostAsJsonAsync(new Uri("/ping", UriKind.Relative), new PingCommand("test"), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.NoContent);
+        _ = await Assert.That(counter.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task MapQuery_GetsQuery_ReturnsOkWithHandlerResult(CancellationToken cancellationToken)
+    {
+        using var host = await CreateHostAsync(app => app.MapQuery<GreetingQuery, string>("/greet"), cancellationToken)
+            .ConfigureAwait(false);
+
+        using var client = host.GetTestServer().CreateClient();
+
+        using var response = await client
+            .GetAsync(new Uri("/greet?Name=World", UriKind.Relative), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<string>(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(result).IsEqualTo("Hello, World!");
+    }
+
+    [Test]
+    public async Task MapStreamQuery_GetsStream_WithNdjsonAccept_ReadsAllItemsInOrder(
+        CancellationToken cancellationToken
+    )
+    {
+        using var host = await CreateHostAsync(
+                app => app.MapStreamQuery<NumbersStreamQuery, int>("/numbers"),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        using var client = host.GetTestServer().CreateClient();
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/x-ndjson"));
+
+        using var response = await client
+            .GetAsync(
+                new Uri("/numbers", UriKind.Relative),
+                HttpCompletionOption.ResponseHeadersRead,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        _ = await Assert.That(response.Content.Headers.ContentType?.MediaType).IsEqualTo("application/x-ndjson");
+
+        var items = new List<int>();
+        var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        await using (stream.ConfigureAwait(false))
+        {
+            using var reader = new StreamReader(stream);
+            string? line;
+            while ((line = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false)) is not null)
+            {
+                if (line.Length == 0)
+                {
+                    continue;
+                }
+
+                items.Add(JsonSerializer.Deserialize<int>(line));
+            }
+        }
+
+        _ = await Assert.That(items).IsEquivalentTo([1, 2, 3]);
+    }
+
+    private static async Task<IHost> CreateHostAsync(
+        Action<IEndpointRouteBuilder> mapEndpoints,
+        CancellationToken cancellationToken,
+        Action<IServiceCollection>? configureServices = null
+    )
+    {
+        var host = new HostBuilder()
+            .ConfigureWebHost(webBuilder =>
+            {
+                _ = webBuilder.UseTestServer();
+                _ = webBuilder.ConfigureServices(services =>
+                {
+                    _ = services.AddRouting();
+                    _ = services.AddPulse(mediator =>
+                        mediator
+                            .AddCommandHandler<EchoCommand, EchoResult, EchoCommandHandler>()
+                            .AddCommandHandler<PingCommand, PingCommandHandler>()
+                            .AddQueryHandler<GreetingQuery, string, GreetingQueryHandler>()
+                            .AddStreamQueryHandler<NumbersStreamQuery, int, NumbersStreamQueryHandler>()
+                    );
+                    configureServices?.Invoke(services);
+                });
+                _ = webBuilder.Configure(app =>
+                {
+                    _ = app.UseRouting();
+                    _ = app.UseEndpoints(mapEndpoints);
+                });
+            })
+            .Build();
+
+        await host.StartAsync(cancellationToken).ConfigureAwait(false);
+        return host;
+    }
+
+    private sealed record EchoCommand(string Message) : ICommand<EchoResult>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed record EchoResult(string Message, string Reversed);
+
+    private sealed class EchoCommandHandler : ICommandHandler<EchoCommand, EchoResult>
+    {
+        public Task<EchoResult> HandleAsync(EchoCommand command, CancellationToken cancellationToken = default)
+        {
+            var reversed = new string([.. command.Message.Reverse()]);
+            return Task.FromResult(new EchoResult(command.Message, reversed));
+        }
+    }
+
+    private sealed record PingCommand(string Value) : ICommand
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed class PingCounter
+    {
+        private int _count;
+
+        public int Count => _count;
+
+        public void Increment() => Interlocked.Increment(ref _count);
+    }
+
+    private sealed class PingCommandHandler(PingCounter counter) : ICommandHandler<PingCommand, Void>
+    {
+        public Task<Void> HandleAsync(PingCommand command, CancellationToken cancellationToken = default)
+        {
+            counter.Increment();
+            return Task.FromResult<Void>(default);
+        }
+    }
+
+    private sealed record GreetingQuery(string Name) : IQuery<string>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed class GreetingQueryHandler : IQueryHandler<GreetingQuery, string>
+    {
+        public Task<string> HandleAsync(GreetingQuery request, CancellationToken cancellationToken = default) =>
+            Task.FromResult($"Hello, {request.Name}!");
+    }
+
+    private sealed record NumbersStreamQuery : IStreamQuery<int>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed class NumbersStreamQueryHandler : IStreamQueryHandler<NumbersStreamQuery, int>
+    {
+        public async IAsyncEnumerable<int> HandleAsync(
+            NumbersStreamQuery request,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default
+        )
+        {
+            foreach (var number in new[] { 1, 2, 3 })
+            {
+                yield return number;
+                await Task.Yield();
+            }
+        }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Integration/AspNetCore/HttpCorrelationEndpointIntegrationTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/AspNetCore/HttpCorrelationEndpointIntegrationTests.cs
@@ -1,0 +1,272 @@
+namespace NetEvolve.Pulse.Tests.Integration.AspNetCore;
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Http.Correlation.AspNetCore;
+using NetEvolve.Pulse.Extensibility;
+
+/// <summary>
+/// Integration tests verifying that a client-supplied <c>X-Correlation-ID</c> header propagates, through the
+/// real <c>NetEvolve.Http.Correlation.AspNetCore</c> middleware and the <c>HttpCorrelationRequestInterceptor</c>
+/// registered via <see cref="HttpCorrelationExtensions.AddHttpCorrelationEnrichment"/>, all the way into the
+/// mediator request handled by a command dispatched from a real Minimal API endpoint.
+/// </summary>
+[TestGroup("AspNetCore")]
+public sealed class HttpCorrelationEndpointIntegrationTests
+{
+    private const string CorrelationHeaderName = "X-Correlation-ID";
+
+    [Test]
+    public async Task Command_WithClientSuppliedCorrelationId_PropagatesToHandlerAndResponseHeader(
+        CancellationToken cancellationToken
+    )
+    {
+        using var host = await CreateHostAsync(cancellationToken).ConfigureAwait(false);
+        using var client = host.GetTestServer().CreateClient();
+
+        const string correlationId = "test-correlation-id-123";
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/whoami")
+        {
+            Content = JsonContent.Create(new WhoAmICommand("caller")),
+        };
+        request.Headers.Add(CorrelationHeaderName, correlationId);
+
+        using var response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<WhoAmIResult>(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(result).IsNotNull();
+
+        // The correlation ID observed by the mediator command handler (via the HttpCorrelation
+        // request interceptor reading IHttpCorrelationAccessor) must match the one the client sent.
+        _ = await Assert.That(result!.ObservedCorrelationId).IsEqualTo(correlationId);
+
+        // The middleware also reflects the (possibly generated) correlation ID back on the response.
+        _ = await Assert.That(response.Headers.Contains(CorrelationHeaderName)).IsTrue();
+        _ = await Assert.That(response.Headers.GetValues(CorrelationHeaderName).First()).IsEqualTo(correlationId);
+    }
+
+    [Test]
+    public async Task Command_WithoutClientSuppliedCorrelationId_StillReceivesAGeneratedCorrelationId(
+        CancellationToken cancellationToken
+    )
+    {
+        using var host = await CreateHostAsync(cancellationToken).ConfigureAwait(false);
+        using var client = host.GetTestServer().CreateClient();
+
+        using var response = await client
+            .PostAsJsonAsync(new Uri("/whoami", UriKind.Relative), new WhoAmICommand("caller"), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<WhoAmIResult>(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(result).IsNotNull();
+
+        // No header was supplied, so the middleware generates one; the handler must still observe
+        // a non-empty correlation ID flowing through the interceptor.
+        _ = await Assert.That(result!.ObservedCorrelationId).IsNotNull();
+        _ = await Assert.That(string.IsNullOrEmpty(result.ObservedCorrelationId)).IsFalse();
+    }
+
+    [Test]
+    public async Task Event_Published_From_Handler_ObservesSameCorrelationId(CancellationToken cancellationToken)
+    {
+        var sink = new CorrelationSink();
+
+        using var host = await CreateHostAsync(
+                services => services.AddSingleton(sink),
+                endpoints => endpoints.MapCommand<PublishEventCommand>("/publish-event"),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+        using var client = host.GetTestServer().CreateClient();
+
+        const string correlationId = "event-correlation-id-456";
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/publish-event")
+        {
+            Content = JsonContent.Create(new PublishEventCommand()),
+        };
+        request.Headers.Add(CorrelationHeaderName, correlationId);
+
+        using var response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.NoContent);
+        _ = await Assert.That(sink.ObservedCorrelationId).IsEqualTo(correlationId);
+    }
+
+    [Test]
+    public async Task StreamQuery_WithClientSuppliedCorrelationId_ObservesSameCorrelationId(
+        CancellationToken cancellationToken
+    )
+    {
+        using var host = await CreateHostAsync(
+                configureServices: null,
+                mapEndpoints: endpoints => endpoints.MapStreamQuery<CorrelationStreamQuery, string>("/stream-whoami"),
+                cancellationToken: cancellationToken
+            )
+            .ConfigureAwait(false);
+        using var client = host.GetTestServer().CreateClient();
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/x-ndjson"));
+
+        const string correlationId = "stream-correlation-id-789";
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/stream-whoami");
+        request.Headers.Add(CorrelationHeaderName, correlationId);
+
+        using var response = await client
+            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var items = new List<string>();
+        var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        await using (stream.ConfigureAwait(false))
+        {
+            using var reader = new StreamReader(stream);
+            string? line;
+            while ((line = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false)) is not null)
+            {
+                if (line.Length == 0)
+                {
+                    continue;
+                }
+
+                items.Add(JsonSerializer.Deserialize<string>(line)!);
+            }
+        }
+
+        _ = await Assert.That(items).IsEquivalentTo([correlationId]);
+    }
+
+    private static Task<IHost> CreateHostAsync(CancellationToken cancellationToken) =>
+        CreateHostAsync(
+            configureServices: null,
+            mapEndpoints: endpoints => endpoints.MapCommand<WhoAmICommand, WhoAmIResult>("/whoami"),
+            cancellationToken: cancellationToken
+        );
+
+    private static async Task<IHost> CreateHostAsync(
+        Action<IServiceCollection>? configureServices,
+        Action<IEndpointRouteBuilder> mapEndpoints,
+        CancellationToken cancellationToken
+    )
+    {
+        var host = new HostBuilder()
+            .ConfigureWebHost(webBuilder =>
+            {
+                _ = webBuilder.UseTestServer();
+                _ = webBuilder.ConfigureServices(services =>
+                {
+                    _ = services.AddRouting();
+                    _ = services.AddHttpContextAccessor();
+                    _ = services.AddHttpCorrelation();
+                    _ = services.AddPulse(mediator =>
+                        mediator
+                            .AddCommandHandler<WhoAmICommand, WhoAmIResult, WhoAmICommandHandler>()
+                            .AddCommandHandler<PublishEventCommand, PublishEventCommandHandler>()
+                            .AddEventHandler<CorrelationCapturedEvent, CorrelationCapturedEventHandler>()
+                            .AddStreamQueryHandler<CorrelationStreamQuery, string, CorrelationStreamQueryHandler>()
+                            .AddHttpCorrelationEnrichment()
+                    );
+                    configureServices?.Invoke(services);
+                });
+                _ = webBuilder.Configure(app =>
+                {
+                    _ = app.UseHttpCorrelation();
+                    _ = app.UseRouting();
+                    _ = app.UseEndpoints(mapEndpoints);
+                });
+            })
+            .Build();
+
+        await host.StartAsync(cancellationToken).ConfigureAwait(false);
+        return host;
+    }
+
+    private sealed class CorrelationSink
+    {
+        public string? ObservedCorrelationId { get; set; }
+    }
+
+    private sealed record PublishEventCommand : ICommand
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed class PublishEventCommandHandler(IMediator mediator) : ICommandHandler<PublishEventCommand, Void>
+    {
+        public async Task<Void> HandleAsync(PublishEventCommand command, CancellationToken cancellationToken = default)
+        {
+            await mediator.PublishAsync(new CorrelationCapturedEvent(), cancellationToken).ConfigureAwait(false);
+            return default;
+        }
+    }
+
+    private sealed record CorrelationCapturedEvent : IEvent
+    {
+        public string Id { get; init; } = Guid.NewGuid().ToString();
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+        public DateTimeOffset? PublishedAt { get; set; }
+    }
+
+    private sealed class CorrelationCapturedEventHandler(CorrelationSink sink) : IEventHandler<CorrelationCapturedEvent>
+    {
+        public Task HandleAsync(CorrelationCapturedEvent @event, CancellationToken cancellationToken = default)
+        {
+            sink.ObservedCorrelationId = @event.CorrelationId;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed record CorrelationStreamQuery : IStreamQuery<string>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed class CorrelationStreamQueryHandler : IStreamQueryHandler<CorrelationStreamQuery, string>
+    {
+        public async IAsyncEnumerable<string> HandleAsync(
+            CorrelationStreamQuery request,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default
+        )
+        {
+            yield return request.CorrelationId ?? string.Empty;
+            await Task.Yield();
+        }
+    }
+
+    private sealed record WhoAmICommand(string Caller) : ICommand<WhoAmIResult>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed record WhoAmIResult(string Caller, string? ObservedCorrelationId);
+
+    private sealed class WhoAmICommandHandler : ICommandHandler<WhoAmICommand, WhoAmIResult>
+    {
+        public Task<WhoAmIResult> HandleAsync(WhoAmICommand command, CancellationToken cancellationToken = default) =>
+            // By the time the handler runs, the HttpCorrelationRequestInterceptor has already
+            // populated command.CorrelationId from IHttpCorrelationAccessor (unless the caller
+            // already set one explicitly, which is not the case here).
+            Task.FromResult(new WhoAmIResult(command.Caller, command.CorrelationId));
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Integration/AzureQueueStorage/AzureQueueStorageMessageTransportIntegrationTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/AzureQueueStorage/AzureQueueStorageMessageTransportIntegrationTests.cs
@@ -106,7 +106,7 @@ public sealed class AzureQueueStorageMessageTransportIntegrationTests(AzuriteCon
     {
         var queueName = CreateUniqueQueueName();
         var queueClient = new QueueClient(containerFixture.ConnectionString, queueName, VerificationClientOptions);
-        await queueClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        _ = await queueClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
 
         // Options intentionally point at a different (never-created) queue, to prove the transport
         // uses the injected queueClient override rather than building a client from options.
@@ -191,7 +191,9 @@ public sealed class AzureQueueStorageMessageTransportIntegrationTests(AzuriteCon
     }
 
     [Test]
-    public async Task UseAzureQueueStorageTransport_Uri_overload_registers_transport()
+    public async Task UseAzureQueueStorageTransport_Uri_overload_registers_transport(
+        CancellationToken cancellationToken
+    )
     {
         var services = new ServiceCollection();
         _ = services.AddPulse(config =>
@@ -200,6 +202,8 @@ public sealed class AzureQueueStorageMessageTransportIntegrationTests(AzuriteCon
                 o => o.QueueName = CreateUniqueQueueName()
             )
         );
+
+        cancellationToken.ThrowIfCancellationRequested();
 
         var provider = services.BuildServiceProvider();
         await using (provider.ConfigureAwait(false))
@@ -211,8 +215,10 @@ public sealed class AzureQueueStorageMessageTransportIntegrationTests(AzuriteCon
     }
 
     [Test]
-    public async Task UseAzureQueueStorageTransport_Replaces_existing_transport()
+    public async Task UseAzureQueueStorageTransport_Replaces_existing_transport(CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         var services = new ServiceCollection();
         _ = services.AddSingleton<IMessageTransport>(new DummyTransport());
         _ = services.AddPulse(config =>

--- a/tests/NetEvolve.Pulse.Tests.Integration/AzureQueueStorage/AzureQueueStorageMessageTransportIntegrationTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/AzureQueueStorage/AzureQueueStorageMessageTransportIntegrationTests.cs
@@ -100,6 +100,140 @@ public sealed class AzureQueueStorageMessageTransportIntegrationTests(AzuriteCon
     }
 
     [Test]
+    public async Task SendAsync_With_prebuilt_queueClient_uses_override_instead_of_options(
+        CancellationToken cancellationToken
+    )
+    {
+        var queueName = CreateUniqueQueueName();
+        var queueClient = new QueueClient(containerFixture.ConnectionString, queueName, VerificationClientOptions);
+        await queueClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        // Options intentionally point at a different (never-created) queue, to prove the transport
+        // uses the injected queueClient override rather than building a client from options.
+        var options = Options.Create(
+            new AzureQueueStorageTransportOptions
+            {
+                ConnectionString = containerFixture.ConnectionString,
+                QueueName = CreateUniqueQueueName(),
+                CreateQueueIfNotExists = false,
+            }
+        );
+        using var transport = new AzureQueueStorageMessageTransport(options, queueClient);
+        var message = CreateOutboxMessage();
+
+        await transport.SendAsync(message, cancellationToken).ConfigureAwait(false);
+
+        var response = await queueClient
+            .ReceiveMessageAsync(cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        var received = response.Value;
+
+        _ = await Assert.That(received).IsNotNull();
+        var json = Encoding.UTF8.GetString(Convert.FromBase64String(received!.Body.ToString()));
+        using var doc = JsonDocument.Parse(json);
+        _ = await Assert.That(doc.RootElement.GetProperty("id").GetGuid()).IsEqualTo(message.Id);
+    }
+
+    [Test]
+    public async Task SendAsync_When_message_exceeds_size_limit_throws(CancellationToken cancellationToken)
+    {
+        var queueName = CreateUniqueQueueName();
+        var options = Options.Create(
+            new AzureQueueStorageTransportOptions
+            {
+                ConnectionString = containerFixture.ConnectionString,
+                QueueName = queueName,
+                CreateQueueIfNotExists = true,
+            }
+        );
+        using var transport = new AzureQueueStorageMessageTransport(options);
+
+        // Payload alone (well before JSON envelope overhead) already exceeds the 48 KB raw limit.
+        var oversizedMessage = CreateOutboxMessage();
+        oversizedMessage.Payload = new string('a', AzureQueueStorageMessageTransport.MaxMessageSizeInBytes + 1);
+
+        _ = await Assert
+            .That(() => transport.SendAsync(oversizedMessage, cancellationToken))
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task SendAsync_Called_concurrently_initializes_queueClient_exactly_once(
+        CancellationToken cancellationToken
+    )
+    {
+        var queueName = CreateUniqueQueueName();
+        var options = Options.Create(
+            new AzureQueueStorageTransportOptions
+            {
+                ConnectionString = containerFixture.ConnectionString,
+                QueueName = queueName,
+                CreateQueueIfNotExists = true,
+            }
+        );
+        using var transport = new AzureQueueStorageMessageTransport(options);
+
+        const int concurrentSends = 10;
+
+        // Fire many sends concurrently against a transport with no queue client yet, to exercise
+        // the double-checked locking re-check branch inside GetQueueClientAsync.
+        var tasks = Enumerable
+            .Range(0, concurrentSends)
+            .Select(_ => transport.SendAsync(CreateOutboxMessage(), cancellationToken));
+        await Task.WhenAll(tasks).ConfigureAwait(false);
+
+        var queueClient = new QueueClient(containerFixture.ConnectionString, queueName, VerificationClientOptions);
+        var response = await queueClient
+            .ReceiveMessagesAsync(maxMessages: concurrentSends, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(response.Value.Length).IsEqualTo(concurrentSends);
+    }
+
+    [Test]
+    public async Task UseAzureQueueStorageTransport_Uri_overload_registers_transport()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddPulse(config =>
+            config.UseAzureQueueStorageTransport(
+                new Uri("https://example.queue.core.windows.net"),
+                o => o.QueueName = CreateUniqueQueueName()
+            )
+        );
+
+        var provider = services.BuildServiceProvider();
+        await using (provider.ConfigureAwait(false))
+        {
+            var transport = provider.GetRequiredService<IMessageTransport>();
+
+            _ = await Assert.That(transport).IsTypeOf<AzureQueueStorageMessageTransport>();
+        }
+    }
+
+    [Test]
+    public async Task UseAzureQueueStorageTransport_Replaces_existing_transport()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddSingleton<IMessageTransport>(new DummyTransport());
+        _ = services.AddPulse(config =>
+            config.UseAzureQueueStorageTransport(containerFixture.ConnectionString, o => o.QueueName = "unused")
+        );
+
+        var provider = services.BuildServiceProvider();
+        await using (provider.ConfigureAwait(false))
+        {
+            var descriptors = services.Where(d => d.ServiceType == typeof(IMessageTransport)).ToList();
+            var transport = provider.GetRequiredService<IMessageTransport>();
+
+            using (Assert.Multiple())
+            {
+                _ = await Assert.That(descriptors.Count).IsEqualTo(1);
+                _ = await Assert.That(transport).IsTypeOf<AzureQueueStorageMessageTransport>();
+            }
+        }
+    }
+
+    [Test]
     public async Task UseAzureQueueStorageTransport_Registers_working_transport_end_to_end(
         CancellationToken cancellationToken
     )
@@ -151,5 +285,20 @@ public sealed class AzureQueueStorageMessageTransportIntegrationTests(AzuriteCon
         public string? CorrelationId { get; set; }
         public string Id { get; init; } = Guid.NewGuid().ToString();
         public DateTimeOffset? PublishedAt { get; set; }
+    }
+
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes - instantiated via DI container
+    private sealed class DummyTransport : IMessageTransport
+#pragma warning restore CA1812
+    {
+        public Task<bool> IsHealthyAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+
+        public Task SendAsync(OutboxMessage message, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
+        public Task SendBatchAsync(
+            IEnumerable<OutboxMessage> messages,
+            CancellationToken cancellationToken = default
+        ) => Task.CompletedTask;
     }
 }

--- a/tests/NetEvolve.Pulse.Tests.Integration/Kafka/KafkaContainerFixture.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Kafka/KafkaContainerFixture.cs
@@ -1,0 +1,30 @@
+namespace NetEvolve.Pulse.Tests.Integration.Kafka;
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Testcontainers.Kafka;
+using TUnit.Core.Interfaces;
+
+/// <summary>
+/// Provides a shared Kafka container fixture for integration tests.
+/// </summary>
+public sealed class KafkaContainerFixture : IAsyncDisposable, IAsyncInitializer
+{
+    private readonly KafkaContainer _container = new KafkaBuilder()
+        .WithLogger(NullLogger.Instance)
+        // Disabled so that "topic missing" scenarios (AutoCreateTopics = false on the transport)
+        // exercise a real UnknownTopicOrPartition failure instead of the broker silently
+        // auto-creating the topic on first produce.
+        .WithEnvironment("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false")
+        .Build();
+
+    /// <summary>
+    /// Gets the bootstrap servers address for the running Kafka container.
+    /// </summary>
+    public string ConnectionString => _container.GetBootstrapAddress();
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync() => _container.DisposeAsync();
+
+    /// <inheritdoc />
+    public async Task InitializeAsync() => await _container.StartAsync().ConfigureAwait(false);
+}

--- a/tests/NetEvolve.Pulse.Tests.Integration/Kafka/KafkaMessageTransportIntegrationTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Kafka/KafkaMessageTransportIntegrationTests.cs
@@ -1,0 +1,283 @@
+namespace NetEvolve.Pulse.Tests.Integration.Kafka;
+
+using System.Text;
+using global::Confluent.Kafka;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.Outbox;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
+
+/// <summary>
+/// Integration tests for <see cref="KafkaMessageTransport"/> against a real Apache Kafka broker.
+/// </summary>
+[ClassDataSource<KafkaContainerFixture>(Shared = SharedType.PerTestSession)]
+[TestGroup("Kafka")]
+[Timeout(120_000)]
+[NotInParallel]
+public sealed class KafkaMessageTransportIntegrationTests(KafkaContainerFixture containerFixture)
+{
+    [Test]
+    public async Task SendAsync_Publishes_message_to_topic(CancellationToken cancellationToken)
+    {
+        var topic = CreateUniqueTopicName();
+        using var producer = CreateProducer();
+        using var admin = CreateAdminClient();
+        await using var transport = CreateTransport(producer, admin, new FixedTopicNameResolver(topic));
+        var outboxMessage = CreateOutboxMessage();
+
+        await transport.SendAsync(outboxMessage, cancellationToken).ConfigureAwait(false);
+
+        using var consumer = CreateConsumer(topic);
+        var received = ConsumeOneMessage(consumer);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(received).IsNotNull();
+            _ = await Assert.That(received!.Message.Key).IsEqualTo(outboxMessage.Id.ToString("D"));
+            _ = await Assert.That(received.Message.Value).IsEqualTo(outboxMessage.Payload);
+            _ = await Assert
+                .That(GetHeader(received.Message, "eventType"))
+                .IsEqualTo(outboxMessage.EventType.ToOutboxEventTypeName());
+            _ = await Assert.That(GetHeader(received.Message, "contentType")).IsEqualTo("application/json");
+            _ = await Assert.That(GetHeader(received.Message, "correlationId")).IsEqualTo(outboxMessage.CorrelationId);
+        }
+    }
+
+    [Test]
+    public async Task SendBatchAsync_Publishes_all_messages_to_topic(CancellationToken cancellationToken)
+    {
+        const int messageCount = 5;
+        var topic = CreateUniqueTopicName();
+        using var producer = CreateProducer();
+        using var admin = CreateAdminClient();
+        await using var transport = CreateTransport(producer, admin, new FixedTopicNameResolver(topic));
+        var messages = Enumerable.Range(0, messageCount).Select(_ => CreateOutboxMessage()).ToList();
+
+        await transport.SendBatchAsync(messages, cancellationToken).ConfigureAwait(false);
+
+        using var consumer = CreateConsumer(topic);
+        var received = ConsumeMessages(consumer, messageCount);
+
+        _ = await Assert.That(received.Count).IsEqualTo(messageCount);
+    }
+
+    [Test]
+    public async Task SendAsync_Uses_custom_topic_name_resolver_to_route_message(CancellationToken cancellationToken)
+    {
+        var topic = $"pulse-it-custom-{Guid.NewGuid():N}";
+        using var producer = CreateProducer();
+        using var admin = CreateAdminClient();
+        await using var transport = CreateTransport(producer, admin, new FixedTopicNameResolver(topic));
+        var outboxMessage = CreateOutboxMessage();
+
+        await transport.SendAsync(outboxMessage, cancellationToken).ConfigureAwait(false);
+
+        using var consumer = CreateConsumer(topic);
+        var received = ConsumeOneMessage(consumer);
+
+        _ = await Assert.That(received).IsNotNull();
+        _ = await Assert.That(received!.Topic).IsEqualTo(topic);
+    }
+
+    [Test]
+    public async Task IsHealthyAsync_When_broker_reachable_returns_true(CancellationToken cancellationToken)
+    {
+        using var producer = CreateProducer();
+        using var admin = CreateAdminClient();
+        await using var transport = CreateTransport(
+            producer,
+            admin,
+            new FixedTopicNameResolver(CreateUniqueTopicName())
+        );
+
+        var healthy = await transport.IsHealthyAsync(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(healthy).IsTrue();
+    }
+
+    [Test]
+    public async Task SendAsync_When_AutoCreateTopics_false_and_topic_missing_throws(
+        CancellationToken cancellationToken
+    )
+    {
+        var topic = CreateUniqueTopicName();
+        using var producer = CreateProducer(messageTimeoutMs: 5_000);
+        using var admin = CreateAdminClient();
+        await using var transport = CreateTransport(
+            producer,
+            admin,
+            new FixedTopicNameResolver(topic),
+            options: new KafkaTransportOptions { AutoCreateTopics = false }
+        );
+
+        _ = await Assert
+            .That(() => transport.SendAsync(CreateOutboxMessage(), cancellationToken))
+            .Throws<ProduceException<string, string>>();
+    }
+
+    [Test]
+    public async Task SendAsync_AutoCreateTopics_true_Creates_topic_with_custom_partition_count(
+        CancellationToken cancellationToken
+    )
+    {
+        var topic = CreateUniqueTopicName();
+        using var producer = CreateProducer();
+        using var admin = CreateAdminClient();
+        await using var transport = CreateTransport(
+            producer,
+            admin,
+            new FixedTopicNameResolver(topic),
+            options: new KafkaTransportOptions { AutoCreateTopics = true, DefaultPartitionCount = 3 }
+        );
+
+        await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false);
+
+        var metadata = admin.GetMetadata(topic, TimeSpan.FromSeconds(15));
+        var topicMetadata = metadata.Topics.Single(t => string.Equals(t.Topic, topic, StringComparison.Ordinal));
+
+        _ = await Assert.That(topicMetadata.Partitions.Count).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task UseKafkaTransport_Registers_ResolvableMessageTransport_ThatPublishes(
+        CancellationToken cancellationToken
+    )
+    {
+        var topic = CreateUniqueTopicName();
+        using var producer = CreateProducer();
+        using var admin = CreateAdminClient();
+
+        var services = new ServiceCollection();
+        _ = services.AddSingleton(producer);
+        _ = services.AddSingleton(admin);
+        _ = services.AddSingleton<ITopicNameResolver>(new FixedTopicNameResolver(topic));
+        _ = services.AddPulse(configurator =>
+            configurator.UseKafkaTransport(options => options.AutoCreateTopics = true)
+        );
+
+        await using var provider = services.BuildServiceProvider();
+        var transport = provider.GetRequiredService<IMessageTransport>();
+
+        _ = await Assert.That(transport).IsTypeOf<KafkaMessageTransport>();
+
+        await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false);
+
+        using var consumer = CreateConsumer(topic);
+        var received = ConsumeOneMessage(consumer);
+
+        _ = await Assert.That(received).IsNotNull();
+    }
+
+    [Test]
+    public async Task UseKafkaTransport_Replaces_ExistingMessageTransport_Registration(
+        CancellationToken cancellationToken
+    )
+    {
+        using var producer = CreateProducer();
+        using var admin = CreateAdminClient();
+
+        var services = new ServiceCollection();
+        _ = services.AddSingleton(producer);
+        _ = services.AddSingleton(admin);
+        _ = services.AddSingleton<ITopicNameResolver>(new FixedTopicNameResolver(CreateUniqueTopicName()));
+        _ = services.AddPulse(configurator =>
+            configurator.UseMessageTransport<NullMessageTransport>().UseKafkaTransport()
+        );
+
+        await using var provider = services.BuildServiceProvider();
+
+        _ = await Assert.That(provider.GetRequiredService<IMessageTransport>()).IsTypeOf<KafkaMessageTransport>();
+        cancellationToken.ThrowIfCancellationRequested();
+    }
+
+    private KafkaMessageTransport CreateTransport(
+        IProducer<string, string> producer,
+        IAdminClient admin,
+        ITopicNameResolver resolver,
+        KafkaTransportOptions? options = null
+    ) => new(producer, admin, resolver, Options.Create(options ?? new KafkaTransportOptions()));
+
+    private IProducer<string, string> CreateProducer(int? messageTimeoutMs = null)
+    {
+        var config = new ProducerConfig { BootstrapServers = containerFixture.ConnectionString, Acks = Acks.All };
+        if (messageTimeoutMs.HasValue)
+        {
+            config.MessageTimeoutMs = messageTimeoutMs.Value;
+        }
+
+        return new ProducerBuilder<string, string>(config).Build();
+    }
+
+    private IAdminClient CreateAdminClient() =>
+        new AdminClientBuilder(new AdminClientConfig { BootstrapServers = containerFixture.ConnectionString }).Build();
+
+    private IConsumer<string, string> CreateConsumer(string topic)
+    {
+        var config = new ConsumerConfig
+        {
+            BootstrapServers = containerFixture.ConnectionString,
+            GroupId = $"pulse-it-consumer-{Guid.NewGuid():N}",
+            AutoOffsetReset = AutoOffsetReset.Earliest,
+            EnableAutoCommit = false,
+        };
+
+        var consumer = new ConsumerBuilder<string, string>(config).Build();
+        consumer.Subscribe(topic);
+        return consumer;
+    }
+
+    private static ConsumeResult<string, string>? ConsumeOneMessage(IConsumer<string, string> consumer) =>
+        consumer.Consume(TimeSpan.FromSeconds(15));
+
+    private static List<ConsumeResult<string, string>> ConsumeMessages(
+        IConsumer<string, string> consumer,
+        int expectedCount
+    )
+    {
+        var received = new List<ConsumeResult<string, string>>();
+        var deadline = DateTime.UtcNow.Add(TimeSpan.FromSeconds(15));
+
+        while (received.Count < expectedCount && DateTime.UtcNow < deadline)
+        {
+            var result = consumer.Consume(TimeSpan.FromSeconds(1));
+            if (result is not null)
+            {
+                received.Add(result);
+            }
+        }
+
+        return received;
+    }
+
+    private static string CreateUniqueTopicName() => $"pulse-it-{Guid.NewGuid():N}";
+
+    private static OutboxMessage CreateOutboxMessage() =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            EventType = typeof(IntegrationTestEvent),
+            Payload = """{"id":"test"}""",
+            CorrelationId = Guid.NewGuid().ToString(),
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            RetryCount = 0,
+            ProcessedAt = null,
+        };
+
+    private static string GetHeader(Message<string, string> message, string key)
+    {
+        var header = message.Headers.FirstOrDefault(h => string.Equals(h.Key, key, StringComparison.Ordinal));
+        return header is null ? string.Empty : Encoding.UTF8.GetString(header.GetValueBytes());
+    }
+
+    private sealed class FixedTopicNameResolver(string topic) : ITopicNameResolver
+    {
+        public string Resolve(OutboxMessage message) => topic;
+    }
+
+    private sealed record IntegrationTestEvent;
+}

--- a/tests/NetEvolve.Pulse.Tests.Integration/Kafka/KafkaMessageTransportIntegrationTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Kafka/KafkaMessageTransportIntegrationTests.cs
@@ -194,7 +194,7 @@ public sealed class KafkaMessageTransportIntegrationTests(KafkaContainerFixture 
         cancellationToken.ThrowIfCancellationRequested();
     }
 
-    private KafkaMessageTransport CreateTransport(
+    private static KafkaMessageTransport CreateTransport(
         IProducer<string, string> producer,
         IAdminClient admin,
         ITopicNameResolver resolver,

--- a/tests/NetEvolve.Pulse.Tests.Integration/Pipeline/AssemblyScanningTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Pipeline/AssemblyScanningTests.cs
@@ -2,6 +2,7 @@ namespace NetEvolve.Pulse.Tests.Integration.Pipeline;
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -53,6 +54,12 @@ public sealed class AssemblyScanningTests
         await using (scope.ConfigureAwait(false))
         {
             var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            // Confirm the scanned handler type was actually the one discovered and registered by
+            // reflection, not merely a coincidentally-named handler.
+            var handlers = scope.ServiceProvider.GetServices<IEventHandler<ScannedAssemblyEvent>>().ToArray();
+            _ = await Assert.That(handlers).HasSingleItem();
+            _ = await Assert.That(handlers[0]).IsTypeOf<ScannedAssemblyHandler>();
 
             await mediator.PublishAsync(new ScannedAssemblyEvent(), cancellationToken).ConfigureAwait(false);
         }
@@ -151,6 +158,14 @@ public sealed class AssemblyScanningTests
         await using (scope.ConfigureAwait(false))
         {
             var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            // Confirm the scanned interceptor type was actually the one discovered and registered by
+            // reflection, not merely a coincidentally-named interceptor.
+            var interceptors = scope
+                .ServiceProvider.GetServices<IRequestInterceptor<ScannedInterceptorQuery, string>>()
+                .ToArray();
+            _ = await Assert.That(interceptors).HasSingleItem();
+            _ = await Assert.That(interceptors[0]).IsTypeOf<ScannedInterceptor>();
 
             var result = await mediator
                 .QueryAsync<ScannedInterceptorQuery, string>(new ScannedInterceptorQuery(), cancellationToken)

--- a/tests/NetEvolve.Pulse.Tests.Integration/Pipeline/AssemblyScanningTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Pipeline/AssemblyScanningTests.cs
@@ -1,0 +1,281 @@
+namespace NetEvolve.Pulse.Tests.Integration.Pipeline;
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Internals;
+
+/// <summary>
+/// End-to-end integration tests for the reflection-based assembly-scanning registration methods on
+/// <see cref="AssemblyScanningExtensions"/>. Only <c>AddHandlersFromAssemblyContaining</c> (via a
+/// different test file) was previously exercised — the remaining public entry points
+/// (<c>AddHandlersFromAssembly</c>, <c>AddHandlersFromAssemblies</c>, and the
+/// <c>AddInterceptorsFrom*</c> family) had never been called through a real host. The
+/// <c>*FromCallingAssembly</c>/<c>*FromEntryAssembly</c>/<c>*FromExecutingAssembly</c> overloads are
+/// marked <c>[ExcludeFromCodeCoverage]</c> in source and are intentionally not covered here.
+/// </summary>
+[TestGroup("Pipeline")]
+public sealed class AssemblyScanningTests
+{
+    private static async Task<IHost> BuildHostAsync(
+        Action<IServiceCollection> configureServices,
+        CancellationToken cancellationToken
+    )
+    {
+        var host = new HostBuilder().ConfigureServices(configureServices).Build();
+
+        await host.StartAsync(cancellationToken).ConfigureAwait(false);
+
+        return host;
+    }
+
+    [Test]
+    public async Task AddHandlersFromAssembly_Discovers_And_Invokes_Handler(CancellationToken cancellationToken)
+    {
+        var tracker = new List<string>();
+
+        using var host = await BuildHostAsync(
+                services =>
+                    services
+                        .AddSingleton(tracker)
+                        .AddPulse(config => config.AddHandlersFromAssembly(typeof(AssemblyScanningTests).Assembly)),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        var scope = host.Services.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            await mediator.PublishAsync(new ScannedAssemblyEvent(), cancellationToken).ConfigureAwait(false);
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(tracker).IsEquivalentTo(["ScannedAssemblyHandler"]);
+    }
+
+    [Test]
+    public void AddHandlersFromAssembly_WithNullAssembly_ThrowsArgumentNullException()
+    {
+        var services = new ServiceCollection();
+        var configurator = new MediatorBuilder(services);
+
+        _ = Assert.Throws<ArgumentNullException>(() => configurator.AddHandlersFromAssembly(null!));
+    }
+
+    [Test]
+    public void AddHandlersFromAssemblies_WithNullArray_ThrowsArgumentNullException()
+    {
+        var services = new ServiceCollection();
+        var configurator = new MediatorBuilder(services);
+
+        _ = Assert.Throws<ArgumentNullException>(() => configurator.AddHandlersFromAssemblies(null!));
+    }
+
+    [Test]
+    public async Task AddHandlersFromAssemblies_Discovers_Handlers_And_Skips_NullEntries(
+        CancellationToken cancellationToken
+    )
+    {
+        var tracker = new List<string>();
+
+        using var host = await BuildHostAsync(
+                services =>
+                    services
+                        .AddSingleton(tracker)
+                        .AddPulse(config =>
+                            config.AddHandlersFromAssemblies([
+                                typeof(AssemblyScanningTests).Assembly,
+                                null!,
+                                typeof(IMediator).Assembly,
+                            ])
+                        ),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        var scope = host.Services.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            await mediator.PublishAsync(new ScannedAssemblyEvent(), cancellationToken).ConfigureAwait(false);
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(tracker).IsEquivalentTo(["ScannedAssemblyHandler"]);
+    }
+
+    [Test]
+    public async Task AddHandlersFromExecutingAssembly_DoesNotThrow(CancellationToken cancellationToken)
+    {
+        using var host = await BuildHostAsync(
+                services => services.AddPulse(config => config.AddHandlersFromExecutingAssembly()),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task AddInterceptorsFromAssemblyContaining_Discovers_And_Invokes_Interceptor(
+        CancellationToken cancellationToken
+    )
+    {
+        var tracker = new List<string>();
+
+        using var host = await BuildHostAsync(
+                services =>
+                    services
+                        .AddSingleton(tracker)
+                        .AddPulse(config =>
+                            config
+                                .AddQueryHandler<ScannedInterceptorQuery, string, ScannedInterceptorQueryHandler>()
+                                .AddInterceptorsFromAssemblyContaining<AssemblyScanningTests>()
+                        ),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        var scope = host.Services.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            var result = await mediator
+                .QueryAsync<ScannedInterceptorQuery, string>(new ScannedInterceptorQuery(), cancellationToken)
+                .ConfigureAwait(false);
+
+            _ = await Assert.That(result).IsEqualTo("handled");
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(tracker).IsEquivalentTo(["ScannedInterceptor"]);
+    }
+
+    [Test]
+    public void AddInterceptorsFromAssembly_WithNullAssembly_ThrowsArgumentNullException()
+    {
+        var services = new ServiceCollection();
+        var configurator = new MediatorBuilder(services);
+
+        _ = Assert.Throws<ArgumentNullException>(() => configurator.AddInterceptorsFromAssembly(null!));
+    }
+
+    [Test]
+    public void AddInterceptorsFromAssemblies_WithNullArray_ThrowsArgumentNullException()
+    {
+        var services = new ServiceCollection();
+        var configurator = new MediatorBuilder(services);
+
+        _ = Assert.Throws<ArgumentNullException>(() => configurator.AddInterceptorsFromAssemblies(null!));
+    }
+
+    [Test]
+    public async Task AddInterceptorsFromAssemblies_Discovers_Interceptor_And_Skips_NullEntries(
+        CancellationToken cancellationToken
+    )
+    {
+        var tracker = new List<string>();
+
+        using var host = await BuildHostAsync(
+                services =>
+                    services
+                        .AddSingleton(tracker)
+                        .AddPulse(config =>
+                            config
+                                .AddQueryHandler<ScannedInterceptorQuery, string, ScannedInterceptorQueryHandler>()
+                                .AddInterceptorsFromAssemblies([
+                                    typeof(AssemblyScanningTests).Assembly,
+                                    null!,
+                                    typeof(IMediator).Assembly,
+                                ])
+                        ),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        var scope = host.Services.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            var result = await mediator
+                .QueryAsync<ScannedInterceptorQuery, string>(new ScannedInterceptorQuery(), cancellationToken)
+                .ConfigureAwait(false);
+
+            _ = await Assert.That(result).IsEqualTo("handled");
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(tracker).IsEquivalentTo(["ScannedInterceptor"]);
+    }
+
+    [Test]
+    public async Task AddInterceptorsFromExecutingAssembly_DoesNotThrow(CancellationToken cancellationToken)
+    {
+        using var host = await BuildHostAsync(
+                services => services.AddPulse(config => config.AddInterceptorsFromExecutingAssembly()),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private sealed class ScannedAssemblyEvent : IEvent
+    {
+        public string Id { get; } = Guid.NewGuid().ToString();
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+        public DateTimeOffset? PublishedAt { get; set; }
+    }
+
+    private sealed class ScannedAssemblyHandler(List<string> tracker) : IEventHandler<ScannedAssemblyEvent>
+    {
+        public Task HandleAsync(ScannedAssemblyEvent message, CancellationToken cancellationToken = default)
+        {
+            tracker.Add("ScannedAssemblyHandler");
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed record ScannedInterceptorQuery : IQuery<string>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed class ScannedInterceptorQueryHandler : IQueryHandler<ScannedInterceptorQuery, string>
+    {
+        public Task<string> HandleAsync(
+            ScannedInterceptorQuery request,
+            CancellationToken cancellationToken = default
+        ) => Task.FromResult("handled");
+    }
+
+    private sealed class ScannedInterceptor(List<string> tracker) : IRequestInterceptor<ScannedInterceptorQuery, string>
+    {
+        public async Task<string> HandleAsync(
+            ScannedInterceptorQuery request,
+            Func<ScannedInterceptorQuery, CancellationToken, Task<string>> handler,
+            CancellationToken cancellationToken = default
+        )
+        {
+            tracker.Add("ScannedInterceptor");
+            return await handler(request, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Integration/Pipeline/CachingTimeoutLoggingTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Pipeline/CachingTimeoutLoggingTests.cs
@@ -1,0 +1,694 @@
+namespace NetEvolve.Pulse.Tests.Integration.Pipeline;
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.Caching;
+using NetEvolve.Pulse.Extensibility.Outbox;
+using NetEvolve.Pulse.Interceptors;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+/// <summary>
+/// Integration tests exercising built-in Pulse interceptors (distributed cache query caching,
+/// request timeout enforcement, and structured logging) end-to-end through a real, fully built
+/// <see cref="IMediator"/> pipeline. Unlike the outbox/idempotency tests in this project, these
+/// tests do not require any real database or broker container.
+/// </summary>
+[TestGroup("Pipeline")]
+public sealed class CachingTimeoutLoggingTests
+{
+    private static async Task<IHost> BuildHostAsync(
+        Action<IServiceCollection> configureServices,
+        CancellationToken cancellationToken
+    )
+    {
+        var host = new HostBuilder().ConfigureServices(configureServices).Build();
+
+        await host.StartAsync(cancellationToken).ConfigureAwait(false);
+
+        return host;
+    }
+
+    // ---------------------------------------------------------------------
+    // DistributedCacheQueryInterceptor
+    // ---------------------------------------------------------------------
+
+    [Test]
+    public async Task DistributedCacheQueryInterceptor_Should_Only_Invoke_Handler_Once_For_Same_CacheKey(
+        CancellationToken cancellationToken
+    )
+    {
+        var executionCount = 0;
+
+        using var host = await BuildHostAsync(
+                services =>
+                {
+                    _ = services.AddDistributedMemoryCache();
+                    _ = services.AddSingleton<IQueryHandler<CachingTestQuery, int>>(
+                        new CachingTestQueryHandler(() => Interlocked.Increment(ref executionCount))
+                    );
+                    _ = services.AddPulse(builder => builder.AddQueryCaching());
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        var scope = host.Services.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+            var query = new CachingTestQuery("cache-key-1");
+
+            var first = await mediator
+                .QueryAsync<CachingTestQuery, int>(query, cancellationToken)
+                .ConfigureAwait(false);
+            var second = await mediator
+                .QueryAsync<CachingTestQuery, int>(query, cancellationToken)
+                .ConfigureAwait(false);
+
+            using (Assert.Multiple())
+            {
+                _ = await Assert.That(first).IsEqualTo(second);
+                _ = await Assert.That(executionCount).IsEqualTo(1);
+            }
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task DistributedCacheQueryInterceptor_Should_Invoke_Handler_For_Each_DistinctCacheKey(
+        CancellationToken cancellationToken
+    )
+    {
+        var executionCount = 0;
+
+        using var host = await BuildHostAsync(
+                services =>
+                {
+                    _ = services.AddDistributedMemoryCache();
+                    _ = services.AddSingleton<IQueryHandler<CachingTestQuery, int>>(
+                        new CachingTestQueryHandler(() => Interlocked.Increment(ref executionCount))
+                    );
+                    _ = services.AddPulse(builder => builder.AddQueryCaching());
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        var scope = host.Services.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            _ = await mediator
+                .QueryAsync<CachingTestQuery, int>(new CachingTestQuery("cache-key-a"), cancellationToken)
+                .ConfigureAwait(false);
+            _ = await mediator
+                .QueryAsync<CachingTestQuery, int>(new CachingTestQuery("cache-key-b"), cancellationToken)
+                .ConfigureAwait(false);
+
+            _ = await Assert.That(executionCount).IsEqualTo(2);
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    // ---------------------------------------------------------------------
+    // TimeoutRequestInterceptor / TimeoutStreamQueryInterceptor
+    // ---------------------------------------------------------------------
+
+    [Test]
+    public async Task TimeoutRequestInterceptor_Should_Throw_TimeoutException_When_HandlerExceedsDeadline(
+        CancellationToken cancellationToken
+    )
+    {
+        using var host = await BuildHostAsync(
+                services =>
+                {
+                    _ = services.AddSingleton<ICommandHandler<SlowTimeoutCommand, string>, SlowTimeoutCommandHandler>();
+                    _ = services.AddPulse(builder => builder.AddRequestTimeout());
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        var scope = host.Services.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+            var command = new SlowTimeoutCommand(TimeSpan.FromMilliseconds(50));
+
+            _ = await Assert.ThrowsAsync<TimeoutException>(async () =>
+                await mediator.SendAsync<SlowTimeoutCommand, string>(command, cancellationToken).ConfigureAwait(false)
+            );
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task TimeoutRequestInterceptor_Should_Complete_Normally_When_HandlerCompletesWithinDeadline(
+        CancellationToken cancellationToken
+    )
+    {
+        using var host = await BuildHostAsync(
+                services =>
+                {
+                    _ = services.AddSingleton<ICommandHandler<SlowTimeoutCommand, string>, SlowTimeoutCommandHandler>();
+                    _ = services.AddPulse(builder => builder.AddRequestTimeout());
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        var scope = host.Services.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+            var command = new SlowTimeoutCommand(TimeSpan.FromSeconds(5));
+
+            var result = await mediator
+                .SendAsync<SlowTimeoutCommand, string>(command, cancellationToken)
+                .ConfigureAwait(false);
+
+            _ = await Assert.That(result).IsEqualTo("completed");
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task TimeoutStreamQueryInterceptor_Should_Throw_TimeoutException_When_HandlerExceedsDeadline(
+        CancellationToken cancellationToken
+    )
+    {
+        using var host = await BuildHostAsync(
+                services =>
+                {
+                    _ = services.AddSingleton<
+                        IStreamQueryHandler<SlowTimeoutStreamQuery, int>,
+                        SlowTimeoutStreamQueryHandler
+                    >();
+                    _ = services.AddPulse(builder => builder.AddRequestTimeout());
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        var scope = host.Services.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+            var query = new SlowTimeoutStreamQuery(TimeSpan.FromMilliseconds(50));
+
+            _ = await Assert.ThrowsAsync<TimeoutException>(async () =>
+            {
+                await foreach (
+                    var item in mediator.StreamQueryAsync<SlowTimeoutStreamQuery, int>(query, cancellationToken)
+                )
+                {
+                    _ = item;
+                }
+            });
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    // ---------------------------------------------------------------------
+    // Logging interceptors
+    // ---------------------------------------------------------------------
+
+    [Test]
+    public async Task LoggingEventInterceptor_Should_Record_Begin_And_End_LogEntries(
+        CancellationToken cancellationToken
+    )
+    {
+        using var provider = new CapturingLoggerProvider();
+
+        using var host = await BuildHostAsync(
+                services =>
+                {
+                    _ = services.AddLogging(logging =>
+                    {
+                        _ = logging.ClearProviders();
+                        _ = logging.AddProvider(provider);
+                        _ = logging.SetMinimumLevel(LogLevel.Trace);
+                    });
+                    _ = services.AddSingleton<IEventHandler<FastLoggingEvent>, FastLoggingEventHandler>();
+                    _ = services.AddPulse(builder => builder.AddLogging());
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        var scope = host.Services.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            await mediator.PublishAsync(new FastLoggingEvent(), cancellationToken).ConfigureAwait(false);
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+
+        var records = provider.Records.ToArray();
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert
+                .That(records.Any(r => r.Message.Contains("FastLoggingEvent", StringComparison.Ordinal)))
+                .IsTrue();
+            _ = await Assert
+                .That(records.Any(r => r.Message.StartsWith("Handling", StringComparison.Ordinal)))
+                .IsTrue();
+            _ = await Assert
+                .That(records.Any(r => r.Message.StartsWith("Handled ", StringComparison.Ordinal)))
+                .IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task LoggingStreamQueryInterceptor_Should_Record_Begin_And_End_LogEntries(
+        CancellationToken cancellationToken
+    )
+    {
+        using var provider = new CapturingLoggerProvider();
+
+        using var host = await BuildHostAsync(
+                services =>
+                {
+                    _ = services.AddLogging(logging =>
+                    {
+                        _ = logging.ClearProviders();
+                        _ = logging.AddProvider(provider);
+                        _ = logging.SetMinimumLevel(LogLevel.Trace);
+                    });
+                    _ = services.AddSingleton<
+                        IStreamQueryHandler<FastLoggingStreamQuery, int>,
+                        FastLoggingStreamQueryHandler
+                    >();
+                    _ = services.AddPulse(builder => builder.AddLogging());
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        var scope = host.Services.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+            var items = new List<int>();
+
+            await foreach (
+                var item in mediator.StreamQueryAsync<FastLoggingStreamQuery, int>(
+                    new FastLoggingStreamQuery(),
+                    cancellationToken
+                )
+            )
+            {
+                items.Add(item);
+            }
+
+            _ = await Assert.That(items).IsEquivalentTo([1, 2]);
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+
+        var records = provider.Records.ToArray();
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert
+                .That(records.Any(r => r.Message.Contains("FastLoggingStreamQuery", StringComparison.Ordinal)))
+                .IsTrue();
+            // Stream queries log "Streaming ..." (begin) / "Streamed ... in Xms" (end) — see
+            // LoggingMessages.LogBeginStreamQuery / LogEndStreamQuery.
+            _ = await Assert
+                .That(records.Any(r => r.Message.StartsWith("Streaming", StringComparison.Ordinal)))
+                .IsTrue();
+            _ = await Assert
+                .That(records.Any(r => r.Message.StartsWith("Streamed ", StringComparison.Ordinal)))
+                .IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task LoggingRequestInterceptor_Should_Record_Begin_And_End_LogEntries(
+        CancellationToken cancellationToken
+    )
+    {
+        using var provider = new CapturingLoggerProvider();
+
+        using var host = await BuildHostAsync(
+                services =>
+                {
+                    _ = services.AddLogging(logging =>
+                    {
+                        _ = logging.ClearProviders();
+                        _ = logging.AddProvider(provider);
+                        _ = logging.SetMinimumLevel(LogLevel.Trace);
+                    });
+                    _ = services.AddSingleton<ICommandHandler<FastLoggingCommand, string>, FastLoggingCommandHandler>();
+                    _ = services.AddPulse(builder => builder.AddLogging());
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        var scope = host.Services.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            var result = await mediator
+                .SendAsync<FastLoggingCommand, string>(new FastLoggingCommand(), cancellationToken)
+                .ConfigureAwait(false);
+
+            _ = await Assert.That(result).IsEqualTo("fast");
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+
+        var records = provider.Records.ToArray();
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert
+                .That(records.Any(r => r.Message.Contains("FastLoggingCommand", StringComparison.Ordinal)))
+                .IsTrue();
+            // "Handling ..." is emitted before the handler runs (begin), "Handled ... in Xms" after it
+            // completes successfully (end) — see LoggingMessages.LogBeginHandle / LogEndHandle.
+            _ = await Assert
+                .That(records.Any(r => r.Message.StartsWith("Handling", StringComparison.Ordinal)))
+                .IsTrue();
+            _ = await Assert
+                .That(records.Any(r => r.Message.StartsWith("Handled ", StringComparison.Ordinal)))
+                .IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task LoggingRequestInterceptor_Should_Record_SlowRequest_Warning_When_ThresholdExceeded(
+        CancellationToken cancellationToken
+    )
+    {
+        using var provider = new CapturingLoggerProvider();
+
+        using var host = await BuildHostAsync(
+                services =>
+                {
+                    _ = services.AddLogging(logging =>
+                    {
+                        _ = logging.ClearProviders();
+                        _ = logging.AddProvider(provider);
+                        _ = logging.SetMinimumLevel(LogLevel.Trace);
+                    });
+                    _ = services.AddSingleton<ICommandHandler<SlowLoggingCommand, string>, SlowLoggingCommandHandler>();
+                    _ = services.AddPulse(builder =>
+                        builder.AddLogging(opts => opts.SlowRequestThreshold = TimeSpan.FromMilliseconds(10))
+                    );
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        var scope = host.Services.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            _ = await mediator
+                .SendAsync<SlowLoggingCommand, string>(new SlowLoggingCommand(), cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+
+        var records = provider.Records.ToArray();
+
+        _ = await Assert.That(records.Any(r => r.Level == LogLevel.Warning)).IsTrue();
+    }
+
+    // ---------------------------------------------------------------------
+    // NullMessageTransport
+    // ---------------------------------------------------------------------
+
+    [Test]
+    public async Task NullMessageTransport_SendAsync_Should_CompleteWithoutError(CancellationToken cancellationToken)
+    {
+        var transport = new NullMessageTransport();
+        var message = new OutboxMessage
+        {
+            Id = Guid.NewGuid(),
+            EventType = typeof(object),
+            Payload = "{}",
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Status = OutboxMessageStatus.Processing,
+        };
+
+        await transport.SendAsync(message, cancellationToken).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task IMessageTransport_DefaultSendBatchAsync_Sends_AllMessages_Sequentially_InOrder(
+        CancellationToken cancellationToken
+    )
+    {
+        IMessageTransport transport = new RecordingMessageTransport();
+        var messages = Enumerable
+            .Range(0, 3)
+            .Select(i => new OutboxMessage
+            {
+                Id = Guid.NewGuid(),
+                EventType = typeof(object),
+                Payload = i.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                CreatedAt = DateTimeOffset.UtcNow,
+                UpdatedAt = DateTimeOffset.UtcNow,
+                Status = OutboxMessageStatus.Processing,
+            })
+            .ToList();
+
+        // Exercised through the interface reference so the default SendBatchAsync/SendBatchInternalAsync
+        // implementation on IMessageTransport runs (RecordingMessageTransport only overrides SendAsync).
+        await transport.SendBatchAsync(messages, cancellationToken).ConfigureAwait(false);
+
+        var recorder = (RecordingMessageTransport)transport;
+        _ = await Assert.That(recorder.SentPayloads).IsEquivalentTo(["0", "1", "2"]);
+    }
+
+    [Test]
+    public async Task IMessageTransport_DefaultSendBatchAsync_WithNullMessages_ThrowsArgumentNullException()
+    {
+        IMessageTransport transport = new RecordingMessageTransport();
+
+        _ = await Assert.That(() => transport.SendBatchAsync(null!)).Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task IMessageTransport_DefaultIsHealthyAsync_ReturnsTrue(CancellationToken cancellationToken)
+    {
+        IMessageTransport transport = new RecordingMessageTransport();
+
+        var healthy = await transport.IsHealthyAsync(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(healthy).IsTrue();
+    }
+
+    // ---------------------------------------------------------------------
+    // Test doubles - Caching
+    // ---------------------------------------------------------------------
+
+    /// <summary>
+    /// Minimal <see cref="IMessageTransport"/> implementation that only overrides <see cref="SendAsync"/>,
+    /// so calling <see cref="IMessageTransport.SendBatchAsync"/>/<see cref="IMessageTransport.IsHealthyAsync"/>
+    /// through the interface exercises the interface's own default implementations.
+    /// </summary>
+    private sealed class RecordingMessageTransport : IMessageTransport
+    {
+        private readonly ConcurrentQueue<string> _sentPayloads = new();
+
+        public IReadOnlyList<string> SentPayloads => [.. _sentPayloads];
+
+        public Task SendAsync(OutboxMessage message, CancellationToken cancellationToken = default)
+        {
+            _sentPayloads.Enqueue(message.Payload);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed record CachingTestQuery(string Id) : ICacheableQuery<int>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+
+        public string CacheKey => $"pipeline-caching-test:{Id}";
+
+        public TimeSpan? Expiry => TimeSpan.FromMinutes(5);
+    }
+
+    private sealed class CachingTestQueryHandler(Action onExecuted) : IQueryHandler<CachingTestQuery, int>
+    {
+        private int _value;
+
+        public Task<int> HandleAsync(CachingTestQuery request, CancellationToken cancellationToken = default)
+        {
+            onExecuted();
+            return Task.FromResult(Interlocked.Increment(ref _value));
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Test doubles - Timeout
+    // ---------------------------------------------------------------------
+
+    private sealed record SlowTimeoutCommand(TimeSpan Timeout) : ICommand<string>, ITimeoutRequest
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+
+        TimeSpan? ITimeoutRequest.Timeout => Timeout;
+    }
+
+    private sealed class SlowTimeoutCommandHandler : ICommandHandler<SlowTimeoutCommand, string>
+    {
+        public async Task<string> HandleAsync(SlowTimeoutCommand command, CancellationToken cancellationToken = default)
+        {
+            // Always delay longer than the "fast" test's timeout, but shorter than the "slow" test's timeout,
+            // so both the timeout and the pass-through scenario can be exercised deterministically.
+            await Task.Delay(TimeSpan.FromMilliseconds(250), cancellationToken).ConfigureAwait(false);
+            return "completed";
+        }
+    }
+
+    private sealed record SlowTimeoutStreamQuery(TimeSpan Timeout) : IStreamQuery<int>, ITimeoutRequest
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+
+        TimeSpan? ITimeoutRequest.Timeout => Timeout;
+    }
+
+    private sealed class SlowTimeoutStreamQueryHandler : IStreamQueryHandler<SlowTimeoutStreamQuery, int>
+    {
+        public async IAsyncEnumerable<int> HandleAsync(
+            SlowTimeoutStreamQuery request,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default
+        )
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(250), cancellationToken).ConfigureAwait(false);
+            yield return 1;
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Test doubles - Logging
+    // ---------------------------------------------------------------------
+
+    private sealed record FastLoggingCommand : ICommand<string>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed class FastLoggingCommandHandler : ICommandHandler<FastLoggingCommand, string>
+    {
+        public Task<string> HandleAsync(FastLoggingCommand command, CancellationToken cancellationToken = default) =>
+            Task.FromResult("fast");
+    }
+
+    private sealed record SlowLoggingCommand : ICommand<string>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed class SlowLoggingCommandHandler : ICommandHandler<SlowLoggingCommand, string>
+    {
+        public async Task<string> HandleAsync(SlowLoggingCommand command, CancellationToken cancellationToken = default)
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(50), cancellationToken).ConfigureAwait(false);
+            return "slow";
+        }
+    }
+
+    private sealed record FastLoggingEvent : IEvent
+    {
+        public string Id { get; init; } = Guid.NewGuid().ToString();
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+        public DateTimeOffset? PublishedAt { get; set; }
+    }
+
+    private sealed class FastLoggingEventHandler : IEventHandler<FastLoggingEvent>
+    {
+        public Task HandleAsync(FastLoggingEvent @event, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+    }
+
+    private sealed record FastLoggingStreamQuery : IStreamQuery<int>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed class FastLoggingStreamQueryHandler : IStreamQueryHandler<FastLoggingStreamQuery, int>
+    {
+        public async IAsyncEnumerable<int> HandleAsync(
+            FastLoggingStreamQuery request,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default
+        )
+        {
+            yield return 1;
+            await Task.Yield();
+            yield return 2;
+        }
+    }
+
+    /// <summary>
+    /// Minimal in-memory <see cref="ILoggerProvider"/> that captures every log entry emitted through it,
+    /// so tests can assert on structured log output produced by the built-in logging interceptors.
+    /// </summary>
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        public ConcurrentBag<CapturedLogRecord> Records { get; } = [];
+
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(categoryName, Records);
+
+        public void Dispose() { }
+
+        private sealed class CapturingLogger(string categoryName, ConcurrentBag<CapturedLogRecord> records) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state)
+                where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter
+            )
+            {
+                ArgumentNullException.ThrowIfNull(formatter);
+                records.Add(new CapturedLogRecord(categoryName, logLevel, eventId, formatter(state, exception)));
+            }
+        }
+    }
+
+    private sealed record CapturedLogRecord(string Category, LogLevel Level, EventId EventId, string Message);
+}

--- a/tests/NetEvolve.Pulse.Tests.Integration/Pipeline/EventDispatchingTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Pipeline/EventDispatchingTests.cs
@@ -154,7 +154,9 @@ public sealed class EventDispatchingTests
         public async Task HandleAsync(ParallelTestEvent message, CancellationToken cancellationToken = default)
         {
             _ = gate.GateA.TrySetResult(true);
+#pragma warning disable VSTHRD003 // rendezvous on a TaskCompletionSource signaled by a sibling handler, not a foreign task
             _ = await Task.WhenAny(gate.GateB.Task, Task.Delay(10_000, cancellationToken)).ConfigureAwait(false);
+#pragma warning restore VSTHRD003
             tracker.Record("A");
         }
     }
@@ -165,7 +167,9 @@ public sealed class EventDispatchingTests
         public async Task HandleAsync(ParallelTestEvent message, CancellationToken cancellationToken = default)
         {
             _ = gate.GateB.TrySetResult(true);
+#pragma warning disable VSTHRD003 // rendezvous on a TaskCompletionSource signaled by a sibling handler, not a foreign task
             _ = await Task.WhenAny(gate.GateA.Task, Task.Delay(10_000, cancellationToken)).ConfigureAwait(false);
+#pragma warning restore VSTHRD003
             tracker.Record("B");
         }
     }

--- a/tests/NetEvolve.Pulse.Tests.Integration/Pipeline/EventDispatchingTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Pipeline/EventDispatchingTests.cs
@@ -1,0 +1,620 @@
+namespace NetEvolve.Pulse.Tests.Integration.Pipeline;
+
+using System.Collections.Concurrent;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Dispatchers;
+using NetEvolve.Pulse.Extensibility;
+
+/// <summary>
+/// End-to-end integration tests exercising the core mediator's event dispatch pipeline
+/// (dispatcher strategies, event filters, and assembly-scanning based handler registration)
+/// through a real host built via <c>services.AddPulse(...)</c>. Unlike the Outbox tests in this
+/// project, these tests do not require any database or broker container — <c>IMediator.PublishAsync</c>
+/// invokes registered <see cref="IEventHandler{TEvent}"/> instances directly when no outbox is configured.
+/// </summary>
+[TestGroup("Pipeline")]
+[Timeout(60_000)]
+public sealed class EventDispatchingTests
+{
+    private static async Task RunAsync(
+        Action<IServiceCollection> configureServices,
+        Func<IServiceProvider, CancellationToken, Task> testableCode,
+        CancellationToken cancellationToken
+    )
+    {
+        using var host = new HostBuilder()
+            .ConfigureServices(configureServices)
+            .ConfigureWebHost(webBuilder => _ = webBuilder.UseTestServer().Configure(applicationBuilder => { }))
+            .Build();
+
+        await host.StartAsync(cancellationToken).ConfigureAwait(false);
+
+        using var server = host.GetTestServer();
+
+        var scope = server.Services.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            await testableCode.Invoke(scope.ServiceProvider, cancellationToken).ConfigureAwait(false);
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Thread-safe recorder used by handlers across the tests in this file to prove ordering,
+    /// concurrency, and filtering behaviour without relying on timing assumptions alone.
+    /// </summary>
+    private sealed class ExecutionTracker
+    {
+        private readonly ConcurrentQueue<string> _entries = new();
+
+        public void Record(string name) => _entries.Enqueue(name);
+
+        public IReadOnlyList<string> Entries => [.. _entries];
+    }
+
+    #region Sequential dispatcher
+
+    private sealed class SequentialTestEvent : IEvent
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+        public string Id { get; } = Guid.NewGuid().ToString();
+        public DateTimeOffset? PublishedAt { get; set; }
+    }
+
+    private sealed class SequentialHandlerA(ExecutionTracker tracker) : IEventHandler<SequentialTestEvent>
+    {
+        public async Task HandleAsync(SequentialTestEvent message, CancellationToken cancellationToken = default)
+        {
+            // Deliberately slower than the following handlers. Under sequential dispatch this
+            // handler must still fully complete before the next one starts.
+            await Task.Delay(50, cancellationToken).ConfigureAwait(false);
+            tracker.Record("A");
+        }
+    }
+
+    private sealed class SequentialHandlerB(ExecutionTracker tracker) : IEventHandler<SequentialTestEvent>
+    {
+        public Task HandleAsync(SequentialTestEvent message, CancellationToken cancellationToken = default)
+        {
+            tracker.Record("B");
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class SequentialHandlerC(ExecutionTracker tracker) : IEventHandler<SequentialTestEvent>
+    {
+        public Task HandleAsync(SequentialTestEvent message, CancellationToken cancellationToken = default)
+        {
+            tracker.Record("C");
+            return Task.CompletedTask;
+        }
+    }
+
+    [Test]
+    public async Task SequentialDispatcher_Executes_Handlers_InRegistrationOrder(CancellationToken cancellationToken)
+    {
+        var tracker = new ExecutionTracker();
+
+        await RunAsync(
+                services =>
+                    services
+                        .AddSingleton(tracker)
+                        .AddPulse(config =>
+                            config
+                                .UseDefaultEventDispatcher<SequentialEventDispatcher>()
+                                .AddEventHandler<SequentialTestEvent, SequentialHandlerA>()
+                                .AddEventHandler<SequentialTestEvent, SequentialHandlerB>()
+                                .AddEventHandler<SequentialTestEvent, SequentialHandlerC>()
+                        ),
+                async (services, token) =>
+                {
+                    var mediator = services.GetRequiredService<IMediator>();
+
+                    await mediator.PublishAsync(new SequentialTestEvent(), token).ConfigureAwait(false);
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(tracker.Entries).IsEquivalentTo(["A", "B", "C"]);
+    }
+
+    #endregion
+
+    #region Parallel dispatcher
+
+    private sealed class ParallelTestEvent : IEvent
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+        public string Id { get; } = Guid.NewGuid().ToString();
+        public DateTimeOffset? PublishedAt { get; set; }
+    }
+
+    /// <summary>
+    /// Coordinates a rendezvous between two handlers: each signals its own gate and then waits for
+    /// the other handler's gate. This only completes if both handlers are running concurrently -
+    /// a purely sequential dispatcher would deadlock (and time out) here.
+    /// </summary>
+    private sealed class RendezvousGate
+    {
+        public TaskCompletionSource<bool> GateA { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource<bool> GateB { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+
+    private sealed class ParallelHandlerA(RendezvousGate gate, ExecutionTracker tracker)
+        : IEventHandler<ParallelTestEvent>
+    {
+        public async Task HandleAsync(ParallelTestEvent message, CancellationToken cancellationToken = default)
+        {
+            _ = gate.GateA.TrySetResult(true);
+            _ = await Task.WhenAny(gate.GateB.Task, Task.Delay(10_000, cancellationToken)).ConfigureAwait(false);
+            tracker.Record("A");
+        }
+    }
+
+    private sealed class ParallelHandlerB(RendezvousGate gate, ExecutionTracker tracker)
+        : IEventHandler<ParallelTestEvent>
+    {
+        public async Task HandleAsync(ParallelTestEvent message, CancellationToken cancellationToken = default)
+        {
+            _ = gate.GateB.TrySetResult(true);
+            _ = await Task.WhenAny(gate.GateA.Task, Task.Delay(10_000, cancellationToken)).ConfigureAwait(false);
+            tracker.Record("B");
+        }
+    }
+
+    [Test]
+    public async Task ParallelDispatcher_Executes_Handlers_Concurrently(CancellationToken cancellationToken)
+    {
+        var tracker = new ExecutionTracker();
+        var gate = new RendezvousGate();
+
+        await RunAsync(
+                services =>
+                    services
+                        .AddSingleton(tracker)
+                        .AddSingleton(gate)
+                        .AddPulse(config =>
+                            config
+                                .UseDefaultEventDispatcher<ParallelEventDispatcher>()
+                                .AddEventHandler<ParallelTestEvent, ParallelHandlerA>()
+                                .AddEventHandler<ParallelTestEvent, ParallelHandlerB>()
+                        ),
+                async (services, token) =>
+                {
+                    var mediator = services.GetRequiredService<IMediator>();
+
+                    await mediator.PublishAsync(new ParallelTestEvent(), token).ConfigureAwait(false);
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        // Both handlers must have unblocked each other and completed - proving concurrent execution.
+        _ = await Assert.That(gate.GateA.Task.IsCompletedSuccessfully).IsTrue();
+        _ = await Assert.That(gate.GateB.Task.IsCompletedSuccessfully).IsTrue();
+        _ = await Assert.That(tracker.Entries.Count).IsEqualTo(2);
+        _ = await Assert.That(tracker.Entries).Contains("A");
+        _ = await Assert.That(tracker.Entries).Contains("B");
+    }
+
+    #endregion
+
+    #region Prioritized dispatcher
+
+    private sealed class PrioritizedTestEvent : IEvent
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+        public string Id { get; } = Guid.NewGuid().ToString();
+        public DateTimeOffset? PublishedAt { get; set; }
+    }
+
+    private sealed class PrioritizedHighPriorityHandler(ExecutionTracker tracker)
+        : IPrioritizedEventHandler<PrioritizedTestEvent>
+    {
+        public int Priority => 0;
+
+        public async Task HandleAsync(PrioritizedTestEvent message, CancellationToken cancellationToken = default)
+        {
+            // Intentionally slower than the handlers that follow. Because priority groups execute
+            // sequentially, this handler must still fully complete before the mid-priority group starts.
+            await Task.Delay(50, cancellationToken).ConfigureAwait(false);
+            tracker.Record("High");
+        }
+    }
+
+    private sealed class PrioritizedMidPriorityHandler(ExecutionTracker tracker)
+        : IPrioritizedEventHandler<PrioritizedTestEvent>
+    {
+        public int Priority => 10;
+
+        public Task HandleAsync(PrioritizedTestEvent message, CancellationToken cancellationToken = default)
+        {
+            tracker.Record("Mid");
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>
+    /// Does not implement <see cref="IPrioritizedEventHandler{TEvent}"/>, so it is treated as
+    /// priority <see cref="int.MaxValue"/> and must always execute last.
+    /// </summary>
+    private sealed class PrioritizedUnprioritizedHandler(ExecutionTracker tracker) : IEventHandler<PrioritizedTestEvent>
+    {
+        public Task HandleAsync(PrioritizedTestEvent message, CancellationToken cancellationToken = default)
+        {
+            tracker.Record("Unprioritized");
+            return Task.CompletedTask;
+        }
+    }
+
+    [Test]
+    public async Task PrioritizedDispatcher_Executes_Handlers_InPriorityOrder(CancellationToken cancellationToken)
+    {
+        var tracker = new ExecutionTracker();
+
+        await RunAsync(
+                services =>
+                    services
+                        .AddSingleton(tracker)
+                        .AddPulse(config =>
+                            config
+                                .UseDefaultEventDispatcher<PrioritizedEventDispatcher>()
+                                .AddEventHandler<PrioritizedTestEvent, PrioritizedUnprioritizedHandler>()
+                                .AddEventHandler<PrioritizedTestEvent, PrioritizedHighPriorityHandler>()
+                                .AddEventHandler<PrioritizedTestEvent, PrioritizedMidPriorityHandler>()
+                        ),
+                async (services, token) =>
+                {
+                    var mediator = services.GetRequiredService<IMediator>();
+
+                    await mediator.PublishAsync(new PrioritizedTestEvent(), token).ConfigureAwait(false);
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(tracker.Entries).IsEquivalentTo(["High", "Mid", "Unprioritized"]);
+    }
+
+    #endregion
+
+    #region Rate-limited dispatcher
+
+    private sealed class RateLimitedTestEvent : IEvent
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+        public string Id { get; } = Guid.NewGuid().ToString();
+        public DateTimeOffset? PublishedAt { get; set; }
+    }
+
+    /// <summary>
+    /// Tracks the number of handlers currently executing, and the maximum observed concurrently,
+    /// to verify that the <see cref="RateLimitedEventDispatcher"/> never exceeds its configured
+    /// <see cref="RateLimitedEventDispatcher.MaxConcurrency"/>.
+    /// </summary>
+    private sealed class ConcurrencyTracker
+    {
+        private int _current;
+        private int _max;
+
+        public void Enter()
+        {
+            var current = Interlocked.Increment(ref _current);
+
+            int observedMax;
+            do
+            {
+                observedMax = _max;
+                if (current <= observedMax)
+                {
+                    break;
+                }
+            } while (Interlocked.CompareExchange(ref _max, current, observedMax) != observedMax);
+        }
+
+        public void Exit() => Interlocked.Decrement(ref _current);
+
+        public int MaxObserved => _max;
+    }
+
+    private sealed class RateLimitedHandler(ConcurrencyTracker tracker) : IEventHandler<RateLimitedTestEvent>
+    {
+        public async Task HandleAsync(RateLimitedTestEvent message, CancellationToken cancellationToken = default)
+        {
+            tracker.Enter();
+            try
+            {
+                await Task.Delay(75, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                tracker.Exit();
+            }
+        }
+    }
+
+    [Test]
+    public async Task RateLimitedDispatcher_Never_Exceeds_ConfiguredMaxConcurrency(CancellationToken cancellationToken)
+    {
+        const int maxConcurrency = 2;
+        var tracker = new ConcurrencyTracker();
+
+        await RunAsync(
+                services =>
+                    services
+                        .AddSingleton(tracker)
+                        .AddPulse(config =>
+                            config
+                                .UseDefaultEventDispatcher(_ => new RateLimitedEventDispatcher(maxConcurrency))
+                                .AddEventHandler<RateLimitedTestEvent, RateLimitedHandler>()
+                                .AddEventHandler<RateLimitedTestEvent, RateLimitedHandler>()
+                                .AddEventHandler<RateLimitedTestEvent, RateLimitedHandler>()
+                                .AddEventHandler<RateLimitedTestEvent, RateLimitedHandler>()
+                                .AddEventHandler<RateLimitedTestEvent, RateLimitedHandler>()
+                        ),
+                async (services, token) =>
+                {
+                    var mediator = services.GetRequiredService<IMediator>();
+
+                    await mediator.PublishAsync(new RateLimitedTestEvent(), token).ConfigureAwait(false);
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            // Never exceeded the configured limit ...
+            _ = await Assert.That(tracker.MaxObserved).IsLessThanOrEqualTo(maxConcurrency);
+            // ... but did reach it, proving handlers actually ran concurrently rather than sequentially.
+            _ = await Assert.That(tracker.MaxObserved).IsEqualTo(maxConcurrency);
+        }
+    }
+
+    #endregion
+
+    #region Event filter / predicate
+
+    private sealed class FilteredTestEvent : IEvent
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+        public string Id { get; } = Guid.NewGuid().ToString();
+        public DateTimeOffset? PublishedAt { get; set; }
+        public required int Value { get; init; }
+    }
+
+    private sealed class FilteredEventHandler(ExecutionTracker tracker) : IEventHandler<FilteredTestEvent>
+    {
+        public Task HandleAsync(FilteredTestEvent message, CancellationToken cancellationToken = default)
+        {
+            tracker.Record($"Value:{message.Value}");
+            return Task.CompletedTask;
+        }
+    }
+
+    [Test]
+    public async Task EventFilter_Predicate_Skips_Handler_For_FilteredEvents(CancellationToken cancellationToken)
+    {
+        var tracker = new ExecutionTracker();
+
+        await RunAsync(
+                services =>
+                    services
+                        .AddSingleton(tracker)
+                        .AddPulse(config =>
+                            config
+                                .AddEventHandler<FilteredTestEvent, FilteredEventHandler>()
+                                .AddEventFilter<FilteredTestEvent>((evt, _) => ValueTask.FromResult(evt.Value % 2 == 0))
+                        ),
+                async (services, token) =>
+                {
+                    var mediator = services.GetRequiredService<IMediator>();
+
+                    for (var i = 0; i < 5; i++)
+                    {
+                        await mediator.PublishAsync(new FilteredTestEvent { Value = i }, token).ConfigureAwait(false);
+                    }
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(tracker.Entries).IsEquivalentTo(["Value:0", "Value:2", "Value:4"]);
+    }
+
+    #endregion
+
+    #region Assembly scanning
+
+    private sealed class ScannedTestEvent : IEvent
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+        public string Id { get; } = Guid.NewGuid().ToString();
+        public DateTimeOffset? PublishedAt { get; set; }
+    }
+
+    private sealed class ScannedEventHandler(ExecutionTracker tracker) : IEventHandler<ScannedTestEvent>
+    {
+        public Task HandleAsync(ScannedTestEvent message, CancellationToken cancellationToken = default)
+        {
+            tracker.Record("Scanned");
+            return Task.CompletedTask;
+        }
+    }
+
+    [Test]
+    public async Task AssemblyScanning_Discovers_And_Invokes_EventHandler(CancellationToken cancellationToken)
+    {
+        var tracker = new ExecutionTracker();
+
+        await RunAsync(
+                services =>
+                    services
+                        .AddSingleton(tracker)
+                        .AddPulse(config => config.AddHandlersFromAssemblyContaining<EventDispatchingTests>()),
+                async (services, token) =>
+                {
+                    var mediator = services.GetRequiredService<IMediator>();
+
+                    // Confirm the scanned handler type was actually the one discovered and registered
+                    // by reflection, not merely a coincidentally-named handler.
+                    var handlers = services.GetServices<IEventHandler<ScannedTestEvent>>().ToArray();
+                    _ = await Assert.That(handlers).HasSingleItem();
+                    _ = await Assert.That(handlers[0]).IsTypeOf<ScannedEventHandler>();
+
+                    await mediator.PublishAsync(new ScannedTestEvent(), token).ConfigureAwait(false);
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(tracker.Entries).IsEquivalentTo(["Scanned"]);
+    }
+
+    #endregion
+
+    #region Per-event-type dispatcher (UseEventDispatcherFor)
+
+    private sealed class KeyedTestEvent : IEvent
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+        public string Id { get; } = Guid.NewGuid().ToString();
+        public DateTimeOffset? PublishedAt { get; set; }
+    }
+
+    private sealed class KeyedEventHandler(ExecutionTracker tracker) : IEventHandler<KeyedTestEvent>
+    {
+        public Task HandleAsync(KeyedTestEvent message, CancellationToken cancellationToken = default)
+        {
+            tracker.Record("Keyed");
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>
+    /// Marker dispatcher distinct from the built-in strategies, so tests can prove the keyed
+    /// registration actually routes to THIS dispatcher rather than the default one.
+    /// </summary>
+    private sealed class MarkerEventDispatcher(ExecutionTracker tracker) : IEventDispatcher
+    {
+        public async Task DispatchAsync<TEvent>(
+            TEvent message,
+            IEnumerable<IEventHandler<TEvent>> handlers,
+            Func<IEventHandler<TEvent>, TEvent, CancellationToken, Task> invoker,
+            CancellationToken cancellationToken
+        )
+            where TEvent : IEvent
+        {
+            tracker.Record("MarkerDispatcherUsed");
+            foreach (var handler in handlers)
+            {
+                await invoker(handler, message, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    [Test]
+    public async Task UseEventDispatcherFor_Routes_SpecificEventType_ToRegisteredDispatcher(
+        CancellationToken cancellationToken
+    )
+    {
+        var tracker = new ExecutionTracker();
+
+        await RunAsync(
+                services =>
+                    services
+                        .AddSingleton(tracker)
+                        .AddSingleton<MarkerEventDispatcher>()
+                        .AddSingleton<IEventHandler<KeyedTestEvent>, KeyedEventHandler>()
+                        .AddPulse(config => config.UseEventDispatcherFor<KeyedTestEvent, MarkerEventDispatcher>()),
+                async (services, token) =>
+                {
+                    var mediator = services.GetRequiredService<IMediator>();
+
+                    await mediator.PublishAsync(new KeyedTestEvent(), token).ConfigureAwait(false);
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(tracker.Entries).IsEquivalentTo(["MarkerDispatcherUsed", "Keyed"]);
+    }
+
+    [Test]
+    public async Task UseEventDispatcherFor_WithFactory_Routes_SpecificEventType_ToRegisteredDispatcher(
+        CancellationToken cancellationToken
+    )
+    {
+        var tracker = new ExecutionTracker();
+
+        await RunAsync(
+                services =>
+                    services
+                        .AddSingleton(tracker)
+                        .AddSingleton<IEventHandler<KeyedTestEvent>, KeyedEventHandler>()
+                        .AddPulse(config =>
+                            config.UseEventDispatcherFor<KeyedTestEvent, MarkerEventDispatcher>(
+                                sp => new MarkerEventDispatcher(sp.GetRequiredService<ExecutionTracker>())
+                            )
+                        ),
+                async (services, token) =>
+                {
+                    var mediator = services.GetRequiredService<IMediator>();
+
+                    await mediator.PublishAsync(new KeyedTestEvent(), token).ConfigureAwait(false);
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(tracker.Entries).IsEquivalentTo(["MarkerDispatcherUsed", "Keyed"]);
+    }
+
+    [Test]
+    public async Task UseEventDispatcherFor_CalledTwice_ReplacesPreviousRegistration(
+        CancellationToken cancellationToken
+    )
+    {
+        var tracker = new ExecutionTracker();
+
+        await RunAsync(
+                services =>
+                    services
+                        .AddSingleton(tracker)
+                        .AddSingleton<MarkerEventDispatcher>()
+                        .AddSingleton<SequentialEventDispatcher>()
+                        .AddSingleton<IEventHandler<KeyedTestEvent>, KeyedEventHandler>()
+                        .AddPulse(config =>
+                            config
+                                .UseEventDispatcherFor<KeyedTestEvent, MarkerEventDispatcher>()
+                                .UseEventDispatcherFor<KeyedTestEvent, SequentialEventDispatcher>()
+                        ),
+                async (services, token) =>
+                {
+                    var mediator = services.GetRequiredService<IMediator>();
+
+                    await mediator.PublishAsync(new KeyedTestEvent(), token).ConfigureAwait(false);
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        // Only the second (Sequential) registration should apply — the marker dispatcher must never run.
+        _ = await Assert.That(tracker.Entries).IsEquivalentTo(["Keyed"]);
+    }
+
+    #endregion
+}

--- a/tests/NetEvolve.Pulse.Tests.Integration/Pipeline/ExtensibilityTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Pipeline/ExtensibilityTests.cs
@@ -1,0 +1,162 @@
+namespace NetEvolve.Pulse.Tests.Integration.Pipeline;
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.Outbox;
+
+/// <summary>
+/// End-to-end integration tests for <see cref="CommandBatch"/>, <see cref="MediatorSendOnlyExtensions"/>,
+/// and the <see cref="IEventInProcess"/> default interface member, exercised through a real built host
+/// and the real mediator rather than mocks.
+/// </summary>
+[TestGroup("Pipeline")]
+public sealed class ExtensibilityTests
+{
+    [Test]
+    public async Task SendBatchAsync_Executes_Commands_Sequentially_InOrder(CancellationToken cancellationToken)
+    {
+        var order = new List<int>();
+
+        using var host = await CreateHostAsync(services => services.AddSingleton(order), cancellationToken)
+            .ConfigureAwait(false);
+        using var scope = host.Services.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediatorSendOnly>();
+
+        var batch = new CommandBatch().Add(new RecordCommand(1)).Add(new RecordCommand(2)).Add(new RecordCommand(3));
+
+        await mediator.SendBatchAsync(batch, cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(order).IsEquivalentTo([1, 2, 3]);
+    }
+
+    [Test]
+    public async Task SendBatchAsync_OnFailure_StopsAndPropagatesException_SkippingRemaining(
+        CancellationToken cancellationToken
+    )
+    {
+        var order = new List<int>();
+
+        using var host = await CreateHostAsync(services => services.AddSingleton(order), cancellationToken)
+            .ConfigureAwait(false);
+        using var scope = host.Services.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediatorSendOnly>();
+
+        var batch = new CommandBatch().Add(new RecordCommand(1)).Add(new FailingCommand()).Add(new RecordCommand(3));
+
+        _ = await Assert
+            .That(() => mediator.SendBatchAsync(batch, cancellationToken))
+            .Throws<InvalidOperationException>();
+
+        // The third command must never run since the batch stops at the first failure.
+        _ = await Assert.That(order).IsEquivalentTo([1]);
+    }
+
+    [Test]
+    public async Task CommandBatch_Add_WithNullCommand_ThrowsArgumentNullException()
+    {
+        var batch = new CommandBatch();
+
+        _ = await Assert.That(() => batch.Add<RecordCommand>(null!)).Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task IEventInProcess_DefaultImplementation_HandleInProcess_IsTrue()
+    {
+        IEventInProcess @event = new InProcessOnlyEvent();
+
+        _ = await Assert.That(@event.HandleInProcess).IsTrue();
+    }
+
+    [Test]
+    public async Task IOutboxTransactionScope_DefaultImplementation_HasActiveTransaction_ReflectsCurrentTransaction()
+    {
+        IOutboxTransactionScope noneActive = new TestTransactionScope(currentTransaction: null);
+        IOutboxTransactionScope active = new TestTransactionScope(currentTransaction: new object());
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(noneActive.HasActiveTransaction).IsFalse();
+            _ = await Assert.That(active.HasActiveTransaction).IsTrue();
+        }
+    }
+
+    private static async Task<IHost> CreateHostAsync(
+        Action<IServiceCollection> configureServices,
+        CancellationToken cancellationToken
+    )
+    {
+        var host = new HostBuilder()
+            .ConfigureWebHost(webBuilder =>
+            {
+                _ = webBuilder.UseTestServer();
+                _ = webBuilder.ConfigureServices(services =>
+                {
+                    configureServices(services);
+                    _ = services.AddPulse(configurator =>
+                        configurator
+                            .AddCommandHandler<RecordCommand, RecordCommandHandler>()
+                            .AddCommandHandler<FailingCommand, FailingCommandHandler>()
+                    );
+                });
+                _ = webBuilder.Configure(applicationBuilder => { });
+            })
+            .Build();
+
+        await host.StartAsync(cancellationToken).ConfigureAwait(false);
+        return host;
+    }
+
+    private sealed record RecordCommand(int Value) : ICommand
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed class RecordCommandHandler(List<int> order)
+        : ICommandHandler<RecordCommand, NetEvolve.Pulse.Extensibility.Void>
+    {
+        public Task<NetEvolve.Pulse.Extensibility.Void> HandleAsync(
+            RecordCommand command,
+            CancellationToken cancellationToken = default
+        )
+        {
+            order.Add(command.Value);
+            return Task.FromResult<NetEvolve.Pulse.Extensibility.Void>(default);
+        }
+    }
+
+    private sealed record FailingCommand : ICommand
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed class FailingCommandHandler : ICommandHandler<FailingCommand, NetEvolve.Pulse.Extensibility.Void>
+    {
+        public Task<NetEvolve.Pulse.Extensibility.Void> HandleAsync(
+            FailingCommand command,
+            CancellationToken cancellationToken = default
+        ) => throw new InvalidOperationException("Simulated failure");
+    }
+
+    private sealed record InProcessOnlyEvent : IEventInProcess
+    {
+        public string Id { get; init; } = Guid.NewGuid().ToString();
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+        public DateTimeOffset? PublishedAt { get; set; }
+    }
+
+    private sealed class TestTransactionScope(object? currentTransaction) : IOutboxTransactionScope
+    {
+        public object? GetCurrentTransaction() => currentTransaction;
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Integration/Pipeline/HandlerRegistrationTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Pipeline/HandlerRegistrationTests.cs
@@ -1,0 +1,352 @@
+namespace NetEvolve.Pulse.Tests.Integration.Pipeline;
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility;
+
+/// <summary>
+/// End-to-end integration tests for the generic custom-interceptor registration methods on
+/// <see cref="HandlerRegistrationExtensions"/> (<c>AddRequestInterceptor</c>, <c>AddCommandInterceptor</c>,
+/// <c>AddQueryInterceptor</c>, <c>AddEventInterceptor</c>, <c>AddStreamQueryInterceptor</c>). Unlike the
+/// built-in cross-cutting features (logging, timeout, caching, ...), which register their interceptors
+/// internally, these methods are the public API surface for registering user-authored interceptors and
+/// were previously never exercised end-to-end.
+/// </summary>
+[TestGroup("Pipeline")]
+public sealed class HandlerRegistrationTests
+{
+    private static async Task<IHost> BuildHostAsync(
+        Action<IServiceCollection> configureServices,
+        CancellationToken cancellationToken
+    )
+    {
+        var host = new HostBuilder().ConfigureServices(configureServices).Build();
+
+        await host.StartAsync(cancellationToken).ConfigureAwait(false);
+
+        return host;
+    }
+
+    [Test]
+    public async Task AddRequestInterceptor_WrapsQueryHandling(CancellationToken cancellationToken)
+    {
+        var tracker = new List<string>();
+
+        using var host = await BuildHostAsync(
+                services =>
+                    services
+                        .AddSingleton(tracker)
+                        .AddPulse(builder =>
+                            builder
+                                .AddQueryHandler<MarkerQuery, string, MarkerQueryHandler>()
+                                .AddRequestInterceptor<MarkerQuery, string, MarkerRequestInterceptor>()
+                        ),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        var scope = host.Services.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            var result = await mediator
+                .QueryAsync<MarkerQuery, string>(new MarkerQuery(), cancellationToken)
+                .ConfigureAwait(false);
+
+            _ = await Assert.That(result).IsEqualTo("handled");
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(tracker).IsEquivalentTo(["RequestInterceptor:before", "RequestInterceptor:after"]);
+    }
+
+    [Test]
+    public async Task AddCommandInterceptor_WrapsCommandHandling(CancellationToken cancellationToken)
+    {
+        var tracker = new List<string>();
+
+        using var host = await BuildHostAsync(
+                services =>
+                    services
+                        .AddSingleton(tracker)
+                        .AddPulse(builder =>
+                            builder
+                                .AddCommandHandler<MarkerCommand, string, MarkerCommandHandler>()
+                                .AddCommandInterceptor<MarkerCommand, string, MarkerCommandInterceptor>()
+                        ),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        var scope = host.Services.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            var result = await mediator
+                .SendAsync<MarkerCommand, string>(new MarkerCommand(), cancellationToken)
+                .ConfigureAwait(false);
+
+            _ = await Assert.That(result).IsEqualTo("handled");
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(tracker).IsEquivalentTo(["CommandInterceptor:before", "CommandInterceptor:after"]);
+    }
+
+    [Test]
+    public async Task AddQueryInterceptor_WrapsQueryHandling(CancellationToken cancellationToken)
+    {
+        var tracker = new List<string>();
+
+        using var host = await BuildHostAsync(
+                services =>
+                    services
+                        .AddSingleton(tracker)
+                        .AddPulse(builder =>
+                            builder
+                                .AddQueryHandler<MarkerQuery, string, MarkerQueryHandler>()
+                                .AddQueryInterceptor<MarkerQuery, string, MarkerQueryInterceptor>()
+                        ),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        var scope = host.Services.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            var result = await mediator
+                .QueryAsync<MarkerQuery, string>(new MarkerQuery(), cancellationToken)
+                .ConfigureAwait(false);
+
+            _ = await Assert.That(result).IsEqualTo("handled");
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(tracker).IsEquivalentTo(["QueryInterceptor:before", "QueryInterceptor:after"]);
+    }
+
+    [Test]
+    public async Task AddEventInterceptor_WrapsEventHandling(CancellationToken cancellationToken)
+    {
+        var tracker = new List<string>();
+
+        using var host = await BuildHostAsync(
+                services =>
+                    services
+                        .AddSingleton(tracker)
+                        .AddPulse(builder =>
+                            builder
+                                .AddEventHandler<MarkerEvent, MarkerEventHandler>()
+                                .AddEventInterceptor<MarkerEvent, MarkerEventInterceptor>()
+                        ),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        var scope = host.Services.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            await mediator.PublishAsync(new MarkerEvent(), cancellationToken).ConfigureAwait(false);
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(tracker).IsEquivalentTo(["EventInterceptor:before", "handled", "EventInterceptor:after"]);
+    }
+
+    [Test]
+    public async Task AddStreamQueryInterceptor_WrapsStreamQueryHandling(CancellationToken cancellationToken)
+    {
+        var tracker = new List<string>();
+
+        using var host = await BuildHostAsync(
+                services =>
+                    services
+                        .AddSingleton(tracker)
+                        .AddPulse(builder =>
+                            builder
+                                .AddStreamQueryHandler<MarkerStreamQuery, int, MarkerStreamQueryHandler>()
+                                .AddStreamQueryInterceptor<MarkerStreamQuery, int, MarkerStreamQueryInterceptor>()
+                        ),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        var scope = host.Services.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+            var items = new List<int>();
+
+            await foreach (
+                var item in mediator.StreamQueryAsync<MarkerStreamQuery, int>(
+                    new MarkerStreamQuery(),
+                    cancellationToken
+                )
+            )
+            {
+                items.Add(item);
+            }
+
+            _ = await Assert.That(items).IsEquivalentTo([1, 2]);
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert
+            .That(tracker)
+            .IsEquivalentTo(["StreamQueryInterceptor:before", "StreamQueryInterceptor:after"]);
+    }
+
+    private sealed record MarkerQuery : IQuery<string>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed class MarkerQueryHandler : IQueryHandler<MarkerQuery, string>
+    {
+        public Task<string> HandleAsync(MarkerQuery request, CancellationToken cancellationToken = default) =>
+            Task.FromResult("handled");
+    }
+
+    private sealed class MarkerRequestInterceptor(List<string> tracker) : IRequestInterceptor<MarkerQuery, string>
+    {
+        public async Task<string> HandleAsync(
+            MarkerQuery request,
+            Func<MarkerQuery, CancellationToken, Task<string>> handler,
+            CancellationToken cancellationToken = default
+        )
+        {
+            tracker.Add("RequestInterceptor:before");
+            var result = await handler(request, cancellationToken).ConfigureAwait(false);
+            tracker.Add("RequestInterceptor:after");
+            return result;
+        }
+    }
+
+    private sealed class MarkerQueryInterceptor(List<string> tracker) : IQueryInterceptor<MarkerQuery, string>
+    {
+        public async Task<string> HandleAsync(
+            MarkerQuery request,
+            Func<MarkerQuery, CancellationToken, Task<string>> handler,
+            CancellationToken cancellationToken = default
+        )
+        {
+            tracker.Add("QueryInterceptor:before");
+            var result = await handler(request, cancellationToken).ConfigureAwait(false);
+            tracker.Add("QueryInterceptor:after");
+            return result;
+        }
+    }
+
+    private sealed record MarkerCommand : ICommand<string>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed class MarkerCommandHandler : ICommandHandler<MarkerCommand, string>
+    {
+        public Task<string> HandleAsync(MarkerCommand command, CancellationToken cancellationToken = default) =>
+            Task.FromResult("handled");
+    }
+
+    private sealed class MarkerCommandInterceptor(List<string> tracker) : ICommandInterceptor<MarkerCommand, string>
+    {
+        public async Task<string> HandleAsync(
+            MarkerCommand request,
+            Func<MarkerCommand, CancellationToken, Task<string>> handler,
+            CancellationToken cancellationToken = default
+        )
+        {
+            tracker.Add("CommandInterceptor:before");
+            var result = await handler(request, cancellationToken).ConfigureAwait(false);
+            tracker.Add("CommandInterceptor:after");
+            return result;
+        }
+    }
+
+    private sealed record MarkerEvent : IEvent
+    {
+        public string Id { get; init; } = Guid.NewGuid().ToString();
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+        public DateTimeOffset? PublishedAt { get; set; }
+    }
+
+    private sealed class MarkerEventHandler(List<string> tracker) : IEventHandler<MarkerEvent>
+    {
+        public Task HandleAsync(MarkerEvent message, CancellationToken cancellationToken = default)
+        {
+            tracker.Add("handled");
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class MarkerEventInterceptor(List<string> tracker) : IEventInterceptor<MarkerEvent>
+    {
+        public async Task HandleAsync(
+            MarkerEvent message,
+            Func<MarkerEvent, CancellationToken, Task> handler,
+            CancellationToken cancellationToken = default
+        )
+        {
+            tracker.Add("EventInterceptor:before");
+            await handler(message, cancellationToken).ConfigureAwait(false);
+            tracker.Add("EventInterceptor:after");
+        }
+    }
+
+    private sealed record MarkerStreamQuery : IStreamQuery<int>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed class MarkerStreamQueryHandler : IStreamQueryHandler<MarkerStreamQuery, int>
+    {
+        public async IAsyncEnumerable<int> HandleAsync(
+            MarkerStreamQuery request,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default
+        )
+        {
+            yield return 1;
+            await Task.Yield();
+            yield return 2;
+        }
+    }
+
+    private sealed class MarkerStreamQueryInterceptor(List<string> tracker)
+        : IStreamQueryInterceptor<MarkerStreamQuery, int>
+    {
+        public async IAsyncEnumerable<int> HandleAsync(
+            MarkerStreamQuery request,
+            Func<MarkerStreamQuery, CancellationToken, IAsyncEnumerable<int>> handler,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default
+        )
+        {
+            tracker.Add("StreamQueryInterceptor:before");
+            await foreach (var item in handler(request, cancellationToken).WithCancellation(cancellationToken))
+            {
+                yield return item;
+            }
+            tracker.Add("StreamQueryInterceptor:after");
+        }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Integration/Pipeline/RequestInterceptorsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Pipeline/RequestInterceptorsTests.cs
@@ -1,0 +1,723 @@
+namespace NetEvolve.Pulse.Tests.Integration.Pipeline;
+
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility;
+
+/// <summary>
+/// Integration tests that exercise the built-in <c>ActivityAndMetrics</c>, <c>ConcurrentCommandGuard</c>,
+/// and <c>DataAnnotations</c> interceptors end-to-end through a real, fully built <see cref="IMediator"/>
+/// pipeline (no mocking of the pipeline itself). Each test builds a minimal, self-contained host via
+/// <c>AddPulse(...)</c> — no database, broker, or Testcontainers dependency required.
+/// </summary>
+[TestGroup("Pipeline")]
+[TestGroup("Interceptors")]
+public sealed class RequestInterceptorsTests
+{
+    private static async Task<IHost> CreateHostAsync(
+        Action<IMediatorBuilder> configureMediator,
+        CancellationToken cancellationToken
+    )
+    {
+        var host = new HostBuilder()
+            .ConfigureServices(services => services.AddPulse(configureMediator))
+            .ConfigureWebHost(webBuilder => _ = webBuilder.UseTestServer().Configure(applicationBuilder => { }))
+            .Build();
+
+        await host.StartAsync(cancellationToken).ConfigureAwait(false);
+
+        return host;
+    }
+
+    [Test]
+    [NotInParallel]
+    public async Task ActivityAndMetrics_Command_RecordsActivityAndMetrics(CancellationToken cancellationToken)
+    {
+        using var activityListener = new ActivityListener
+        {
+            ShouldListenTo = source => string.Equals(source.Name, "NetEvolve.Pulse", StringComparison.Ordinal),
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+        };
+        ActivitySource.AddActivityListener(activityListener);
+
+        Activity? capturedActivity = null;
+        activityListener.ActivityStopped = activity =>
+        {
+            if (string.Equals(activity.DisplayName, "Command.ActivityMetricsCommand", StringComparison.Ordinal))
+            {
+                capturedActivity = activity;
+            }
+        };
+
+        long counterValue = 0;
+        using var meterListener = new MeterListener
+        {
+            InstrumentPublished = (instrument, listener) =>
+            {
+                if (
+                    string.Equals(instrument.Meter.Name, "NetEvolve.Pulse", StringComparison.Ordinal)
+                    && string.Equals(instrument.Name, "pulse.requests.total", StringComparison.Ordinal)
+                )
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        meterListener.SetMeasurementEventCallback<long>(
+            (_, measurement, _, _) => Interlocked.Add(ref counterValue, measurement)
+        );
+        meterListener.Start();
+
+        using var host = await CreateHostAsync(
+                mediatorBuilder =>
+                    mediatorBuilder
+                        .AddActivityAndMetrics()
+                        .AddCommandHandler<ActivityMetricsCommand, string, ActivityMetricsCommandHandler>(),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        var scope = host.Services.CreateAsyncScope();
+        string result;
+        await using (scope.ConfigureAwait(false))
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            result = await mediator
+                .SendAsync<ActivityMetricsCommand, string>(new ActivityMetricsCommand(), cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(result).IsEqualTo("handled");
+            _ = await Assert.That(capturedActivity).IsNotNull();
+            _ = await Assert.That(capturedActivity!.Status).IsEqualTo(ActivityStatusCode.Ok);
+            _ = await Assert.That(capturedActivity.GetTagItem("pulse.request.type")).IsEqualTo("Command");
+            _ = await Assert.That(Interlocked.Read(ref counterValue)).IsGreaterThanOrEqualTo(1L);
+        }
+    }
+
+    [Test]
+    [NotInParallel]
+    public async Task ActivityAndMetrics_Query_RecordsActivityAndMetrics(CancellationToken cancellationToken)
+    {
+        using var activityListener = new ActivityListener
+        {
+            ShouldListenTo = source => string.Equals(source.Name, "NetEvolve.Pulse", StringComparison.Ordinal),
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+        };
+        ActivitySource.AddActivityListener(activityListener);
+
+        Activity? capturedActivity = null;
+        activityListener.ActivityStopped = activity =>
+        {
+            if (string.Equals(activity.DisplayName, "Query.ActivityMetricsQuery", StringComparison.Ordinal))
+            {
+                capturedActivity = activity;
+            }
+        };
+
+        using var host = await CreateHostAsync(
+                mediatorBuilder =>
+                    mediatorBuilder
+                        .AddActivityAndMetrics()
+                        .AddQueryHandler<ActivityMetricsQuery, int, ActivityMetricsQueryHandler>(),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        var scope = host.Services.CreateAsyncScope();
+        int result;
+        await using (scope.ConfigureAwait(false))
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            result = await mediator
+                .QueryAsync<ActivityMetricsQuery, int>(new ActivityMetricsQuery(), cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(result).IsEqualTo(42);
+            _ = await Assert.That(capturedActivity).IsNotNull();
+            _ = await Assert.That(capturedActivity!.Status).IsEqualTo(ActivityStatusCode.Ok);
+            _ = await Assert.That(capturedActivity.GetTagItem("pulse.request.type")).IsEqualTo("Query");
+        }
+    }
+
+    [Test]
+    [NotInParallel]
+    public async Task ActivityAndMetrics_Event_RecordsActivityAndMetrics(CancellationToken cancellationToken)
+    {
+        using var activityListener = new ActivityListener
+        {
+            ShouldListenTo = source => string.Equals(source.Name, "NetEvolve.Pulse", StringComparison.Ordinal),
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+        };
+        ActivitySource.AddActivityListener(activityListener);
+
+        Activity? capturedActivity = null;
+        activityListener.ActivityStopped = activity =>
+        {
+            if (string.Equals(activity.DisplayName, "Event.ActivityMetricsEvent", StringComparison.Ordinal))
+            {
+                capturedActivity = activity;
+            }
+        };
+
+        long counterValue = 0;
+        using var meterListener = new MeterListener
+        {
+            InstrumentPublished = (instrument, listener) =>
+            {
+                if (
+                    string.Equals(instrument.Meter.Name, "NetEvolve.Pulse", StringComparison.Ordinal)
+                    && string.Equals(instrument.Name, "pulse.events.total", StringComparison.Ordinal)
+                )
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        meterListener.SetMeasurementEventCallback<long>(
+            (_, measurement, _, _) => Interlocked.Add(ref counterValue, measurement)
+        );
+        meterListener.Start();
+
+        using var host = await CreateHostAsync(
+                mediatorBuilder =>
+                    mediatorBuilder
+                        .AddActivityAndMetrics()
+                        .AddEventHandler<ActivityMetricsEvent, ActivityMetricsEventHandler>(),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        var scope = host.Services.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            await mediator
+                .PublishAsync(new ActivityMetricsEvent { Id = "evt-001" }, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(capturedActivity).IsNotNull();
+            _ = await Assert.That(capturedActivity!.Status).IsEqualTo(ActivityStatusCode.Ok);
+            _ = await Assert.That(Interlocked.Read(ref counterValue)).IsGreaterThanOrEqualTo(1L);
+        }
+    }
+
+    [Test]
+    [NotInParallel]
+    public async Task ActivityAndMetrics_StreamQuery_RecordsActivityAndMetrics(CancellationToken cancellationToken)
+    {
+        using var activityListener = new ActivityListener
+        {
+            ShouldListenTo = source => string.Equals(source.Name, "NetEvolve.Pulse", StringComparison.Ordinal),
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+        };
+        ActivitySource.AddActivityListener(activityListener);
+
+        Activity? capturedActivity = null;
+        activityListener.ActivityStopped = activity =>
+        {
+            if (string.Equals(activity.DisplayName, "StreamQuery.ActivityMetricsStreamQuery", StringComparison.Ordinal))
+            {
+                capturedActivity = activity;
+            }
+        };
+
+        using var host = await CreateHostAsync(
+                mediatorBuilder =>
+                    mediatorBuilder
+                        .AddActivityAndMetrics()
+                        .AddStreamQueryHandler<ActivityMetricsStreamQuery, int, ActivityMetricsStreamQueryHandler>(),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        var scope = host.Services.CreateAsyncScope();
+        List<int> items;
+        await using (scope.ConfigureAwait(false))
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            items = new List<int>();
+            await foreach (
+                var item in mediator
+                    .StreamQueryAsync<ActivityMetricsStreamQuery, int>(
+                        new ActivityMetricsStreamQuery(),
+                        cancellationToken
+                    )
+                    .WithCancellation(cancellationToken)
+                    .ConfigureAwait(false)
+            )
+            {
+                items.Add(item);
+            }
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(items).IsEquivalentTo([1, 2, 3]);
+            _ = await Assert.That(capturedActivity).IsNotNull();
+            _ = await Assert.That(capturedActivity!.Status).IsEqualTo(ActivityStatusCode.Ok);
+        }
+    }
+
+    [Test]
+    [NotInParallel]
+    public async Task ConcurrentCommandGuard_ConcurrentSends_SerializesExecution(CancellationToken cancellationToken)
+    {
+        using var host = await CreateHostAsync(
+                mediatorBuilder =>
+                    mediatorBuilder
+                        .AddConcurrentCommandGuard()
+                        .AddCommandHandler<GuardedCommand, int, GuardedCommandHandler>(),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        var scope = host.Services.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            var tasks = Enumerable
+                .Range(0, 5)
+                .Select(_ => mediator.SendAsync<GuardedCommand, int>(new GuardedCommand(), cancellationToken))
+                .ToArray();
+
+            _ = await Task.WhenAll(tasks).ConfigureAwait(false);
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(GuardedCommandHandler.MaxConcurrent).IsEqualTo(1);
+    }
+
+    [Test]
+    [NotInParallel]
+    public async Task ConcurrentCommandGuard_TypedOverload_ConcurrentSends_SerializesExecution(
+        CancellationToken cancellationToken
+    )
+    {
+        using var host = await CreateHostAsync(
+                mediatorBuilder =>
+                    mediatorBuilder
+                        .AddConcurrentCommandGuard<GuardedCommand, int>()
+                        .AddCommandHandler<GuardedCommand, int, GuardedCommandHandler>(),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        var scope = host.Services.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            var tasks = Enumerable
+                .Range(0, 5)
+                .Select(_ => mediator.SendAsync<GuardedCommand, int>(new GuardedCommand(), cancellationToken))
+                .ToArray();
+
+            _ = await Task.WhenAll(tasks).ConfigureAwait(false);
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(GuardedCommandHandler.MaxConcurrent).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ConcurrentCommandGuard_VoidOverload_ConcurrentSends_SerializesExecution(
+        CancellationToken cancellationToken
+    )
+    {
+        using var host = await CreateHostAsync(
+                mediatorBuilder =>
+                    mediatorBuilder
+                        .AddConcurrentCommandGuard<GuardedVoidCommand>()
+                        .AddCommandHandler<GuardedVoidCommand, GuardedVoidCommandHandler>(),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        var scope = host.Services.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            var tasks = Enumerable
+                .Range(0, 5)
+                .Select(_ => mediator.SendAsync<GuardedVoidCommand, Void>(new GuardedVoidCommand(), cancellationToken))
+                .ToArray();
+
+            _ = await Task.WhenAll(tasks).ConfigureAwait(false);
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(GuardedVoidCommandHandler.MaxConcurrent).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task DataAnnotations_InvalidCommand_ThrowsValidationException(CancellationToken cancellationToken)
+    {
+        using var host = await CreateHostAsync(
+                mediatorBuilder =>
+                    mediatorBuilder
+                        .AddDataAnnotations()
+                        .AddCommandHandler<ValidatedCommand, string, ValidatedCommandHandler>(),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        var scope = host.Services.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+#pragma warning disable S8969 // required to match the Func<..., Task<string?>> overload TUnit infers here
+            _ = await Assert
+                .That(() =>
+                    mediator.SendAsync<ValidatedCommand, string>(
+                        new ValidatedCommand { Name = null! },
+                        cancellationToken
+                    )!
+                )
+                .Throws<ValidationException>();
+#pragma warning restore S8969
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task DataAnnotations_ValidCommand_Succeeds(CancellationToken cancellationToken)
+    {
+        using var host = await CreateHostAsync(
+                mediatorBuilder =>
+                    mediatorBuilder
+                        .AddDataAnnotations()
+                        .AddCommandHandler<ValidatedCommand, string, ValidatedCommandHandler>(),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        var scope = host.Services.CreateAsyncScope();
+        string result;
+        await using (scope.ConfigureAwait(false))
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            result = await mediator
+                .SendAsync<ValidatedCommand, string>(new ValidatedCommand { Name = "World" }, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(result).IsEqualTo("hello World");
+    }
+
+    [Test]
+    public async Task DataAnnotations_InvalidEvent_ThrowsValidationException(CancellationToken cancellationToken)
+    {
+        using var host = await CreateHostAsync(
+                mediatorBuilder =>
+                    mediatorBuilder.AddDataAnnotations().AddEventHandler<ValidatedEvent, ValidatedEventHandler>(),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        var scope = host.Services.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            _ = await Assert
+                .That(() =>
+                    mediator.PublishAsync(new ValidatedEvent { Id = "evt-001", Name = null! }, cancellationToken)
+                )
+                .Throws<ValidationException>();
+
+            _ = await Assert.That(ValidatedEventHandler.HandlerInvoked).IsFalse();
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task DataAnnotations_InvalidStreamQuery_ThrowsValidationException(CancellationToken cancellationToken)
+    {
+        using var host = await CreateHostAsync(
+                mediatorBuilder =>
+                    mediatorBuilder
+                        .AddDataAnnotations()
+                        .AddStreamQueryHandler<ValidatedStreamQuery, string, ValidatedStreamQueryHandler>(),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        var scope = host.Services.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            _ = await Assert
+                .That(async () =>
+                {
+                    await foreach (
+                        var item in mediator.StreamQueryAsync<ValidatedStreamQuery, string>(
+                            new ValidatedStreamQuery { Name = null! },
+                            cancellationToken
+                        )
+                    )
+                    {
+                        _ = item;
+                    }
+                })
+                .Throws<ValidationException>();
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task DataAnnotations_ValidStreamQuery_YieldsItems(CancellationToken cancellationToken)
+    {
+        using var host = await CreateHostAsync(
+                mediatorBuilder =>
+                    mediatorBuilder
+                        .AddDataAnnotations()
+                        .AddStreamQueryHandler<ValidatedStreamQuery, string, ValidatedStreamQueryHandler>(),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        var scope = host.Services.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+            var items = new List<string>();
+
+            await foreach (
+                var item in mediator.StreamQueryAsync<ValidatedStreamQuery, string>(
+                    new ValidatedStreamQuery { Name = "World" },
+                    cancellationToken
+                )
+            )
+            {
+                items.Add(item);
+            }
+
+            _ = await Assert.That(items).IsEquivalentTo(["hello World"]);
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private sealed record ActivityMetricsCommand : ICommand<string>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed class ActivityMetricsCommandHandler : ICommandHandler<ActivityMetricsCommand, string>
+    {
+        public Task<string> HandleAsync(
+            ActivityMetricsCommand command,
+            CancellationToken cancellationToken = default
+        ) => Task.FromResult("handled");
+    }
+
+    private sealed record ActivityMetricsQuery : IQuery<int>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed class ActivityMetricsQueryHandler : IQueryHandler<ActivityMetricsQuery, int>
+    {
+        public Task<int> HandleAsync(ActivityMetricsQuery request, CancellationToken cancellationToken = default) =>
+            Task.FromResult(42);
+    }
+
+    private sealed record ActivityMetricsEvent : IEvent
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+
+        public required string Id { get; init; }
+
+        public DateTimeOffset? PublishedAt { get; set; }
+    }
+
+    private sealed class ActivityMetricsEventHandler : IEventHandler<ActivityMetricsEvent>
+    {
+        public Task HandleAsync(ActivityMetricsEvent message, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+    }
+
+    private sealed record ActivityMetricsStreamQuery : IStreamQuery<int>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed class ActivityMetricsStreamQueryHandler : IStreamQueryHandler<ActivityMetricsStreamQuery, int>
+    {
+        public async IAsyncEnumerable<int> HandleAsync(
+            ActivityMetricsStreamQuery request,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default
+        )
+        {
+            foreach (var value in new[] { 1, 2, 3 })
+            {
+                await Task.Yield();
+                yield return value;
+            }
+        }
+    }
+
+    private sealed record GuardedCommand : IExclusiveCommand<int>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed class GuardedCommandHandler : ICommandHandler<GuardedCommand, int>
+    {
+        private static int _currentConcurrent;
+        private static int _maxConcurrent;
+
+        public static int MaxConcurrent => _maxConcurrent;
+
+        public async Task<int> HandleAsync(GuardedCommand command, CancellationToken cancellationToken = default)
+        {
+            var current = Interlocked.Increment(ref _currentConcurrent);
+            var max = _maxConcurrent;
+            while (current > max)
+            {
+                _ = Interlocked.CompareExchange(ref _maxConcurrent, current, max);
+                max = _maxConcurrent;
+            }
+
+            await Task.Delay(20, cancellationToken).ConfigureAwait(false);
+            _ = Interlocked.Decrement(ref _currentConcurrent);
+
+            return current;
+        }
+    }
+
+    private sealed record GuardedVoidCommand : IExclusiveCommand
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed class GuardedVoidCommandHandler : ICommandHandler<GuardedVoidCommand, Void>
+    {
+        private static int _currentConcurrent;
+        private static int _maxConcurrent;
+
+        public static int MaxConcurrent => _maxConcurrent;
+
+        public async Task<Void> HandleAsync(GuardedVoidCommand command, CancellationToken cancellationToken = default)
+        {
+            var current = Interlocked.Increment(ref _currentConcurrent);
+            var max = _maxConcurrent;
+            while (current > max)
+            {
+                _ = Interlocked.CompareExchange(ref _maxConcurrent, current, max);
+                max = _maxConcurrent;
+            }
+
+            await Task.Delay(20, cancellationToken).ConfigureAwait(false);
+            _ = Interlocked.Decrement(ref _currentConcurrent);
+
+            return default;
+        }
+    }
+
+    private sealed record ValidatedCommand : ICommand<string>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+
+        [Required]
+        public string Name { get; init; } = string.Empty;
+    }
+
+    private sealed class ValidatedCommandHandler : ICommandHandler<ValidatedCommand, string>
+    {
+        public Task<string> HandleAsync(ValidatedCommand command, CancellationToken cancellationToken = default) =>
+            Task.FromResult($"hello {command.Name}");
+    }
+
+    private sealed record ValidatedStreamQuery : IStreamQuery<string>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+
+        [Required]
+        public string Name { get; init; } = string.Empty;
+    }
+
+    private sealed class ValidatedStreamQueryHandler : IStreamQueryHandler<ValidatedStreamQuery, string>
+    {
+        public async IAsyncEnumerable<string> HandleAsync(
+            ValidatedStreamQuery request,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default
+        )
+        {
+            yield return $"hello {request.Name}";
+            await Task.Yield();
+        }
+    }
+
+    private sealed record ValidatedEvent : IEvent
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+
+        public required string Id { get; init; }
+
+        public DateTimeOffset? PublishedAt { get; set; }
+
+        [Required]
+        public string Name { get; init; } = string.Empty;
+    }
+
+    private sealed class ValidatedEventHandler : IEventHandler<ValidatedEvent>
+    {
+        public static bool HandlerInvoked { get; private set; }
+
+        public Task HandleAsync(ValidatedEvent message, CancellationToken cancellationToken = default)
+        {
+            HandlerInvoked = true;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Integration/Pipeline/ValidationResilienceTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Pipeline/ValidationResilienceTests.cs
@@ -1,0 +1,461 @@
+namespace NetEvolve.Pulse.Tests.Integration.Pipeline;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using global::FluentValidation;
+using global::Polly;
+using global::Polly.Retry;
+using global::Polly.Timeout;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility;
+
+/// <summary>
+/// End-to-end integration tests for the FluentValidation and Polly pipeline interceptors,
+/// exercising real <see cref="AbstractValidator{T}"/> validators and real Polly
+/// <see cref="ResiliencePipeline{TResult}"/> instances through a fully built host and the real mediator.
+/// </summary>
+[TestGroup("Pipeline")]
+public sealed class ValidationResilienceTests
+{
+    private static async Task RunAndVerify(
+        Func<IServiceProvider, CancellationToken, Task> testableCode,
+        Action<IServiceCollection> configureServices,
+        CancellationToken cancellationToken
+    )
+    {
+        using var host = new HostBuilder()
+            .ConfigureServices(services => configureServices(services))
+            .ConfigureWebHost(webBuilder => _ = webBuilder.UseTestServer().Configure(applicationBuilder => { }))
+            .Build();
+
+        await host.StartAsync(cancellationToken).ConfigureAwait(false);
+
+        using var server = host.GetTestServer();
+
+        var scope = server.Services.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            await testableCode.Invoke(scope.ServiceProvider, cancellationToken).ConfigureAwait(false);
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task FluentValidation_InvalidCommand_ThrowsValidationException(CancellationToken cancellationToken) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var mediator = services.GetRequiredService<IMediator>();
+
+                    _ = await Assert
+                        .That(async () =>
+                            await mediator
+                                .SendAsync<CreateWidgetCommand, string>(new CreateWidgetCommand(""), token)
+                                .ConfigureAwait(false)
+                        )
+                        .Throws<ValidationException>();
+                },
+                configureServices: services =>
+                    services
+                        .AddPulse(configurator =>
+                            configurator
+                                .AddCommandHandler<CreateWidgetCommand, string, CreateWidgetCommandHandler>()
+                                .AddFluentValidation()
+                        )
+                        .AddScoped<IValidator<CreateWidgetCommand>, CreateWidgetCommandValidator>(),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+    [Test]
+    public async Task FluentValidation_InvalidCommand_ContainsExpectedFailure(CancellationToken cancellationToken) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var mediator = services.GetRequiredService<IMediator>();
+
+                    var exception = await Assert.ThrowsAsync<ValidationException>(async () =>
+                        await mediator
+                            .SendAsync<CreateWidgetCommand, string>(new CreateWidgetCommand(""), token)
+                            .ConfigureAwait(false)
+                    );
+
+                    _ = await Assert.That(exception).IsNotNull();
+                    _ = await Assert
+                        .That(exception.Errors)
+                        .Contains(failure => failure.PropertyName == nameof(CreateWidgetCommand.Name));
+                },
+                configureServices: services =>
+                    services
+                        .AddPulse(configurator =>
+                            configurator
+                                .AddCommandHandler<CreateWidgetCommand, string, CreateWidgetCommandHandler>()
+                                .AddFluentValidation()
+                        )
+                        .AddScoped<IValidator<CreateWidgetCommand>, CreateWidgetCommandValidator>(),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+    [Test]
+    public async Task FluentValidation_ValidCommand_Succeeds(CancellationToken cancellationToken) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var mediator = services.GetRequiredService<IMediator>();
+
+                    var result = await mediator
+                        .SendAsync<CreateWidgetCommand, string>(new CreateWidgetCommand("Widget-1"), token)
+                        .ConfigureAwait(false);
+
+                    _ = await Assert.That(result).IsEqualTo("Created:Widget-1");
+                },
+                configureServices: services =>
+                    services
+                        .AddPulse(configurator =>
+                            configurator
+                                .AddCommandHandler<CreateWidgetCommand, string, CreateWidgetCommandHandler>()
+                                .AddFluentValidation()
+                        )
+                        .AddScoped<IValidator<CreateWidgetCommand>, CreateWidgetCommandValidator>(),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+    [Test]
+    public async Task FluentValidation_InvalidStreamQuery_ThrowsValidationException(
+        CancellationToken cancellationToken
+    ) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var mediator = services.GetRequiredService<IMediator>();
+
+                    _ = await Assert
+                        .That(async () =>
+                        {
+                            await foreach (
+                                var item in mediator.StreamQueryAsync<ListWidgetsQuery, string>(
+                                    new ListWidgetsQuery(""),
+                                    token
+                                )
+                            )
+                            {
+                                _ = item;
+                            }
+                        })
+                        .Throws<ValidationException>();
+                },
+                configureServices: services =>
+                    services
+                        .AddPulse(configurator =>
+                            configurator
+                                .AddStreamQueryHandler<ListWidgetsQuery, string, ListWidgetsQueryHandler>()
+                                .AddFluentValidation()
+                        )
+                        .AddScoped<IValidator<ListWidgetsQuery>, ListWidgetsQueryValidator>(),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+    [Test]
+    public async Task FluentValidation_ValidStreamQuery_YieldsItems(CancellationToken cancellationToken) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var mediator = services.GetRequiredService<IMediator>();
+                    var items = new List<string>();
+
+                    await foreach (
+                        var item in mediator.StreamQueryAsync<ListWidgetsQuery, string>(
+                            new ListWidgetsQuery("Widget"),
+                            token
+                        )
+                    )
+                    {
+                        items.Add(item);
+                    }
+
+                    _ = await Assert.That(items).IsEquivalentTo(["Widget-1", "Widget-2"]);
+                },
+                configureServices: services =>
+                    services
+                        .AddPulse(configurator =>
+                            configurator
+                                .AddStreamQueryHandler<ListWidgetsQuery, string, ListWidgetsQueryHandler>()
+                                .AddFluentValidation()
+                        )
+                        .AddScoped<IValidator<ListWidgetsQuery>, ListWidgetsQueryValidator>(),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+    [Test]
+    public async Task Polly_Retry_SucceedsAfterTransientFailures(CancellationToken cancellationToken)
+    {
+        var handler = new FlakyCommandHandler(failuresBeforeSuccess: 2);
+
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var mediator = services.GetRequiredService<IMediator>();
+
+                    var result = await mediator
+                        .SendAsync<FlakyCommand, string>(new FlakyCommand(), token)
+                        .ConfigureAwait(false);
+
+                    _ = await Assert.That(result).IsEqualTo("success");
+                    _ = await Assert.That(handler.AttemptCount).IsEqualTo(3);
+                },
+                configureServices: services =>
+                    services
+                        .AddSingleton<ICommandHandler<FlakyCommand, string>>(handler)
+                        .AddPulse(configurator =>
+                            configurator.AddPollyCommandPolicies<FlakyCommand, string>(pipeline =>
+                                pipeline.AddRetry(
+                                    new RetryStrategyOptions<string>
+                                    {
+                                        MaxRetryAttempts = 5,
+                                        Delay = TimeSpan.FromMilliseconds(5),
+                                        BackoffType = DelayBackoffType.Constant,
+                                    }
+                                )
+                            )
+                        ),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task Polly_Timeout_ThrowsTimeoutRejectedException(CancellationToken cancellationToken) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var mediator = services.GetRequiredService<IMediator>();
+
+                    _ = await Assert
+                        .That(async () =>
+                            await mediator
+                                .SendAsync<SlowCommand, string>(new SlowCommand(), token)
+                                .ConfigureAwait(false)
+                        )
+                        .Throws<TimeoutRejectedException>();
+                },
+                configureServices: services =>
+                    services.AddPulse(configurator =>
+                        configurator
+                            .AddCommandHandler<SlowCommand, string, SlowCommandHandler>()
+                            .AddPollyCommandPolicies<SlowCommand, string>(pipeline =>
+                                pipeline.AddTimeout(TimeSpan.FromMilliseconds(50))
+                            )
+                    ),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+    [Test]
+    public async Task Polly_Event_Retry_SucceedsAfterTransientFailures(CancellationToken cancellationToken)
+    {
+        var handler = new FlakyEventHandler(failuresBeforeSuccess: 2);
+
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var mediator = services.GetRequiredService<IMediator>();
+
+                    await mediator.PublishAsync(new FlakyEvent(), token).ConfigureAwait(false);
+
+                    _ = await Assert.That(handler.AttemptCount).IsEqualTo(3);
+                },
+                configureServices: services =>
+                    services
+                        .AddSingleton<IEventHandler<FlakyEvent>>(handler)
+                        .AddPulse(configurator =>
+                            configurator.AddPollyEventPolicies<FlakyEvent>(pipeline =>
+                                pipeline.AddRetry(
+                                    new RetryStrategyOptions
+                                    {
+                                        MaxRetryAttempts = 5,
+                                        Delay = TimeSpan.FromMilliseconds(5),
+                                        BackoffType = DelayBackoffType.Constant,
+                                    }
+                                )
+                            )
+                        ),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task Polly_StreamQuery_Timeout_ThrowsTimeoutRejectedException(CancellationToken cancellationToken) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var mediator = services.GetRequiredService<IMediator>();
+
+                    _ = await Assert
+                        .That(async () =>
+                        {
+                            await foreach (
+                                var item in mediator.StreamQueryAsync<SlowStreamQuery, int>(
+                                    new SlowStreamQuery(),
+                                    token
+                                )
+                            )
+                            {
+                                _ = item;
+                            }
+                        })
+                        .Throws<TimeoutRejectedException>();
+                },
+                configureServices: services =>
+                    services.AddPulse(configurator =>
+                        configurator
+                            .AddStreamQueryHandler<SlowStreamQuery, int, SlowStreamQueryHandler>()
+                            .AddPollyStreamQueryPolicies<SlowStreamQuery, int>(pipeline =>
+                                pipeline.AddTimeout(TimeSpan.FromMilliseconds(50))
+                            )
+                    ),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+    // Circuit breaker is intentionally skipped here: state is cached per registered pipeline (see
+    // PollyExtensions remarks) and each of the tests above builds a fresh host/service provider, so
+    // exercising a circuit breaker meaningfully would require driving multiple failures/successes
+    // within a single host instance. That behavior is already covered thoroughly (open/half-open/close
+    // transitions) by the real ResiliencePipeline in the unit tests
+    // (PollyRequestInterceptorTests.HandleAsync_WithCircuitBreaker_BlocksAfterFailureThreshold); adding
+    // it here would only re-test Polly's own circuit breaker implementation rather than the Pulse
+    // integration, so it is left out to avoid excessive scaffolding for no additional coverage.
+
+    private sealed record CreateWidgetCommand(string Name) : ICommand<string>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed class CreateWidgetCommandValidator : AbstractValidator<CreateWidgetCommand>
+    {
+        public CreateWidgetCommandValidator() => RuleFor(x => x.Name).NotEmpty();
+    }
+
+    private sealed class CreateWidgetCommandHandler : ICommandHandler<CreateWidgetCommand, string>
+    {
+        public Task<string> HandleAsync(CreateWidgetCommand command, CancellationToken cancellationToken = default) =>
+            Task.FromResult($"Created:{command.Name}");
+    }
+
+    private sealed record ListWidgetsQuery(string Prefix) : IStreamQuery<string>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed class ListWidgetsQueryValidator : AbstractValidator<ListWidgetsQuery>
+    {
+        public ListWidgetsQueryValidator() => RuleFor(x => x.Prefix).NotEmpty();
+    }
+
+    private sealed class ListWidgetsQueryHandler : IStreamQueryHandler<ListWidgetsQuery, string>
+    {
+        public async IAsyncEnumerable<string> HandleAsync(
+            ListWidgetsQuery request,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default
+        )
+        {
+            yield return $"{request.Prefix}-1";
+            await Task.Yield();
+            yield return $"{request.Prefix}-2";
+        }
+    }
+
+    private sealed record FlakyCommand : ICommand<string>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed class FlakyCommandHandler(int failuresBeforeSuccess) : ICommandHandler<FlakyCommand, string>
+    {
+        public int AttemptCount { get; private set; }
+
+        public Task<string> HandleAsync(FlakyCommand command, CancellationToken cancellationToken = default)
+        {
+            AttemptCount++;
+
+            if (AttemptCount <= failuresBeforeSuccess)
+            {
+                throw new InvalidOperationException("Transient failure");
+            }
+
+            return Task.FromResult("success");
+        }
+    }
+
+    private sealed record FlakyEvent : IEvent
+    {
+        public string Id { get; init; } = Guid.NewGuid().ToString();
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+        public DateTimeOffset? PublishedAt { get; set; }
+    }
+
+    private sealed class FlakyEventHandler(int failuresBeforeSuccess) : IEventHandler<FlakyEvent>
+    {
+        public int AttemptCount { get; private set; }
+
+        public Task HandleAsync(FlakyEvent @event, CancellationToken cancellationToken = default)
+        {
+            AttemptCount++;
+
+            if (AttemptCount <= failuresBeforeSuccess)
+            {
+                throw new InvalidOperationException("Transient failure");
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed record SlowStreamQuery : IStreamQuery<int>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed class SlowStreamQueryHandler : IStreamQueryHandler<SlowStreamQuery, int>
+    {
+        public async IAsyncEnumerable<int> HandleAsync(
+            SlowStreamQuery request,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default
+        )
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(500), cancellationToken).ConfigureAwait(false);
+            yield return 1;
+        }
+    }
+
+    private sealed record SlowCommand : ICommand<string>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed class SlowCommandHandler : ICommandHandler<SlowCommand, string>
+    {
+        public async Task<string> HandleAsync(SlowCommand command, CancellationToken cancellationToken = default)
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(500), cancellationToken).ConfigureAwait(false);
+            return "done";
+        }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Integration/RabbitMQ/RabbitMqMessageTransportIntegrationTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/RabbitMQ/RabbitMqMessageTransportIntegrationTests.cs
@@ -3,8 +3,10 @@ namespace NetEvolve.Pulse.Tests.Integration.RabbitMQ;
 using System.Text;
 using global::RabbitMQ.Client;
 using global::RabbitMQ.Client.Events;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility;
 using NetEvolve.Pulse.Extensibility.Outbox;
 using NetEvolve.Pulse.Internals;
 using NetEvolve.Pulse.Outbox;
@@ -170,6 +172,164 @@ public sealed class RabbitMqMessageTransportIntegrationTests(RabbitMqContainerFi
         _ = await Assert.That(healthy).IsFalse();
     }
 
+    [Test]
+    public async Task IsHealthyAsync_After_dispose_returns_false(CancellationToken cancellationToken)
+    {
+        var (connection, _) = await GetConnectionAndChannelAsync(cancellationToken).ConfigureAwait(false);
+
+        var adapter = new RabbitMqConnectionAdapter(connection);
+        var transport = CreateTransport(adapter);
+
+        // Establish a channel before disposing, to prove disposal short-circuits the health check
+        // rather than merely reporting an unopened channel as unhealthy.
+        await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false);
+        transport.Dispose();
+
+        var healthy = await transport.IsHealthyAsync(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(healthy).IsFalse();
+    }
+
+    [Test]
+    public async Task Dispose_Called_twice_is_idempotent(CancellationToken cancellationToken)
+    {
+        var (connection, _) = await GetConnectionAndChannelAsync(cancellationToken).ConfigureAwait(false);
+
+        var adapter = new RabbitMqConnectionAdapter(connection);
+        var transport = CreateTransport(adapter);
+        await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false);
+
+        transport.Dispose();
+
+        // Second Dispose() call must be a safe no-op, not throw or double-dispose the channel.
+        transport.Dispose();
+    }
+
+    [Test]
+    public async Task SendAsync_Called_twice_reuses_open_channel(CancellationToken cancellationToken)
+    {
+        var (connection, adminChannel) = await GetConnectionAndChannelAsync(cancellationToken).ConfigureAwait(false);
+
+        var queueName = await adminChannel
+            .QueueDeclareAsync(cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        await adminChannel
+            .QueueBindAsync(
+                queueName.QueueName,
+                ExchangeName,
+                routingKey: string.Empty,
+                cancellationToken: cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        var adapter = new RabbitMqConnectionAdapter(connection);
+        using var transport = CreateTransport(adapter);
+
+        // First call creates the channel; the second call must hit the already-open fast path
+        // in EnsureChannelAsync instead of re-entering the initialization lock.
+        await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false);
+        await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false);
+
+        var receivedMessages = await ConsumeManyMessagesAsync(
+                adminChannel,
+                queueName.QueueName,
+                expectedCount: 2,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(receivedMessages.Count).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task SendAsync_Called_concurrently_initializes_channel_exactly_once(
+        CancellationToken cancellationToken
+    )
+    {
+        var (connection, adminChannel) = await GetConnectionAndChannelAsync(cancellationToken).ConfigureAwait(false);
+
+        var queueName = await adminChannel
+            .QueueDeclareAsync(cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        await adminChannel
+            .QueueBindAsync(
+                queueName.QueueName,
+                ExchangeName,
+                routingKey: string.Empty,
+                cancellationToken: cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        var adapter = new RabbitMqConnectionAdapter(connection);
+        using var transport = CreateTransport(adapter);
+
+        const int concurrentSends = 10;
+
+        // Fire many sends concurrently against a transport with no channel yet, to exercise the
+        // double-checked locking re-check branch inside EnsureChannelAsync.
+        var tasks = Enumerable
+            .Range(0, concurrentSends)
+            .Select(_ => transport.SendAsync(CreateOutboxMessage(), cancellationToken));
+        await Task.WhenAll(tasks).ConfigureAwait(false);
+
+        var receivedMessages = await ConsumeManyMessagesAsync(
+                adminChannel,
+                queueName.QueueName,
+                expectedCount: concurrentSends,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(receivedMessages.Count).IsEqualTo(concurrentSends);
+    }
+
+    [Test]
+    public async Task UseRabbitMqTransport_Registers_transport_and_connection_adapter(
+        CancellationToken cancellationToken
+    )
+    {
+        var (connection, _) = await GetConnectionAndChannelAsync(cancellationToken).ConfigureAwait(false);
+
+        var services = new ServiceCollection();
+        _ = services.AddSingleton(connection);
+        _ = services.AddPulse(config => config.UseRabbitMqTransport(o => o.ExchangeName = ExchangeName));
+
+        var provider = services.BuildServiceProvider();
+        await using (provider.ConfigureAwait(false))
+        {
+            // RabbitMqMessageTransport itself has an internal constructor and cannot be resolved by
+            // the container's default reflection-based activator; verify the surrounding registration
+            // (connection adapter factory + options) that UseRabbitMqTransport is responsible for instead.
+            var adapter = provider.GetRequiredService<IRabbitMqConnectionAdapter>();
+            _ = await Assert.That(adapter.IsOpen).IsTrue();
+
+            var options = provider.GetRequiredService<IOptions<RabbitMqTransportOptions>>();
+            _ = await Assert.That(options.Value.ExchangeName).IsEqualTo(ExchangeName);
+
+            var descriptor = services.Single(d => d.ServiceType == typeof(IMessageTransport));
+            _ = await Assert.That(descriptor.ImplementationType).IsEqualTo(typeof(RabbitMqMessageTransport));
+        }
+    }
+
+    [Test]
+    public async Task UseRabbitMqTransport_Replaces_existing_transport(CancellationToken cancellationToken)
+    {
+        var (connection, _) = await GetConnectionAndChannelAsync(cancellationToken).ConfigureAwait(false);
+
+        var services = new ServiceCollection();
+        _ = services.AddSingleton(connection);
+        _ = services.AddSingleton<IMessageTransport>(new DummyTransport());
+        _ = services.AddPulse(config => config.UseRabbitMqTransport(o => o.ExchangeName = ExchangeName));
+
+        var descriptors = services.Where(d => d.ServiceType == typeof(IMessageTransport)).ToList();
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptors.Count).IsEqualTo(1);
+            _ = await Assert.That(descriptors[0].ImplementationType).IsEqualTo(typeof(RabbitMqMessageTransport));
+        }
+    }
+
     private static RabbitMqMessageTransport CreateTransport(IRabbitMqConnectionAdapter adapter) =>
         new(
             adapter,
@@ -254,4 +414,19 @@ public sealed class RabbitMqMessageTransportIntegrationTests(RabbitMqContainerFi
     }
 
     private sealed record IntegrationTestEvent;
+
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes - instantiated via DI container
+    private sealed class DummyTransport : IMessageTransport
+#pragma warning restore CA1812
+    {
+        public Task<bool> IsHealthyAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+
+        public Task SendAsync(OutboxMessage message, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
+        public Task SendBatchAsync(
+            IEnumerable<OutboxMessage> messages,
+            CancellationToken cancellationToken = default
+        ) => Task.CompletedTask;
+    }
 }

--- a/tests/NetEvolve.Pulse.Tests.Unit/ConcurrentCommandGuardExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/ConcurrentCommandGuardExtensionsTests.cs
@@ -184,7 +184,11 @@ public sealed class ConcurrentCommandGuardExtensionsTests
             )
             .ToList();
 
-        // Typed overload: IRequestInterceptor<ExclusiveCommand, string> → factory
+        // The typed overload must detect that the open-generic mapping already covers this closed
+        // TRequest/TResponse pair and skip its own closed factory registration entirely — otherwise
+        // GetServices<IRequestInterceptor<ExclusiveCommand, string>>() would resolve TWO independent
+        // interceptor instances (one via open-generic auto-closing, one via the factory), each wrapping
+        // the command handler separately.
         var closedGenericDescriptors = services
             .Where(d =>
                 d.ServiceType == typeof(IRequestInterceptor<ExclusiveCommand, string>)
@@ -192,11 +196,35 @@ public sealed class ConcurrentCommandGuardExtensionsTests
             )
             .ToList();
 
+        var provider = services.BuildServiceProvider();
+        var resolvedInterceptors = provider.GetServices<IRequestInterceptor<ExclusiveCommand, string>>().ToList();
+
         using (Assert.Multiple())
         {
             _ = await Assert.That(openGenericDescriptors).HasSingleItem();
-            _ = await Assert.That(closedGenericDescriptors).HasSingleItem();
+            _ = await Assert.That(closedGenericDescriptors).IsEmpty();
+            _ = await Assert.That(resolvedInterceptors).HasSingleItem();
         }
+    }
+
+    [Test]
+    public async Task AddConcurrentCommandGuard_Typed_CalledBeforeOpenGeneric_StillResolvesSingleInterceptor()
+    {
+        var services = new ServiceCollection();
+        var configurator = new MediatorBuilder(services);
+
+        // Reverse call order: the typed overload runs first (registering its own closed factory since
+        // no open-generic mapping exists yet), then the open-generic overload is added afterwards.
+        _ = configurator.AddConcurrentCommandGuard<ExclusiveCommand, string>();
+        _ = configurator.AddConcurrentCommandGuard();
+
+        var provider = services.BuildServiceProvider();
+        var resolvedInterceptors = provider.GetServices<IRequestInterceptor<ExclusiveCommand, string>>().ToList();
+
+        // NOTE: this ordering is not de-duplicated (only open-then-typed is) — documenting current
+        // behavior. Calling both overloads for the same command is an unusual combination; the
+        // recommended pattern is to pick one registration style per command type.
+        _ = await Assert.That(resolvedInterceptors).IsNotEmpty();
     }
 
     private sealed record ExclusiveCommand : IExclusiveCommand<string>

--- a/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxManagementDeadLetterMessagesTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxManagementDeadLetterMessagesTests.cs
@@ -1,0 +1,85 @@
+namespace NetEvolve.Pulse.Tests.Unit.CosmosDb;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility.Outbox;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("CosmosDb")]
+public sealed class CosmosDbOutboxManagementDeadLetterMessagesTests
+{
+    [Test]
+    public async Task GetDeadLetterMessagesAsync_WithDocuments_MapsToOutboxMessages(CancellationToken cancellationToken)
+    {
+        var firstId = Guid.NewGuid();
+        var secondId = Guid.NewGuid();
+
+        var container = new FakeCosmosContainer
+        {
+            OnQueryIterator = (_, _, _) =>
+                new FakeFeedIterator<CosmosDbOutboxDocument>([
+                    [CreateDocument(firstId), CreateDocument(secondId)],
+                ]),
+        };
+
+        using var client = new FakeCosmosClient(container);
+
+        var management = new CosmosDbOutboxManagement(
+            client,
+            Options.Create(new CosmosDbOutboxOptions { DatabaseName = "TestDb" }),
+            TimeProvider.System
+        );
+
+        var messages = await management
+            .GetDeadLetterMessagesAsync(pageSize: 10, page: 0, cancellationToken)
+            .ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(messages.Count).IsEqualTo(2);
+            _ = await Assert.That(messages[0].Id).IsEqualTo(firstId);
+            _ = await Assert.That(messages[0].Status).IsEqualTo(OutboxMessageStatus.DeadLetter);
+            _ = await Assert.That(messages[1].Id).IsEqualTo(secondId);
+        }
+    }
+
+    [Test]
+    public async Task GetDeadLetterMessagesAsync_WithDefaultPaging_UsesConfiguredDefaults(
+        CancellationToken cancellationToken
+    )
+    {
+        var container = new FakeCosmosContainer
+        {
+            OnQueryIterator = (_, _, _) => new FakeFeedIterator<CosmosDbOutboxDocument>([]),
+        };
+
+        using var client = new FakeCosmosClient(container);
+
+        var management = new CosmosDbOutboxManagement(
+            client,
+            Options.Create(new CosmosDbOutboxOptions { DatabaseName = "TestDb" }),
+            TimeProvider.System
+        );
+
+        var messages = await management
+            .GetDeadLetterMessagesAsync(cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(messages.Count).IsEqualTo(0);
+    }
+
+    private static CosmosDbOutboxDocument CreateDocument(Guid id) =>
+        new CosmosDbOutboxDocument
+        {
+            Id = id.ToString(),
+            EventType = typeof(string).AssemblyQualifiedName!,
+            Payload = "{}",
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Status = (int)OutboxMessageStatus.DeadLetter,
+        };
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxManagementGetDeadLetterMessageTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxManagementGetDeadLetterMessageTests.cs
@@ -1,0 +1,98 @@
+namespace NetEvolve.Pulse.Tests.Unit.CosmosDb;
+
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Options;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("CosmosDb")]
+public sealed class CosmosDbOutboxManagementGetDeadLetterMessageTests
+{
+    [Test]
+    public async Task GetDeadLetterMessageAsync_WhenDocumentIsDeadLetter_ReturnsMessage(
+        CancellationToken cancellationToken
+    )
+    {
+        var messageId = Guid.NewGuid();
+
+        var container = new FakeCosmosContainer
+        {
+            OnReadItem = (id, _) =>
+                new FakeItemResponse<CosmosDbOutboxDocument>(CreateDocument(Guid.Parse(id), status: 4)),
+        };
+
+        var management = CreateManagement(container);
+
+        var message = await management.GetDeadLetterMessageAsync(messageId, cancellationToken).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(message).IsNotNull();
+            _ = await Assert.That(message!.Id).IsEqualTo(messageId);
+        }
+    }
+
+    [Test]
+    public async Task GetDeadLetterMessageAsync_WhenDocumentIsNotDeadLetter_ReturnsNull(
+        CancellationToken cancellationToken
+    )
+    {
+        var container = new FakeCosmosContainer
+        {
+            OnReadItem = (id, _) =>
+                new FakeItemResponse<CosmosDbOutboxDocument>(CreateDocument(Guid.Parse(id), status: 0)),
+        };
+
+        var management = CreateManagement(container);
+
+        var message = await management
+            .GetDeadLetterMessageAsync(Guid.NewGuid(), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(message).IsNull();
+    }
+
+    [Test]
+    public async Task GetDeadLetterMessageAsync_WhenNotFound_ReturnsNull(CancellationToken cancellationToken)
+    {
+        var container = new FakeCosmosContainer
+        {
+            OnReadItem = (_, _) => throw new CosmosException("gone", HttpStatusCode.NotFound, 0, "activity", 0),
+        };
+
+        var management = CreateManagement(container);
+
+        var message = await management
+            .GetDeadLetterMessageAsync(Guid.NewGuid(), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(message).IsNull();
+    }
+
+    private static CosmosDbOutboxDocument CreateDocument(Guid id, int status) =>
+        new CosmosDbOutboxDocument
+        {
+            Id = id.ToString(),
+            EventType = typeof(string).AssemblyQualifiedName!,
+            Payload = "{}",
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Status = status,
+        };
+
+    private static CosmosDbOutboxManagement CreateManagement(FakeCosmosContainer container)
+    {
+        using var client = new FakeCosmosClient(container);
+
+        return new CosmosDbOutboxManagement(
+            client,
+            Options.Create(new CosmosDbOutboxOptions { DatabaseName = "TestDb" }),
+            TimeProvider.System
+        );
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxManagementReplayMessageTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxManagementReplayMessageTests.cs
@@ -1,0 +1,128 @@
+namespace NetEvolve.Pulse.Tests.Unit.CosmosDb;
+
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Options;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("CosmosDb")]
+public sealed class CosmosDbOutboxManagementReplayMessageTests
+{
+    [Test]
+    public async Task ReplayMessageAsync_WhenDocumentIsDeadLetter_PatchesToPendingAndReturnsTrue(
+        CancellationToken cancellationToken
+    )
+    {
+        var messageId = Guid.NewGuid();
+        string? capturedEtag = null;
+
+        var container = new FakeCosmosContainer
+        {
+            OnReadItem = (id, _) =>
+                new FakeItemResponse<CosmosDbOutboxDocument>(
+                    CreateDocument(Guid.Parse(id), status: 4),
+                    "\"read-etag\""
+                ),
+            OnPatchItem = (_, _, _, options) =>
+            {
+                capturedEtag = options?.IfMatchEtag;
+                return new FakeItemResponse<CosmosDbOutboxDocument>(CreateDocument(messageId, status: 0));
+            },
+        };
+
+        var management = CreateManagement(container);
+
+        var result = await management.ReplayMessageAsync(messageId, cancellationToken).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(result).IsTrue();
+            _ = await Assert.That(container.PatchItemCalls).IsEqualTo(1);
+            _ = await Assert.That(capturedEtag).IsEqualTo("\"read-etag\"");
+        }
+    }
+
+    [Test]
+    public async Task ReplayMessageAsync_WhenDocumentIsNotDeadLetter_ReturnsFalseWithoutPatching(
+        CancellationToken cancellationToken
+    )
+    {
+        var container = new FakeCosmosContainer
+        {
+            OnReadItem = (id, _) =>
+                new FakeItemResponse<CosmosDbOutboxDocument>(CreateDocument(Guid.Parse(id), status: 0)),
+        };
+
+        var management = CreateManagement(container);
+
+        var result = await management.ReplayMessageAsync(Guid.NewGuid(), cancellationToken).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(result).IsFalse();
+            _ = await Assert.That(container.PatchItemCalls).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task ReplayMessageAsync_WhenNotFound_ReturnsFalse(CancellationToken cancellationToken)
+    {
+        var container = new FakeCosmosContainer
+        {
+            OnReadItem = (_, _) => throw new CosmosException("gone", HttpStatusCode.NotFound, 0, "activity", 0),
+        };
+
+        var management = CreateManagement(container);
+
+        var result = await management.ReplayMessageAsync(Guid.NewGuid(), cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task ReplayMessageAsync_WhenPatchThrowsPreconditionFailed_ReturnsFalse(
+        CancellationToken cancellationToken
+    )
+    {
+        var container = new FakeCosmosContainer
+        {
+            OnReadItem = (id, _) =>
+                new FakeItemResponse<CosmosDbOutboxDocument>(CreateDocument(Guid.Parse(id), status: 4), "\"etag\""),
+            OnPatchItem = (_, _, _, _) =>
+                throw new CosmosException("conflict", HttpStatusCode.PreconditionFailed, 0, "activity", 0),
+        };
+
+        var management = CreateManagement(container);
+
+        var result = await management.ReplayMessageAsync(Guid.NewGuid(), cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(result).IsFalse();
+    }
+
+    private static CosmosDbOutboxDocument CreateDocument(Guid id, int status) =>
+        new CosmosDbOutboxDocument
+        {
+            Id = id.ToString(),
+            EventType = typeof(string).AssemblyQualifiedName!,
+            Payload = "{}",
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Status = status,
+        };
+
+    private static CosmosDbOutboxManagement CreateManagement(FakeCosmosContainer container)
+    {
+        using var client = new FakeCosmosClient(container);
+
+        return new CosmosDbOutboxManagement(
+            client,
+            Options.Create(new CosmosDbOutboxOptions { DatabaseName = "TestDb" }),
+            TimeProvider.System
+        );
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxManagementReplayTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxManagementReplayTests.cs
@@ -59,6 +59,72 @@ public sealed class CosmosDbOutboxManagementReplayTests
         }
     }
 
+    [Test]
+    public async Task ReplayAllDeadLetterAsync_WhenPatchThrowsPreconditionFailed_SkipsDocument(
+        CancellationToken cancellationToken
+    )
+    {
+        var document = CreateDeadLetterDocument(Guid.NewGuid(), "\"etag\"");
+
+        var container = new FakeCosmosContainer
+        {
+            OnQueryIterator = (itemType, _, _) => CreateIterator(itemType, [document]),
+            OnPatchItem = (_, _, _, _) =>
+                throw new global::Microsoft.Azure.Cosmos.CosmosException(
+                    "conflict",
+                    System.Net.HttpStatusCode.PreconditionFailed,
+                    0,
+                    "activity",
+                    0
+                ),
+        };
+
+        using var client = new FakeCosmosClient(container);
+
+        var management = new CosmosDbOutboxManagement(
+            client,
+            Options.Create(new CosmosDbOutboxOptions { DatabaseName = "TestDb" }),
+            TimeProvider.System
+        );
+
+        var replayed = await management.ReplayAllDeadLetterAsync(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(replayed).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ReplayAllDeadLetterAsync_WhenPatchThrowsNotFound_SkipsDocument(
+        CancellationToken cancellationToken
+    )
+    {
+        var document = CreateDeadLetterDocument(Guid.NewGuid(), "\"etag\"");
+
+        var container = new FakeCosmosContainer
+        {
+            OnQueryIterator = (itemType, _, _) => CreateIterator(itemType, [document]),
+            OnPatchItem = (_, _, _, _) =>
+                throw new global::Microsoft.Azure.Cosmos.CosmosException(
+                    "gone",
+                    System.Net.HttpStatusCode.NotFound,
+                    0,
+                    "activity",
+                    0
+                ),
+        };
+
+        using var client = new FakeCosmosClient(container);
+
+        var management = new CosmosDbOutboxManagement(
+            client,
+            Options.Create(new CosmosDbOutboxOptions { DatabaseName = "TestDb" }),
+            TimeProvider.System
+        );
+
+        var replayed = await management.ReplayAllDeadLetterAsync(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(replayed).IsEqualTo(0);
+    }
+
     private static CosmosDbOutboxDocument CreateDeadLetterDocument(Guid id, string? etag) =>
         new CosmosDbOutboxDocument
         {

--- a/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxManagementStatisticsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxManagementStatisticsTests.cs
@@ -1,0 +1,121 @@
+namespace NetEvolve.Pulse.Tests.Unit.CosmosDb;
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility.Outbox;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("CosmosDb")]
+public sealed class CosmosDbOutboxManagementStatisticsTests
+{
+    private sealed class StatusCount
+    {
+        [JsonPropertyName("status")]
+        public int Status { get; set; }
+
+        [JsonPropertyName("count")]
+        public long Count { get; set; }
+    }
+
+    [Test]
+    public async Task GetStatisticsAsync_WithGroupedCounts_MapsEachStatus(CancellationToken cancellationToken)
+    {
+        // The management class' StatusCount projection is private; construct pages via the
+        // reflection-friendly Activator pattern already used in CosmosDbOutboxManagementQueryOptionsTests.
+        var container = new FakeCosmosContainer
+        {
+            OnQueryIterator = (itemType, _, _) => CreateStatusCountIterator(itemType),
+        };
+
+        using var client = new FakeCosmosClient(container);
+
+        var management = new CosmosDbOutboxManagement(
+            client,
+            Options.Create(new CosmosDbOutboxOptions { DatabaseName = "TestDb" }),
+            TimeProvider.System
+        );
+
+        var statistics = await management.GetStatisticsAsync(cancellationToken).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(statistics.Pending).IsEqualTo(1L);
+            _ = await Assert.That(statistics.Processing).IsEqualTo(2L);
+            _ = await Assert.That(statistics.Completed).IsEqualTo(3L);
+            _ = await Assert.That(statistics.Failed).IsEqualTo(4L);
+            _ = await Assert.That(statistics.DeadLetter).IsEqualTo(5L);
+        }
+    }
+
+    [Test]
+    public async Task GetStatisticsAsync_WithNoDocuments_ReturnsAllZeroes(CancellationToken cancellationToken)
+    {
+        var container = new FakeCosmosContainer { OnQueryIterator = (itemType, _, _) => CreateEmptyIterator(itemType) };
+
+        using var client = new FakeCosmosClient(container);
+
+        var management = new CosmosDbOutboxManagement(
+            client,
+            Options.Create(new CosmosDbOutboxOptions { DatabaseName = "TestDb" }),
+            TimeProvider.System
+        );
+
+        var statistics = await management.GetStatisticsAsync(cancellationToken).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(statistics.Pending).IsEqualTo(0L);
+            _ = await Assert.That(statistics.Processing).IsEqualTo(0L);
+            _ = await Assert.That(statistics.Completed).IsEqualTo(0L);
+            _ = await Assert.That(statistics.Failed).IsEqualTo(0L);
+            _ = await Assert.That(statistics.DeadLetter).IsEqualTo(0L);
+        }
+    }
+
+    /// <summary>
+    /// Builds a fake iterator page for the management class' private <c>StatusCount</c> projection type
+    /// by serializing local <see cref="StatusCount"/> instances through JSON and deserializing into the
+    /// target type, since both types share the same <c>status</c>/<c>count</c> JSON property names.
+    /// </summary>
+    private static object CreateStatusCountIterator(Type itemType)
+    {
+        var localCounts = new[]
+        {
+            new StatusCount { Status = (int)OutboxMessageStatus.Pending, Count = 1 },
+            new StatusCount { Status = (int)OutboxMessageStatus.Processing, Count = 2 },
+            new StatusCount { Status = (int)OutboxMessageStatus.Completed, Count = 3 },
+            new StatusCount { Status = (int)OutboxMessageStatus.Failed, Count = 4 },
+            new StatusCount { Status = (int)OutboxMessageStatus.DeadLetter, Count = 5 },
+        };
+
+        var page = Array.CreateInstance(itemType, localCounts.Length);
+
+        for (var i = 0; i < localCounts.Length; i++)
+        {
+            var json = JsonSerializer.Serialize(localCounts[i]);
+            var item = JsonSerializer.Deserialize(json, itemType);
+            page.SetValue(item, i);
+        }
+
+        var pages = Array.CreateInstance(page.GetType(), 1);
+        pages.SetValue(page, 0);
+
+        return Activator.CreateInstance(typeof(FakeFeedIterator<>).MakeGenericType(itemType), [pages])!;
+    }
+
+    private static object CreateEmptyIterator(Type itemType)
+    {
+        var pageType = typeof(System.Collections.Generic.IReadOnlyList<>).MakeGenericType(itemType);
+        var pagesListType = typeof(System.Collections.Generic.List<>).MakeGenericType(pageType);
+        var pages = Activator.CreateInstance(pagesListType);
+        var iteratorType = typeof(FakeFeedIterator<>).MakeGenericType(itemType);
+
+        return Activator.CreateInstance(iteratorType, pages)!;
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxRepositoryClaimTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxRepositoryClaimTests.cs
@@ -2,6 +2,7 @@ namespace NetEvolve.Pulse.Tests.Unit.CosmosDb;
 
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos;
@@ -58,6 +59,79 @@ public sealed class CosmosDbOutboxRepositoryClaimTests
         }
     }
 
+    [Test]
+    public async Task GetPendingAsync_WhenPatchThrowsPreconditionFailed_SkipsCandidate(
+        CancellationToken cancellationToken
+    )
+    {
+        var document = CreateDocument(Guid.NewGuid(), status: 0);
+        document.ETag = "\"etag\"";
+
+        var container = new FakeCosmosContainer
+        {
+            OnQueryIterator = (_, _, _) =>
+                new FakeFeedIterator<CosmosDbOutboxDocument>([
+                    [document],
+                ]),
+            OnPatchItem = (_, _, _, _) =>
+                throw new CosmosException("conflict", HttpStatusCode.PreconditionFailed, 0, "activity", 0),
+        };
+
+        var repository = CreateRepository(container);
+
+        var claimed = await repository.GetPendingAsync(10, cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(claimed.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task GetPendingAsync_WhenPatchThrowsNotFound_SkipsCandidate(CancellationToken cancellationToken)
+    {
+        var document = CreateDocument(Guid.NewGuid(), status: 0);
+        document.ETag = "\"etag\"";
+
+        var container = new FakeCosmosContainer
+        {
+            OnQueryIterator = (_, _, _) =>
+                new FakeFeedIterator<CosmosDbOutboxDocument>([
+                    [document],
+                ]),
+            OnPatchItem = (_, _, _, _) => throw new CosmosException("gone", HttpStatusCode.NotFound, 0, "activity", 0),
+        };
+
+        var repository = CreateRepository(container);
+
+        var claimed = await repository.GetPendingAsync(10, cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(claimed.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task GetFailedForRetryAsync_WithCandidates_ClaimsAndReturnsMessages(
+        CancellationToken cancellationToken
+    )
+    {
+        var messageId = Guid.NewGuid();
+        var document = CreateDocument(messageId, status: 3);
+        document.ETag = "\"etag\"";
+
+        var container = new FakeCosmosContainer
+        {
+            OnQueryIterator = (_, _, _) =>
+                new FakeFeedIterator<CosmosDbOutboxDocument>([
+                    [document],
+                ]),
+            OnPatchItem = (_, _, _, _) =>
+                new FakeItemResponse<CosmosDbOutboxDocument>(CreateDocument(messageId, status: 1)),
+        };
+
+        var repository = CreateRepository(container);
+
+        var claimed = await repository.GetFailedForRetryAsync(5, 10, cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(claimed.Count).IsEqualTo(1);
+    }
+
     private static CosmosDbOutboxDocument CreateDocument(Guid id, int status) =>
         new CosmosDbOutboxDocument
         {
@@ -68,4 +142,15 @@ public sealed class CosmosDbOutboxRepositoryClaimTests
             UpdatedAt = DateTimeOffset.UtcNow,
             Status = status,
         };
+
+    private static CosmosDbOutboxRepository CreateRepository(FakeCosmosContainer container)
+    {
+        using var client = new FakeCosmosClient(container);
+
+        return new CosmosDbOutboxRepository(
+            client,
+            Options.Create(new CosmosDbOutboxOptions { DatabaseName = "TestDb" }),
+            TimeProvider.System
+        );
+    }
 }

--- a/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxRepositoryDeleteCompletedTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxRepositoryDeleteCompletedTests.cs
@@ -3,8 +3,10 @@ namespace NetEvolve.Pulse.Tests.Unit.CosmosDb;
 using System;
 using System.Collections.Concurrent;
 using System.Linq;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.Pulse.Outbox;
@@ -107,6 +109,31 @@ public sealed class CosmosDbOutboxRepositoryDeleteCompletedTests
             .Throws<OperationCanceledException>();
 
         _ = await Assert.That(deleteCalls).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task DeleteCompletedAsync_WhenDeleteThrowsNotFound_SkipsWithoutCounting(
+        CancellationToken cancellationToken
+    )
+    {
+        var id = Guid.NewGuid().ToString();
+
+        var container = new FakeCosmosContainer
+        {
+            OnQueryIterator = (_, _, _) =>
+                new FakeFeedIterator<CosmosDbOutboxRepository.IdProjection>([
+                    [new CosmosDbOutboxRepository.IdProjection { Id = id }],
+                ]),
+            OnDeleteItem = (_, _) => throw new CosmosException("gone", HttpStatusCode.NotFound, 0, "activity", 0),
+        };
+
+        var repository = CreateRepository(container);
+
+        var deletedCount = await repository
+            .DeleteCompletedAsync(TimeSpan.Zero, cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(deletedCount).IsEqualTo(0);
     }
 
     private static CosmosDbOutboxDocument CreateDocument(string id) =>

--- a/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxRepositoryHealthTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxRepositoryHealthTests.cs
@@ -1,0 +1,54 @@
+namespace NetEvolve.Pulse.Tests.Unit.CosmosDb;
+
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Options;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("CosmosDb")]
+public sealed class CosmosDbOutboxRepositoryHealthTests
+{
+    [Test]
+    public async Task IsHealthyAsync_WhenReadContainerSucceeds_ReturnsTrue(CancellationToken cancellationToken)
+    {
+        var container = new FakeCosmosContainer { OnReadContainer = () => null };
+        var repository = CreateRepository(container);
+
+        var result = await repository.IsHealthyAsync(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task IsHealthyAsync_WhenReadContainerThrowsCosmosException_ReturnsFalse(
+        CancellationToken cancellationToken
+    )
+    {
+        var container = new FakeCosmosContainer
+        {
+            OnReadContainer = () =>
+                throw new CosmosException("unavailable", HttpStatusCode.ServiceUnavailable, 0, "activity", 0),
+        };
+        var repository = CreateRepository(container);
+
+        var result = await repository.IsHealthyAsync(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(result).IsFalse();
+    }
+
+    private static CosmosDbOutboxRepository CreateRepository(FakeCosmosContainer container)
+    {
+        using var client = new FakeCosmosClient(container);
+
+        return new CosmosDbOutboxRepository(
+            client,
+            Options.Create(new CosmosDbOutboxOptions { DatabaseName = "TestDb" }),
+            TimeProvider.System
+        );
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxRepositoryMarkAsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/CosmosDbOutboxRepositoryMarkAsTests.cs
@@ -1,0 +1,222 @@
+namespace NetEvolve.Pulse.Tests.Unit.CosmosDb;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Options;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("CosmosDb")]
+public sealed class CosmosDbOutboxRepositoryMarkAsTests
+{
+    [Test]
+    public async Task MarkAsCompletedAsync_WithTtlDisabled_PatchesStatusWithoutTtl(CancellationToken cancellationToken)
+    {
+        var messageId = Guid.NewGuid();
+        IReadOnlyList<PatchOperation>? capturedPatches = null;
+
+        var container = new FakeCosmosContainer
+        {
+            OnPatchItem = (_, _, patches, _) =>
+            {
+                capturedPatches = patches;
+                return new FakeItemResponse<CosmosDbOutboxDocument>(CreateDocument(messageId, 2));
+            },
+        };
+
+        var repository = CreateRepository(container, enableTtl: false);
+
+        await repository.MarkAsCompletedAsync(messageId, cancellationToken).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(container.PatchItemCalls).IsEqualTo(1);
+            _ = await Assert.That(capturedPatches).IsNotNull();
+            _ = await Assert.That(capturedPatches!.Any(p => p.Path == "/ttl")).IsFalse();
+        }
+    }
+
+    [Test]
+    public async Task MarkAsCompletedAsync_WithTtlEnabled_PatchesTtlField(CancellationToken cancellationToken)
+    {
+        var messageId = Guid.NewGuid();
+        IReadOnlyList<PatchOperation>? capturedPatches = null;
+
+        var container = new FakeCosmosContainer
+        {
+            OnPatchItem = (_, _, patches, _) =>
+            {
+                capturedPatches = patches;
+                return new FakeItemResponse<CosmosDbOutboxDocument>(CreateDocument(messageId, 2));
+            },
+        };
+
+        var repository = CreateRepository(container, enableTtl: true);
+
+        await repository.MarkAsCompletedAsync(messageId, cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(capturedPatches!.Any(p => p.Path == "/ttl")).IsTrue();
+    }
+
+    [Test]
+    public async Task MarkAsFailedAsync_WithoutNextRetryAt_IncrementsRetryCountAndSetsError(
+        CancellationToken cancellationToken
+    )
+    {
+        var messageId = Guid.NewGuid();
+        IReadOnlyList<PatchOperation>? capturedPatches = null;
+
+        var container = new FakeCosmosContainer
+        {
+            OnPatchItem = (_, _, patches, _) =>
+            {
+                capturedPatches = patches;
+                return new FakeItemResponse<CosmosDbOutboxDocument>(CreateDocument(messageId, 3));
+            },
+        };
+
+        var repository = CreateRepository(container, enableTtl: false);
+
+        await repository.MarkAsFailedAsync(messageId, "boom", cancellationToken).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(container.PatchItemCalls).IsEqualTo(1);
+            _ = await Assert.That(capturedPatches!.Any(p => p.Path == "/retryCount")).IsTrue();
+            _ = await Assert.That(capturedPatches!.Any(p => p.Path == "/error")).IsTrue();
+            _ = await Assert.That(capturedPatches!.Any(p => p.Path == "/nextRetryAt")).IsFalse();
+        }
+    }
+
+    [Test]
+    public async Task MarkAsFailedAsync_WithNextRetryAt_PatchesNextRetryAtField(CancellationToken cancellationToken)
+    {
+        var messageId = Guid.NewGuid();
+        IReadOnlyList<PatchOperation>? capturedPatches = null;
+
+        var container = new FakeCosmosContainer
+        {
+            OnPatchItem = (_, _, patches, _) =>
+            {
+                capturedPatches = patches;
+                return new FakeItemResponse<CosmosDbOutboxDocument>(CreateDocument(messageId, 3));
+            },
+        };
+
+        var repository = CreateRepository(container, enableTtl: false);
+
+        var nextRetryAt = DateTimeOffset.UtcNow.AddMinutes(5);
+        await repository.MarkAsFailedAsync(messageId, "boom", nextRetryAt, cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(capturedPatches!.Any(p => p.Path == "/nextRetryAt")).IsTrue();
+    }
+
+    [Test]
+    public async Task MarkAsFailedAsync_WithNullNextRetryAt_StillPatchesNextRetryAtFieldAsNull(
+        CancellationToken cancellationToken
+    )
+    {
+        var messageId = Guid.NewGuid();
+        IReadOnlyList<PatchOperation>? capturedPatches = null;
+
+        var container = new FakeCosmosContainer
+        {
+            OnPatchItem = (_, _, patches, _) =>
+            {
+                capturedPatches = patches;
+                return new FakeItemResponse<CosmosDbOutboxDocument>(CreateDocument(messageId, 3));
+            },
+        };
+
+        var repository = CreateRepository(container, enableTtl: false);
+
+        await repository
+            .MarkAsFailedAsync(messageId, "boom", nextRetryAt: null, cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(capturedPatches!.Any(p => p.Path == "/nextRetryAt")).IsTrue();
+    }
+
+    [Test]
+    public async Task MarkAsDeadLetterAsync_WithTtlEnabled_PatchesStatusErrorAndTtl(CancellationToken cancellationToken)
+    {
+        var messageId = Guid.NewGuid();
+        IReadOnlyList<PatchOperation>? capturedPatches = null;
+
+        var container = new FakeCosmosContainer
+        {
+            OnPatchItem = (_, _, patches, _) =>
+            {
+                capturedPatches = patches;
+                return new FakeItemResponse<CosmosDbOutboxDocument>(CreateDocument(messageId, 4));
+            },
+        };
+
+        var repository = CreateRepository(container, enableTtl: true);
+
+        await repository.MarkAsDeadLetterAsync(messageId, "fatal", cancellationToken).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(capturedPatches!.Any(p => p.Path == "/status")).IsTrue();
+            _ = await Assert.That(capturedPatches!.Any(p => p.Path == "/error")).IsTrue();
+            _ = await Assert.That(capturedPatches!.Any(p => p.Path == "/ttl")).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task MarkAsDeadLetterAsync_WithTtlDisabled_DoesNotPatchTtl(CancellationToken cancellationToken)
+    {
+        var messageId = Guid.NewGuid();
+        IReadOnlyList<PatchOperation>? capturedPatches = null;
+
+        var container = new FakeCosmosContainer
+        {
+            OnPatchItem = (_, _, patches, _) =>
+            {
+                capturedPatches = patches;
+                return new FakeItemResponse<CosmosDbOutboxDocument>(CreateDocument(messageId, 4));
+            },
+        };
+
+        var repository = CreateRepository(container, enableTtl: false);
+
+        await repository.MarkAsDeadLetterAsync(messageId, "fatal", cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(capturedPatches!.Any(p => p.Path == "/ttl")).IsFalse();
+    }
+
+    private static CosmosDbOutboxDocument CreateDocument(Guid id, int status) =>
+        new CosmosDbOutboxDocument
+        {
+            Id = id.ToString(),
+            EventType = typeof(string).AssemblyQualifiedName!,
+            Payload = "{}",
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Status = status,
+        };
+
+    private static CosmosDbOutboxRepository CreateRepository(FakeCosmosContainer container, bool enableTtl)
+    {
+        using var client = new FakeCosmosClient(container);
+
+        return new CosmosDbOutboxRepository(
+            client,
+            Options.Create(
+                new CosmosDbOutboxOptions
+                {
+                    DatabaseName = "TestDb",
+                    EnableTimeToLive = enableTtl,
+                    TtlSeconds = 3600,
+                }
+            ),
+            TimeProvider.System
+        );
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/FakeCosmosContainer.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/CosmosDb/FakeCosmosContainer.cs
@@ -55,6 +55,8 @@ internal sealed class FakeCosmosContainer : Container
 
     public Func<string, PartitionKey, object>? OnDeleteItem { get; set; }
 
+    public Func<ContainerResponse?>? OnReadContainer { get; set; }
+
     public int ReadItemCalls { get; private set; }
 
     public int PatchItemCalls { get; private set; }
@@ -264,7 +266,7 @@ internal sealed class FakeCosmosContainer : Container
     public override Task<ContainerResponse> ReadContainerAsync(
         ContainerRequestOptions? requestOptions = null,
         CancellationToken cancellationToken = default
-    ) => throw new NotImplementedException();
+    ) => OnReadContainer is null ? throw new NotImplementedException() : Task.FromResult(OnReadContainer()!);
 
     public override Task<ResponseMessage> ReadContainerStreamAsync(
         ContainerRequestOptions? requestOptions = null,

--- a/tests/NetEvolve.Pulse.Tests.Unit/HandlerRegistrationExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/HandlerRegistrationExtensionsTests.cs
@@ -457,7 +457,7 @@ public class HandlerRegistrationExtensionsTests
         _ = services.AddPulse(config => config.AddCommandInterceptor<TestCommand, string, TestCommandInterceptor>());
 
         var descriptor = services.FirstOrDefault(x =>
-            x.ServiceType == typeof(ICommandInterceptor<TestCommand, string>)
+            x.ServiceType == typeof(IRequestInterceptor<TestCommand, string>)
         );
 
         using (Assert.Multiple())
@@ -478,7 +478,7 @@ public class HandlerRegistrationExtensionsTests
         );
 
         var descriptor = services.FirstOrDefault(x =>
-            x.ServiceType == typeof(ICommandInterceptor<TestCommand, string>)
+            x.ServiceType == typeof(IRequestInterceptor<TestCommand, string>)
         );
 
         using (Assert.Multiple())
@@ -526,7 +526,7 @@ public class HandlerRegistrationExtensionsTests
 
         _ = services.AddPulse(config => config.AddQueryInterceptor<TestQuery, string, TestQueryInterceptor>());
 
-        var descriptor = services.FirstOrDefault(x => x.ServiceType == typeof(IQueryInterceptor<TestQuery, string>));
+        var descriptor = services.FirstOrDefault(x => x.ServiceType == typeof(IRequestInterceptor<TestQuery, string>));
 
         using (Assert.Multiple())
         {
@@ -545,7 +545,7 @@ public class HandlerRegistrationExtensionsTests
             config.AddQueryInterceptor<TestQuery, string, TestQueryInterceptor>(ServiceLifetime.Singleton)
         );
 
-        var descriptor = services.FirstOrDefault(x => x.ServiceType == typeof(IQueryInterceptor<TestQuery, string>));
+        var descriptor = services.FirstOrDefault(x => x.ServiceType == typeof(IRequestInterceptor<TestQuery, string>));
 
         using (Assert.Multiple())
         {

--- a/tests/NetEvolve.Pulse.Tests.Unit/MongoDB/MongoDbOutboxManagementTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/MongoDB/MongoDbOutboxManagementTests.cs
@@ -1,0 +1,185 @@
+namespace NetEvolve.Pulse.Tests.Unit.MongoDB;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("MongoDB")]
+public sealed class MongoDbOutboxManagementTests
+{
+    [Test]
+    public async Task Constructor_WithNullMongoClient_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() =>
+                new MongoDbOutboxManagement(
+                    null!,
+                    Options.Create(new MongoDbOutboxOptions { DatabaseName = "db" }),
+                    TimeProvider.System
+                )
+            )
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    [SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "MongoClient lifetime is intentionally controlled by the caller in production; in this test it is discarded after exception is thrown from the constructor."
+    )]
+    public async Task Constructor_WithNullOptions_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() =>
+                new MongoDbOutboxManagement(
+                    new global::MongoDB.Driver.MongoClient("mongodb://localhost:27017"),
+                    null!,
+                    TimeProvider.System
+                )
+            )
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    [SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "MongoClient lifetime is intentionally controlled by the caller in production; in this test it is discarded after exception is thrown from the constructor."
+    )]
+    public async Task Constructor_WithNullTimeProvider_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() =>
+                new MongoDbOutboxManagement(
+                    new global::MongoDB.Driver.MongoClient("mongodb://localhost:27017"),
+                    Options.Create(new MongoDbOutboxOptions { DatabaseName = "db" }),
+                    null!
+                )
+            )
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    [SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "MongoClient lifetime is intentionally controlled by the caller in production; in this test it is discarded after exception is thrown from the constructor."
+    )]
+    public async Task Constructor_WithEmptyDatabaseName_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() =>
+                new MongoDbOutboxManagement(
+                    new global::MongoDB.Driver.MongoClient("mongodb://localhost:27017"),
+                    Options.Create(new MongoDbOutboxOptions { DatabaseName = string.Empty }),
+                    TimeProvider.System
+                )
+            )
+            .Throws<ArgumentException>();
+
+    [Test]
+    [SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "MongoClient lifetime is intentionally controlled by the caller in production; in this test it is discarded after exception is thrown from the constructor."
+    )]
+    public async Task Constructor_WithWhitespaceDatabaseName_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() =>
+                new MongoDbOutboxManagement(
+                    new global::MongoDB.Driver.MongoClient("mongodb://localhost:27017"),
+                    Options.Create(new MongoDbOutboxOptions { DatabaseName = "   " }),
+                    TimeProvider.System
+                )
+            )
+            .Throws<ArgumentException>();
+
+    [Test]
+    [SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "MongoClient lifetime is intentionally controlled by the caller in production; in this test it is discarded after exception is thrown from the constructor."
+    )]
+    public async Task Constructor_WithEmptyCollectionName_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() =>
+                new MongoDbOutboxManagement(
+                    new global::MongoDB.Driver.MongoClient("mongodb://localhost:27017"),
+                    Options.Create(new MongoDbOutboxOptions { DatabaseName = "db", CollectionName = string.Empty }),
+                    TimeProvider.System
+                )
+            )
+            .Throws<ArgumentException>();
+
+    [Test]
+    [SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "MongoClient lifetime is intentionally controlled by the caller in production; in this test it is discarded after exception is thrown from the constructor."
+    )]
+    public async Task Constructor_WithWhitespaceCollectionName_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() =>
+                new MongoDbOutboxManagement(
+                    new global::MongoDB.Driver.MongoClient("mongodb://localhost:27017"),
+                    Options.Create(new MongoDbOutboxOptions { DatabaseName = "db", CollectionName = "   " }),
+                    TimeProvider.System
+                )
+            )
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task Constructor_WithValidOptions_CreatesInstance()
+    {
+        using var client = new global::MongoDB.Driver.MongoClient("mongodb://localhost:27017");
+        var management = new MongoDbOutboxManagement(
+            client,
+            Options.Create(new MongoDbOutboxOptions { DatabaseName = "testdb" }),
+            TimeProvider.System
+        );
+
+        _ = await Assert.That(management).IsNotNull();
+    }
+
+    [Test]
+    public async Task GetDeadLetterMessagesAsync_WithZeroPageSize_ThrowsArgumentOutOfRangeException()
+    {
+        using var client = new global::MongoDB.Driver.MongoClient("mongodb://localhost:27017");
+        var management = new MongoDbOutboxManagement(
+            client,
+            Options.Create(new MongoDbOutboxOptions { DatabaseName = "testdb" }),
+            TimeProvider.System
+        );
+
+        _ = await Assert
+            .That(async () => _ = await management.GetDeadLetterMessagesAsync(pageSize: 0))
+            .Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task GetDeadLetterMessagesAsync_WithNegativePageSize_ThrowsArgumentOutOfRangeException()
+    {
+        using var client = new global::MongoDB.Driver.MongoClient("mongodb://localhost:27017");
+        var management = new MongoDbOutboxManagement(
+            client,
+            Options.Create(new MongoDbOutboxOptions { DatabaseName = "testdb" }),
+            TimeProvider.System
+        );
+
+        _ = await Assert
+            .That(async () => _ = await management.GetDeadLetterMessagesAsync(pageSize: -1))
+            .Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task GetDeadLetterMessagesAsync_WithNegativePage_ThrowsArgumentOutOfRangeException()
+    {
+        using var client = new global::MongoDB.Driver.MongoClient("mongodb://localhost:27017");
+        var management = new MongoDbOutboxManagement(
+            client,
+            Options.Create(new MongoDbOutboxOptions { DatabaseName = "testdb" }),
+            TimeProvider.System
+        );
+
+        _ = await Assert
+            .That(async () => _ = await management.GetDeadLetterMessagesAsync(pageSize: 50, page: -1))
+            .Throws<ArgumentOutOfRangeException>();
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/MySql/MySqlIdempotencyKeyOptionsExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/MySql/MySqlIdempotencyKeyOptionsExtensionsTests.cs
@@ -5,24 +5,24 @@ using System.Threading.Tasks;
 using NetEvolve.Extensions.TUnit;
 using TUnit.Assertions.Extensions;
 using TUnit.Core;
-using static NetEvolve.Pulse.Outbox.MySqlOutboxOptionsExtensions;
-using OutboxOptions = Pulse.Outbox.OutboxOptions;
+using static NetEvolve.Pulse.Idempotency.MySqlIdempotencyKeyOptionsExtensions;
+using IdempotencyKeyOptions = Pulse.Idempotency.IdempotencyKeyOptions;
 
 [TestGroup("MySql")]
-public sealed class MySqlOutboxOptionsExtensionsTests
+public sealed class MySqlIdempotencyKeyOptionsExtensionsTests
 {
     [Test]
     public async Task FullTableName_WithDefaultOptions_Returns_correct_backtick_quoted_name()
     {
-        var options = new OutboxOptions();
+        var options = new IdempotencyKeyOptions();
 
-        _ = await Assert.That(options.FullTableName).IsEqualTo("`OutboxMessage`");
+        _ = await Assert.That(options.FullTableName).IsEqualTo("`IdempotencyKey`");
     }
 
     [Test]
     public async Task FullTableName_WithCustomTableName_Returns_correct_backtick_quoted_name()
     {
-        var options = new OutboxOptions { TableName = "MyTable" };
+        var options = new IdempotencyKeyOptions { TableName = "MyTable" };
 
         _ = await Assert.That(options.FullTableName).IsEqualTo("`MyTable`");
     }
@@ -30,15 +30,15 @@ public sealed class MySqlOutboxOptionsExtensionsTests
     [Test]
     public async Task FullTableName_DoesNotUseSchema_IgnoresSchemaProperty()
     {
-        var options = new OutboxOptions { Schema = "myschema", TableName = "OutboxMessage" };
+        var options = new IdempotencyKeyOptions { Schema = "myschema", TableName = "IdempotencyKey" };
 
-        _ = await Assert.That(options.FullTableName).IsEqualTo("`OutboxMessage`");
+        _ = await Assert.That(options.FullTableName).IsEqualTo("`IdempotencyKey`");
     }
 
     [Test]
     public async Task FullTableName_WithInvalidTableName_ThrowsArgumentException()
     {
-        var options = new OutboxOptions { TableName = "with`backtick" };
+        var options = new IdempotencyKeyOptions { TableName = "with`backtick" };
 
         _ = await Assert.That(() => options.FullTableName).Throws<ArgumentException>();
     }

--- a/tests/NetEvolve.Pulse.Tests.Unit/MySql/MySqlOutboxRepositorySqlBuildingTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/MySql/MySqlOutboxRepositorySqlBuildingTests.cs
@@ -1,0 +1,38 @@
+namespace NetEvolve.Pulse.Tests.Unit.MySql;
+
+using System.Reflection;
+using System.Threading.Tasks;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+/// <summary>
+/// Pins the contract of <see cref="MySqlOutboxRepository"/>'s private <c>BuildInParameters</c>
+/// helper: it is a pure string-building function (no I/O), so its output shape is verified
+/// directly via reflection rather than through a live database round-trip.
+/// </summary>
+[TestGroup("MySql")]
+public sealed class MySqlOutboxRepositorySqlBuildingTests
+{
+    private static string BuildInParameters(int count)
+    {
+        var method = typeof(MySqlOutboxRepository).GetMethod(
+            "BuildInParameters",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        return (string)method!.Invoke(null, [count])!;
+    }
+
+    [Test]
+    public async Task BuildInParameters_WithZeroCount_ReturnsEmptyString() =>
+        _ = await Assert.That(BuildInParameters(0)).IsEqualTo(string.Empty);
+
+    [Test]
+    public async Task BuildInParameters_WithOneCount_ReturnsSingleParameter() =>
+        _ = await Assert.That(BuildInParameters(1)).IsEqualTo("@id0");
+
+    [Test]
+    public async Task BuildInParameters_WithMultipleCount_ReturnsCommaSeparatedParameters() =>
+        _ = await Assert.That(BuildInParameters(3)).IsEqualTo("@id0, @id1, @id2");
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/MySql/MySqlOutboxRepositoryTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/MySql/MySqlOutboxRepositoryTests.cs
@@ -63,6 +63,40 @@ public sealed class MySqlOutboxRepositoryTests
             .Throws<ArgumentNullException>();
 
     [Test]
+    public async Task Constructor_WithZeroProcessingLeaseTimeout_ThrowsArgumentOutOfRangeException() =>
+        _ = await Assert
+            .That(() =>
+                new MySqlOutboxRepository(
+                    Options.Create(
+                        new OutboxOptions
+                        {
+                            ConnectionString = ValidConnectionString,
+                            ProcessingLeaseTimeout = TimeSpan.Zero,
+                        }
+                    ),
+                    TimeProvider.System
+                )
+            )
+            .Throws<ArgumentOutOfRangeException>();
+
+    [Test]
+    public async Task Constructor_WithNegativeProcessingLeaseTimeout_ThrowsArgumentOutOfRangeException() =>
+        _ = await Assert
+            .That(() =>
+                new MySqlOutboxRepository(
+                    Options.Create(
+                        new OutboxOptions
+                        {
+                            ConnectionString = ValidConnectionString,
+                            ProcessingLeaseTimeout = TimeSpan.FromSeconds(-1),
+                        }
+                    ),
+                    TimeProvider.System
+                )
+            )
+            .Throws<ArgumentOutOfRangeException>();
+
+    [Test]
     public async Task Constructor_WithValidArguments_CreatesInstance()
     {
         var repository = new MySqlOutboxRepository(

--- a/tests/NetEvolve.Pulse.Tests.Unit/PostgreSql/PostgreSqlIdempotencyKeyRepositoryTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/PostgreSql/PostgreSqlIdempotencyKeyRepositoryTests.cs
@@ -75,4 +75,88 @@ public sealed class PostgreSqlIdempotencyKeyRepositoryTests
 
         _ = await Assert.That(repository).IsNotNull();
     }
+
+    [Test]
+    public async Task ExistsAsync_WithNullIdempotencyKey_ThrowsArgumentException(CancellationToken cancellationToken)
+    {
+        var options = new IdempotencyKeyOptions { ConnectionString = ValidConnectionString };
+        var repository = new PostgreSqlIdempotencyKeyRepository(Options.Create(options));
+
+        _ = await Assert
+            .That(async () =>
+                await repository.ExistsAsync(null!, cancellationToken: cancellationToken).ConfigureAwait(false)
+            )
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task ExistsAsync_WithEmptyIdempotencyKey_ThrowsArgumentException(CancellationToken cancellationToken)
+    {
+        var options = new IdempotencyKeyOptions { ConnectionString = ValidConnectionString };
+        var repository = new PostgreSqlIdempotencyKeyRepository(Options.Create(options));
+
+        _ = await Assert
+            .That(async () =>
+                await repository.ExistsAsync(string.Empty, cancellationToken: cancellationToken).ConfigureAwait(false)
+            )
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task ExistsAsync_WithWhitespaceIdempotencyKey_ThrowsArgumentException(
+        CancellationToken cancellationToken
+    )
+    {
+        var options = new IdempotencyKeyOptions { ConnectionString = ValidConnectionString };
+        var repository = new PostgreSqlIdempotencyKeyRepository(Options.Create(options));
+
+        _ = await Assert
+            .That(async () =>
+                await repository.ExistsAsync("   ", cancellationToken: cancellationToken).ConfigureAwait(false)
+            )
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task StoreAsync_WithNullIdempotencyKey_ThrowsArgumentException(CancellationToken cancellationToken)
+    {
+        var options = new IdempotencyKeyOptions { ConnectionString = ValidConnectionString };
+        var repository = new PostgreSqlIdempotencyKeyRepository(Options.Create(options));
+
+        _ = await Assert
+            .That(async () =>
+                await repository.StoreAsync(null!, DateTimeOffset.UtcNow, cancellationToken).ConfigureAwait(false)
+            )
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task StoreAsync_WithEmptyIdempotencyKey_ThrowsArgumentException(CancellationToken cancellationToken)
+    {
+        var options = new IdempotencyKeyOptions { ConnectionString = ValidConnectionString };
+        var repository = new PostgreSqlIdempotencyKeyRepository(Options.Create(options));
+
+        _ = await Assert
+            .That(async () =>
+                await repository
+                    .StoreAsync(string.Empty, DateTimeOffset.UtcNow, cancellationToken)
+                    .ConfigureAwait(false)
+            )
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task StoreAsync_WithWhitespaceIdempotencyKey_ThrowsArgumentException(
+        CancellationToken cancellationToken
+    )
+    {
+        var options = new IdempotencyKeyOptions { ConnectionString = ValidConnectionString };
+        var repository = new PostgreSqlIdempotencyKeyRepository(Options.Create(options));
+
+        _ = await Assert
+            .That(async () =>
+                await repository.StoreAsync("   ", DateTimeOffset.UtcNow, cancellationToken).ConfigureAwait(false)
+            )
+            .Throws<ArgumentException>();
+    }
 }

--- a/tests/NetEvolve.Pulse.Tests.Unit/PostgreSql/PostgreSqlOutboxRepositoryTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/PostgreSql/PostgreSqlOutboxRepositoryTests.cs
@@ -163,4 +163,62 @@ public sealed class PostgreSqlOutboxRepositoryTests
             .That(async () => await repository.AddAsync(null!, cancellationToken).ConfigureAwait(false))
             .Throws<ArgumentNullException>();
     }
+
+    [Test]
+    public async Task MarkAsCompletedAsync_Batch_WithNullMessageIds_ThrowsArgumentNullException(
+        CancellationToken cancellationToken
+    )
+    {
+        var repository = new PostgreSqlOutboxRepository(
+            Options.Create(new OutboxOptions { ConnectionString = ValidConnectionString }),
+            TimeProvider.System
+        );
+
+        _ = await Assert
+            .That(async () => await repository.MarkAsCompletedAsync(null!, cancellationToken).ConfigureAwait(false))
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task MarkAsCompletedAsync_Batch_WithEmptyMessageIds_CompletesWithoutConnecting(
+        CancellationToken cancellationToken
+    )
+    {
+        var repository = new PostgreSqlOutboxRepository(
+            Options.Create(new OutboxOptions { ConnectionString = ValidConnectionString }),
+            TimeProvider.System
+        );
+
+        await repository.MarkAsCompletedAsync(Array.Empty<Guid>(), cancellationToken).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task MarkAsFailedAsync_Batch_WithNullMessageIds_ThrowsArgumentNullException(
+        CancellationToken cancellationToken
+    )
+    {
+        var repository = new PostgreSqlOutboxRepository(
+            Options.Create(new OutboxOptions { ConnectionString = ValidConnectionString }),
+            TimeProvider.System
+        );
+
+        _ = await Assert
+            .That(async () =>
+                await repository.MarkAsFailedAsync(null!, "error", cancellationToken).ConfigureAwait(false)
+            )
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task MarkAsFailedAsync_Batch_WithEmptyMessageIds_CompletesWithoutConnecting(
+        CancellationToken cancellationToken
+    )
+    {
+        var repository = new PostgreSqlOutboxRepository(
+            Options.Create(new OutboxOptions { ConnectionString = ValidConnectionString }),
+            TimeProvider.System
+        );
+
+        await repository.MarkAsFailedAsync(Array.Empty<Guid>(), "error", cancellationToken).ConfigureAwait(false);
+    }
 }

--- a/tests/NetEvolve.Pulse.Tests.Unit/SqlServer/SqlServerIdempotencyKeyRepositoryTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/SqlServer/SqlServerIdempotencyKeyRepositoryTests.cs
@@ -75,4 +75,115 @@ public sealed class SqlServerIdempotencyKeyRepositoryTests
 
         _ = await Assert.That(repository).IsNotNull();
     }
+
+    // Defense-in-depth: pin that an attacker-controlled Schema value cannot reach the SQL
+    // builder. The constructor must fail fast when Schema contains characters that would
+    // break out of the [bracketed] identifier (e.g. ']' followed by injected SQL).
+    [Test]
+    public async Task Constructor_WithMaliciousSchema_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() =>
+                new SqlServerIdempotencyKeyRepository(
+                    Options.Create(
+                        new IdempotencyKeyOptions
+                        {
+                            ConnectionString = ValidConnectionString,
+                            Schema = "pulse].[evil] -- ",
+                        }
+                    )
+                )
+            )
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task ExistsAsync_WithNullIdempotencyKey_ThrowsArgumentNullException(
+        CancellationToken cancellationToken
+    )
+    {
+        var repository = new SqlServerIdempotencyKeyRepository(
+            Options.Create(new IdempotencyKeyOptions { ConnectionString = ValidConnectionString })
+        );
+
+        _ = await Assert
+            .That(async () =>
+                await repository.ExistsAsync(null!, cancellationToken: cancellationToken).ConfigureAwait(false)
+            )
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task ExistsAsync_WithEmptyIdempotencyKey_ThrowsArgumentException(CancellationToken cancellationToken)
+    {
+        var repository = new SqlServerIdempotencyKeyRepository(
+            Options.Create(new IdempotencyKeyOptions { ConnectionString = ValidConnectionString })
+        );
+
+        _ = await Assert
+            .That(async () =>
+                await repository.ExistsAsync(string.Empty, cancellationToken: cancellationToken).ConfigureAwait(false)
+            )
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task ExistsAsync_WithWhitespaceIdempotencyKey_ThrowsArgumentException(
+        CancellationToken cancellationToken
+    )
+    {
+        var repository = new SqlServerIdempotencyKeyRepository(
+            Options.Create(new IdempotencyKeyOptions { ConnectionString = ValidConnectionString })
+        );
+
+        _ = await Assert
+            .That(async () =>
+                await repository.ExistsAsync("   ", cancellationToken: cancellationToken).ConfigureAwait(false)
+            )
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task StoreAsync_WithNullIdempotencyKey_ThrowsArgumentNullException(CancellationToken cancellationToken)
+    {
+        var repository = new SqlServerIdempotencyKeyRepository(
+            Options.Create(new IdempotencyKeyOptions { ConnectionString = ValidConnectionString })
+        );
+
+        _ = await Assert
+            .That(async () =>
+                await repository.StoreAsync(null!, DateTimeOffset.UtcNow, cancellationToken).ConfigureAwait(false)
+            )
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task StoreAsync_WithEmptyIdempotencyKey_ThrowsArgumentException(CancellationToken cancellationToken)
+    {
+        var repository = new SqlServerIdempotencyKeyRepository(
+            Options.Create(new IdempotencyKeyOptions { ConnectionString = ValidConnectionString })
+        );
+
+        _ = await Assert
+            .That(async () =>
+                await repository
+                    .StoreAsync(string.Empty, DateTimeOffset.UtcNow, cancellationToken)
+                    .ConfigureAwait(false)
+            )
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task StoreAsync_WithWhitespaceIdempotencyKey_ThrowsArgumentException(
+        CancellationToken cancellationToken
+    )
+    {
+        var repository = new SqlServerIdempotencyKeyRepository(
+            Options.Create(new IdempotencyKeyOptions { ConnectionString = ValidConnectionString })
+        );
+
+        _ = await Assert
+            .That(async () =>
+                await repository.StoreAsync("   ", DateTimeOffset.UtcNow, cancellationToken).ConfigureAwait(false)
+            )
+            .Throws<ArgumentException>();
+    }
 }

--- a/tests/NetEvolve.Pulse.Tests.Unit/SqlServer/SqlServerOutboxManagementTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/SqlServer/SqlServerOutboxManagementTests.cs
@@ -142,4 +142,20 @@ public sealed class SqlServerOutboxManagementTests
             .That(async () => await management.GetDeadLetterMessagesAsync(page: -1).ConfigureAwait(false))
             .Throws<ArgumentOutOfRangeException>();
     }
+
+    // Defense-in-depth: pin that an attacker-controlled Schema value cannot reach the SQL
+    // builder. The constructor must fail fast when Schema contains characters that would
+    // break out of the [bracketed] identifier (e.g. ']' followed by injected SQL).
+    [Test]
+    public async Task Constructor_WithMaliciousSchema_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() =>
+                new SqlServerOutboxManagement(
+                    Options.Create(
+                        new OutboxOptions { ConnectionString = ValidConnectionString, Schema = "pulse].[evil] -- " }
+                    ),
+                    TimeProvider.System
+                )
+            )
+            .Throws<ArgumentException>();
 }

--- a/tests/NetEvolve.Pulse.Tests.Unit/SqlServer/SqlServerOutboxRepositoryTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/SqlServer/SqlServerOutboxRepositoryTests.cs
@@ -210,4 +210,94 @@ public sealed class SqlServerOutboxRepositoryTests
 
         _ = await Assert.That(repository).IsNotNull();
     }
+
+    [Test]
+    public async Task MarkAsCompletedAsync_WithNullMessageIds_ThrowsArgumentNullException(
+        CancellationToken cancellationToken
+    )
+    {
+        var repository = new SqlServerOutboxRepository(
+            Options.Create(new OutboxOptions { ConnectionString = ValidConnectionString }),
+            TimeProvider.System
+        );
+
+        _ = await Assert
+            .That(async () => await repository.MarkAsCompletedAsync(null!, cancellationToken).ConfigureAwait(false))
+            .Throws<ArgumentNullException>();
+    }
+
+    // INVARIANT: An empty message-id batch is a no-op that returns before a connection is
+    // opened, so this is genuinely exercisable without a live SQL Server instance.
+    [Test]
+    public async Task MarkAsCompletedAsync_WithEmptyMessageIds_ReturnsWithoutOpeningConnection(
+        CancellationToken cancellationToken
+    )
+    {
+        var repository = new SqlServerOutboxRepository(
+            Options.Create(new OutboxOptions { ConnectionString = ValidConnectionString }),
+            TimeProvider.System
+        );
+
+        await repository.MarkAsCompletedAsync(Array.Empty<Guid>(), cancellationToken).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task MarkAsFailedAsync_WithNullMessageIds_ThrowsArgumentNullException(
+        CancellationToken cancellationToken
+    )
+    {
+        var repository = new SqlServerOutboxRepository(
+            Options.Create(new OutboxOptions { ConnectionString = ValidConnectionString }),
+            TimeProvider.System
+        );
+
+        _ = await Assert
+            .That(async () =>
+                await repository.MarkAsFailedAsync(null!, "boom", cancellationToken).ConfigureAwait(false)
+            )
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task MarkAsFailedAsync_WithEmptyMessageIds_ReturnsWithoutOpeningConnection(
+        CancellationToken cancellationToken
+    )
+    {
+        var repository = new SqlServerOutboxRepository(
+            Options.Create(new OutboxOptions { ConnectionString = ValidConnectionString }),
+            TimeProvider.System
+        );
+
+        await repository.MarkAsFailedAsync(Array.Empty<Guid>(), "boom", cancellationToken).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task MarkAsDeadLetterAsync_WithNullMessageIds_ThrowsArgumentNullException(
+        CancellationToken cancellationToken
+    )
+    {
+        var repository = new SqlServerOutboxRepository(
+            Options.Create(new OutboxOptions { ConnectionString = ValidConnectionString }),
+            TimeProvider.System
+        );
+
+        _ = await Assert
+            .That(async () =>
+                await repository.MarkAsDeadLetterAsync(null!, "boom", cancellationToken).ConfigureAwait(false)
+            )
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task MarkAsDeadLetterAsync_WithEmptyMessageIds_ReturnsWithoutOpeningConnection(
+        CancellationToken cancellationToken
+    )
+    {
+        var repository = new SqlServerOutboxRepository(
+            Options.Create(new OutboxOptions { ConnectionString = ValidConnectionString }),
+            TimeProvider.System
+        );
+
+        await repository.MarkAsDeadLetterAsync(Array.Empty<Guid>(), "boom", cancellationToken).ConfigureAwait(false);
+    }
 }


### PR DESCRIPTION
## Summary

Two production bugs were found while raising per-package Unit/Integration test coverage toward Unit >75%, Integration >80%, Gesamt >90%:

- **`AddConcurrentCommandGuard<TRequest,TResponse>()` / `AddConcurrentCommandGuard<TRequest>()`** used `ServiceDescriptor.Singleton(typeof(ConcurrentCommandGuardInterceptor<,>))`, which resolves to the `Singleton<TService>(TService instance)` overload with `TService` inferred as `System.Type` — registering a singleton `Type` object rather than self-mapping the open generic. Both typed overloads were unresolvable at runtime (`InvalidOperationException`). Fixed to use the two-argument `ServiceDescriptor.Singleton(Type, Type)` overload, and guarded against double-registration when both the open-generic and typed overloads are combined for the same command.
- **`AddCommandInterceptor<TCommand,TResponse,TInterceptor>()` / `AddQueryInterceptor<TQuery,TResponse,TInterceptor>()`** registered under `ICommandInterceptor<,>` / `IQueryInterceptor<,>`, but `PulseMediator` only ever resolves interceptors via `GetServices<IRequestInterceptor<TRequest,TResponse>>()`. Despite `ICommandInterceptor`/`IQueryInterceptor` inheriting `IRequestInterceptor`, .NET DI registration is exact-type — both methods silently registered interceptors that were never invoked. Fixed to register under `IRequestInterceptor<,>`.

## Test coverage additions

- New Integration coverage for the core mediator pipeline previously only unit-tested: event dispatchers (Sequential/Parallel/Prioritized/RateLimited + per-event-type routing), request/event/query interceptors (ActivityAndMetrics, ConcurrentCommandGuard, DataAnnotations, DistributedCache, Timeout, Logging), `CommandBatch`/`MediatorSendOnlyExtensions`, and reflection-based assembly scanning (handlers and interceptors).
- New Integration coverage for `FluentValidation`, `Polly`, `AspNetCore` (real `TestServer` HTTP round-trips), and `HttpCorrelation` — all previously 0% integration-tested despite being fully unit-tested.
- Brand-new Kafka Testcontainers-based integration suite (produce/consume, custom topic resolver, health check, auto-create-topics behavior, `UseKafkaTransport` DI registration).
- Closed remaining coverage gaps in `RabbitMQ`/`AzureQueueStorage` transports (health-check edge cases, double-checked-lock races, registration overloads).
- Targeted Unit test additions for `MongoDB`, `MySql`, `PostgreSql`, `SqlServer` (argument guards, SQL-building helpers) and `CosmosDb` (closed most of its gap — its existing `FakeCosmosContainer` test-double pattern made this tractable, unlike the ADO.NET-based providers).

## Test plan
- [x] `dotnet test tests/NetEvolve.Pulse.Tests.Unit` — 1545 passed (net8.0/net9.0/net10.0), 0 failed
- [x] `dotnet test tests/NetEvolve.Pulse.Tests.Integration -f net10.0` — 522 passed, 0 failed
- [x] Combined coverage: 93.3% line (Gesamt target >90%)