### PR TITLE
feat(rabbitmq): pool RabbitMQ channels in RabbitMqMessageTransport

### DIFF
--- a/src/NetEvolve.Pulse.AzureServiceBus/AzureServiceBusExtensions.cs
+++ b/src/NetEvolve.Pulse.AzureServiceBus/AzureServiceBusExtensions.cs
@@ -32,16 +32,30 @@ public static class AzureServiceBusExtensions
 
         var services = configurator.Services;
 
-        _ = services.AddOptions<AzureServiceBusTransportOptions>();
+        _ = services.AddOptions<AzureServiceBusTransportOptions>().ValidateOnStart();
+
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<
+                IConfigureOptions<AzureServiceBusTransportOptions>,
+                AzureServiceBusTransportOptionsConfiguration
+            >()
+        );
+
         if (configureOptions is not null)
         {
             _ = services.Configure(configureOptions);
         }
 
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<
+                IValidateOptions<AzureServiceBusTransportOptions>,
+                AzureServiceBusTransportOptionsValidator
+            >()
+        );
+
         services.TryAddSingleton(static sp =>
         {
             var options = sp.GetRequiredService<IOptions<AzureServiceBusTransportOptions>>().Value;
-            ValidateOptions(options);
 
             return CreateServiceBusClient(options, sp.GetRequiredService<TokenCredential>());
         });
@@ -70,18 +84,5 @@ public static class AzureServiceBusExtensions
         }
 
         return new ServiceBusClient(options.FullyQualifiedNamespace!, credential);
-    }
-
-    private static void ValidateOptions(AzureServiceBusTransportOptions options)
-    {
-        if (
-            string.IsNullOrWhiteSpace(options.ConnectionString)
-            && string.IsNullOrWhiteSpace(options.FullyQualifiedNamespace)
-        )
-        {
-            throw new InvalidOperationException(
-                "Either a Service Bus connection string or a fully qualified namespace must be provided."
-            );
-        }
     }
 }

--- a/src/NetEvolve.Pulse.AzureServiceBus/NetEvolve.Pulse.AzureServiceBus.csproj
+++ b/src/NetEvolve.Pulse.AzureServiceBus/NetEvolve.Pulse.AzureServiceBus.csproj
@@ -9,6 +9,8 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Messaging.ServiceBus" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>

--- a/src/NetEvolve.Pulse.AzureServiceBus/Outbox/AzureServiceBusTransportOptionsConfiguration.cs
+++ b/src/NetEvolve.Pulse.AzureServiceBus/Outbox/AzureServiceBusTransportOptionsConfiguration.cs
@@ -1,0 +1,24 @@
+﻿namespace NetEvolve.Pulse.Outbox;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Binds <see cref="AzureServiceBusTransportOptions"/> from the <c>Pulse:Transports:AzureServiceBus</c>
+/// configuration section.
+/// </summary>
+internal sealed class AzureServiceBusTransportOptionsConfiguration : IConfigureOptions<AzureServiceBusTransportOptions>
+{
+    private readonly IConfiguration _configuration;
+
+    public AzureServiceBusTransportOptionsConfiguration(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        _configuration = configuration;
+    }
+
+    /// <inheritdoc />
+    public void Configure(AzureServiceBusTransportOptions options) =>
+        _configuration.GetSection("Pulse:Transports:AzureServiceBus").Bind(options);
+}

--- a/src/NetEvolve.Pulse.AzureServiceBus/Outbox/AzureServiceBusTransportOptionsValidator.cs
+++ b/src/NetEvolve.Pulse.AzureServiceBus/Outbox/AzureServiceBusTransportOptionsValidator.cs
@@ -1,0 +1,27 @@
+namespace NetEvolve.Pulse.Outbox;
+
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Validates <see cref="AzureServiceBusTransportOptions"/> ensuring that either
+/// <see cref="AzureServiceBusTransportOptions.ConnectionString"/> or
+/// <see cref="AzureServiceBusTransportOptions.FullyQualifiedNamespace"/> is provided.
+/// </summary>
+internal sealed class AzureServiceBusTransportOptionsValidator : IValidateOptions<AzureServiceBusTransportOptions>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, AzureServiceBusTransportOptions options)
+    {
+        if (
+            string.IsNullOrWhiteSpace(options.ConnectionString)
+            && string.IsNullOrWhiteSpace(options.FullyQualifiedNamespace)
+        )
+        {
+            return ValidateOptionsResult.Fail(
+                $"Either {nameof(AzureServiceBusTransportOptions.ConnectionString)} or {nameof(AzureServiceBusTransportOptions.FullyQualifiedNamespace)} must be provided."
+            );
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/NetEvolve.Pulse.Dapr/DaprExtensions.cs
+++ b/src/NetEvolve.Pulse.Dapr/DaprExtensions.cs
@@ -2,6 +2,8 @@ namespace NetEvolve.Pulse;
 
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 using NetEvolve.Pulse.Extensibility;
 using NetEvolve.Pulse.Extensibility.Outbox;
 using NetEvolve.Pulse.Outbox;
@@ -34,11 +36,26 @@ public static class DaprExtensions
 
         var services = configurator.Services;
 
-        _ = services.AddOptions<DaprMessageTransportOptions>();
+        _ = services.AddOptions<DaprMessageTransportOptions>().ValidateOnStart();
+
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<
+                IConfigureOptions<DaprMessageTransportOptions>,
+                DaprMessageTransportOptionsConfiguration
+            >()
+        );
+
         if (configureOptions is not null)
         {
             _ = services.Configure(configureOptions);
         }
+
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<
+                IValidateOptions<DaprMessageTransportOptions>,
+                DaprMessageTransportOptionsValidator
+            >()
+        );
 
         var existing = services.FirstOrDefault(d => d.ServiceType == typeof(IMessageTransport));
         if (existing is not null)

--- a/src/NetEvolve.Pulse.Dapr/NetEvolve.Pulse.Dapr.csproj
+++ b/src/NetEvolve.Pulse.Dapr/NetEvolve.Pulse.Dapr.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Dapr.Client" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NetEvolve.Pulse.Dapr/OutBox/DaprMessageTransportOptionsConfiguration.cs
+++ b/src/NetEvolve.Pulse.Dapr/OutBox/DaprMessageTransportOptionsConfiguration.cs
@@ -1,0 +1,23 @@
+﻿namespace NetEvolve.Pulse.Outbox;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Binds <see cref="DaprMessageTransportOptions"/> from the <c>Pulse:Transports:Dapr</c> configuration section.
+/// </summary>
+internal sealed class DaprMessageTransportOptionsConfiguration : IConfigureOptions<DaprMessageTransportOptions>
+{
+    private readonly IConfiguration _configuration;
+
+    public DaprMessageTransportOptionsConfiguration(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        _configuration = configuration;
+    }
+
+    /// <inheritdoc />
+    public void Configure(DaprMessageTransportOptions options) =>
+        _configuration.GetSection("Pulse:Transports:Dapr").Bind(options);
+}

--- a/src/NetEvolve.Pulse.Dapr/OutBox/DaprMessageTransportOptionsValidator.cs
+++ b/src/NetEvolve.Pulse.Dapr/OutBox/DaprMessageTransportOptionsValidator.cs
@@ -1,0 +1,23 @@
+namespace NetEvolve.Pulse.Outbox;
+
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Validates <see cref="DaprMessageTransportOptions"/> ensuring that
+/// <see cref="DaprMessageTransportOptions.PubSubName"/> is not empty.
+/// </summary>
+internal sealed class DaprMessageTransportOptionsValidator : IValidateOptions<DaprMessageTransportOptions>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, DaprMessageTransportOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.PubSubName))
+        {
+            return ValidateOptionsResult.Fail(
+                $"{nameof(DaprMessageTransportOptions.PubSubName)} must not be null or empty."
+            );
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/NetEvolve.Pulse.Extensibility/Caching/QueryCachingOptionsConfiguration.cs
+++ b/src/NetEvolve.Pulse.Extensibility/Caching/QueryCachingOptionsConfiguration.cs
@@ -1,0 +1,26 @@
+﻿namespace NetEvolve.Pulse.Extensibility.Caching;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Binds <see cref="QueryCachingOptions"/> from the <c>Pulse:QueryCaching</c> configuration section.
+/// </summary>
+public sealed class QueryCachingOptionsConfiguration : IConfigureOptions<QueryCachingOptions>
+{
+    private readonly IConfiguration _configuration;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QueryCachingOptionsConfiguration"/> class.
+    /// </summary>
+    /// <param name="configuration">The application configuration used to bind <see cref="QueryCachingOptions"/>.</param>
+    public QueryCachingOptionsConfiguration(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        _configuration = configuration;
+    }
+
+    /// <inheritdoc />
+    public void Configure(QueryCachingOptions options) => _configuration.GetSection("Pulse:QueryCaching").Bind(options);
+}

--- a/src/NetEvolve.Pulse.Extensibility/Caching/QueryCachingOptionsValidator.cs
+++ b/src/NetEvolve.Pulse.Extensibility/Caching/QueryCachingOptionsValidator.cs
@@ -1,0 +1,26 @@
+namespace NetEvolve.Pulse.Extensibility.Caching;
+
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Validates <see cref="QueryCachingOptions"/> ensuring that
+/// <see cref="QueryCachingOptions.DefaultExpiry"/> is either <see langword="null"/>
+/// or a positive <see cref="TimeSpan"/>.
+/// </summary>
+public sealed class QueryCachingOptionsValidator : IValidateOptions<QueryCachingOptions>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, QueryCachingOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (options.DefaultExpiry.HasValue && options.DefaultExpiry.Value <= TimeSpan.Zero)
+        {
+            return ValidateOptionsResult.Fail(
+                $"{nameof(QueryCachingOptions.DefaultExpiry)} must be null or greater than {nameof(TimeSpan)}.{nameof(TimeSpan.Zero)}."
+            );
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/NetEvolve.Pulse.Extensibility/NetEvolve.Pulse.Extensibility.csproj
+++ b/src/NetEvolve.Pulse.Extensibility/NetEvolve.Pulse.Extensibility.csproj
@@ -7,6 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 </Project>

--- a/src/NetEvolve.Pulse.RabbitMQ/Internals/IRabbitMqChannelPool.cs
+++ b/src/NetEvolve.Pulse.RabbitMQ/Internals/IRabbitMqChannelPool.cs
@@ -1,0 +1,31 @@
+namespace NetEvolve.Pulse.Internals;
+
+/// <summary>
+/// A pool of RabbitMQ channels used to avoid serializing all publishes through a single
+/// shared, non-thread-safe channel.
+/// </summary>
+internal interface IRabbitMqChannelPool
+{
+    /// <summary>
+    /// Rents a channel from the pool, creating a new one if none are idle. Blocks
+    /// asynchronously until a slot becomes available when the pool is at capacity.
+    /// </summary>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A task representing the asynchronous operation, containing a rented channel adapter.</returns>
+    ValueTask<IRabbitMqChannelAdapter> RentAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Returns a previously rented channel back to the pool. An open channel is kept for
+    /// reuse; a closed channel is disposed instead. Either way, the corresponding rental
+    /// slot is released exactly once.
+    /// </summary>
+    /// <param name="channel">The channel to return.</param>
+    void Return(IRabbitMqChannelAdapter channel);
+
+    /// <summary>
+    /// Checks whether the pool (and the underlying connection it creates channels from) is healthy.
+    /// </summary>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A task representing the asynchronous operation, containing a value indicating whether the pool is healthy.</returns>
+    Task<bool> IsHealthyAsync(CancellationToken cancellationToken);
+}

--- a/src/NetEvolve.Pulse.RabbitMQ/Internals/RabbitMqChannelPool.cs
+++ b/src/NetEvolve.Pulse.RabbitMQ/Internals/RabbitMqChannelPool.cs
@@ -1,0 +1,153 @@
+namespace NetEvolve.Pulse.Internals;
+
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+
+/// <summary>
+/// Default <see cref="IRabbitMqChannelPool"/> implementation backed by a
+/// <see cref="ConcurrentQueue{T}"/> of idle channels and a <see cref="SemaphoreSlim"/>
+/// that caps the number of channels concurrently rented from the pool.
+/// </summary>
+internal sealed class RabbitMqChannelPool : IRabbitMqChannelPool, IDisposable
+{
+    private readonly IRabbitMqConnectionAdapter _connectionAdapter;
+    private readonly ConcurrentQueue<IRabbitMqChannelAdapter> _idleChannels = new();
+
+    /// <summary>
+    /// Caps the number of channels concurrently rented from the pool at
+    /// <c>MaxChannelPoolSize</c>. <see cref="RentAsync"/> waits asynchronously when the
+    /// pool is exhausted.
+    /// </summary>
+    [SuppressMessage(
+        "Usage",
+        "CA2213:Disposable fields should be disposed",
+        Justification = "Disposed explicitly in Dispose(); the analyzer cannot see the guarded field initialization."
+    )]
+    private readonly SemaphoreSlim _rentalGate;
+
+    /// <summary>
+    /// Disposal sentinel handled via <see cref="Interlocked.Exchange(ref int, int)"/> so
+    /// that concurrent <see cref="Dispose"/> calls observe a single winning thread.
+    /// </summary>
+    private int _disposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RabbitMqChannelPool"/> class.
+    /// </summary>
+    /// <param name="connectionAdapter">The RabbitMQ connection adapter used to create new channels.</param>
+    /// <param name="maxChannelPoolSize">The maximum number of channels that may be rented concurrently.</param>
+    public RabbitMqChannelPool(IRabbitMqConnectionAdapter connectionAdapter, int maxChannelPoolSize)
+    {
+        ArgumentNullException.ThrowIfNull(connectionAdapter);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(maxChannelPoolSize, 0);
+
+        _connectionAdapter = connectionAdapter;
+        _rentalGate = new SemaphoreSlim(maxChannelPoolSize, maxChannelPoolSize);
+    }
+
+    /// <inheritdoc />
+    /// <exception cref="ObjectDisposedException">Thrown when the pool has already been disposed.</exception>
+    public async ValueTask<IRabbitMqChannelAdapter> RentAsync(CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+
+        await _rentalGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+
+            while (_idleChannels.TryDequeue(out var candidate))
+            {
+                if (candidate.IsOpen)
+                {
+                    return candidate;
+                }
+
+                // Idle channel closed while waiting in the pool (e.g. broker-side
+                // reset); dispose it and try the next one / create a fresh channel.
+                candidate.Dispose();
+            }
+
+            return await _connectionAdapter.CreateChannelAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Rental slot must always be released exactly once; since Return() will never
+            // be called for a channel that failed to be rented, release it here.
+            _ = _rentalGate.Release();
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    public void Return(IRabbitMqChannelAdapter channel)
+    {
+        ArgumentNullException.ThrowIfNull(channel);
+
+        if (Volatile.Read(ref _disposed) == 0 && channel.IsOpen)
+        {
+            _idleChannels.Enqueue(channel);
+        }
+        else
+        {
+            channel.Dispose();
+        }
+
+        try
+        {
+            _ = _rentalGate.Release();
+        }
+        catch (ObjectDisposedException)
+        {
+            // The pool was disposed while this channel was rented out; the rental slot
+            // no longer matters because the semaphore itself has been torn down.
+        }
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Returns <see langword="false"/> when the pool has been disposed instead of
+    /// throwing, because health probes commonly run during shutdown and should report
+    /// unhealthy rather than fail.
+    /// </remarks>
+    public Task<bool> IsHealthyAsync(CancellationToken cancellationToken)
+    {
+        if (Volatile.Read(ref _disposed) != 0)
+        {
+            return Task.FromResult(false);
+        }
+
+        try
+        {
+            return Task.FromResult(_connectionAdapter.IsOpen);
+        }
+        catch (Exception) when (!cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromResult(false);
+        }
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Disposal is single-shot under concurrency: the first thread to flip
+    /// <c>_disposed</c> via <see cref="Interlocked.Exchange(ref int, int)"/> performs the
+    /// teardown, disposing every idle channel currently queued and then the semaphore
+    /// itself. Channels rented out at the time of disposal are not tracked by the pool and
+    /// are therefore not disposed here; their <see cref="Return"/> call disposes them
+    /// instead (see the closed-channel branch above).
+    /// </remarks>
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        while (_idleChannels.TryDequeue(out var channel))
+        {
+            channel.Dispose();
+        }
+
+        _rentalGate.Dispose();
+    }
+}

--- a/src/NetEvolve.Pulse.RabbitMQ/NetEvolve.Pulse.RabbitMQ.csproj
+++ b/src/NetEvolve.Pulse.RabbitMQ/NetEvolve.Pulse.RabbitMQ.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="RabbitMQ.Client" />
   </ItemGroup>

--- a/src/NetEvolve.Pulse.RabbitMQ/Outbox/RabbitMqMessageTransport.cs
+++ b/src/NetEvolve.Pulse.RabbitMQ/Outbox/RabbitMqMessageTransport.cs
@@ -1,6 +1,5 @@
 namespace NetEvolve.Pulse.Outbox;
 
-using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Threading;
 using Microsoft.Extensions.Options;
@@ -13,15 +12,24 @@ using RabbitMQ.Client;
 /// </summary>
 /// <remarks>
 /// <para><strong>Connection Management:</strong></para>
-/// This transport uses an injected connection adapter and creates channels on demand.
-/// The connection lifetime is managed externally via dependency injection.
+/// This transport uses an injected <see cref="IRabbitMqChannelPool"/> to rent channels on
+/// demand. The connection lifetime is managed externally via dependency injection.
+/// <para><strong>Channel Pooling:</strong></para>
+/// RabbitMQ.Client's <see cref="IChannel"/> is not thread-safe for concurrent publish
+/// calls, so a single shared channel would need to serialize every publish. Instead, each
+/// <see cref="SendAsync"/> call rents its own channel from the pool for the duration of the
+/// publish and returns it afterwards, allowing concurrent sends to run on separate
+/// channels rather than blocking each other. <see cref="SendBatchAsync"/> rents a single
+/// channel for the whole batch and publishes all of its messages sequentially on it -
+/// this keeps the implementation simple (no per-message rent/return churn) while staying
+/// correct, since only the thread executing the batch ever touches that channel.
 /// <para><strong>Routing Key Resolution:</strong></para>
 /// Each message is published with a routing key resolved by <see cref="ITopicNameResolver"/>.
 /// By default, the simple class name of the event type is used (e.g., <c>"OrderCreated"</c>).
 /// <para><strong>Payload:</strong></para>
 /// The raw JSON payload from <see cref="OutboxMessage.Payload"/> is published as the message body.
 /// <para><strong>Health Checks:</strong></para>
-/// The <see cref="IsHealthyAsync"/> method verifies that the connection and channel are open.
+/// The <see cref="IsHealthyAsync"/> method delegates to the channel pool's own health check.
 /// </remarks>
 internal sealed class RabbitMqMessageTransport : IMessageTransport, IDisposable
 {
@@ -31,57 +39,32 @@ internal sealed class RabbitMqMessageTransport : IMessageTransport, IDisposable
     /// <summary>The topic name resolver used to determine the routing key from an outbox message.</summary>
     private readonly ITopicNameResolver _topicNameResolver;
 
-    /// <summary>The RabbitMQ connection adapter.</summary>
-    private readonly IRabbitMqConnectionAdapter _connectionAdapter;
-
-    /// <summary>Lazy-initialized RabbitMQ channel for publishing.</summary>
-    private IRabbitMqChannelAdapter? _channel;
-
-    /// <summary>Semaphore for thread-safe channel initialization.</summary>
-    [SuppressMessage(
-        "Usage",
-        "CA2213:Disposable fields should be disposed",
-        Justification = "The semaphore must outlive Dispose so in-flight senders can still release it; SemaphoreSlim holds no unmanaged resources unless its wait handle is accessed, which this type never does."
-    )]
-    private readonly SemaphoreSlim _initializationLock = new(1, 1);
-
-    /// <summary>
-    /// Semaphore serializing publish calls on the shared channel. RabbitMQ.Client's
-    /// <see cref="IChannel"/> is NOT thread-safe for concurrent publish calls, so every
-    /// publish (single send or batch item) must go through this gate.
-    /// </summary>
-    [SuppressMessage(
-        "Usage",
-        "CA2213:Disposable fields should be disposed",
-        Justification = "The semaphore must outlive Dispose so in-flight senders can still release it; SemaphoreSlim holds no unmanaged resources unless its wait handle is accessed, which this type never does."
-    )]
-    private readonly SemaphoreSlim _publishLock = new(1, 1);
+    /// <summary>The RabbitMQ channel pool channels are rented from and returned to.</summary>
+    private readonly IRabbitMqChannelPool _channelPool;
 
     /// <summary>
     /// Disposal sentinel handled via <see cref="Interlocked.Exchange(ref int, int)"/> so that
-    /// concurrent <see cref="Dispose"/> calls observe a single winning thread. Storing this as a
-    /// plain <c>bool</c> would leave a TOCTOU window between the early-exit check and the
-    /// teardown work, allowing the underlying channel adapter to be disposed twice.
+    /// concurrent <see cref="Dispose"/> calls observe a single winning thread.
     /// </summary>
     private int _disposed;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RabbitMqMessageTransport"/> class.
     /// </summary>
-    /// <param name="connectionAdapter">The RabbitMQ connection adapter.</param>
+    /// <param name="channelPool">The RabbitMQ channel pool used to rent channels for publishing.</param>
     /// <param name="topicNameResolver">The topic name resolver for determining routing keys from outbox messages.</param>
     /// <param name="options">The transport options.</param>
     internal RabbitMqMessageTransport(
-        IRabbitMqConnectionAdapter connectionAdapter,
+        IRabbitMqChannelPool channelPool,
         ITopicNameResolver topicNameResolver,
         IOptions<RabbitMqTransportOptions> options
     )
     {
-        ArgumentNullException.ThrowIfNull(connectionAdapter);
+        ArgumentNullException.ThrowIfNull(channelPool);
         ArgumentNullException.ThrowIfNull(topicNameResolver);
         ArgumentNullException.ThrowIfNull(options);
 
-        _connectionAdapter = connectionAdapter;
+        _channelPool = channelPool;
         _topicNameResolver = topicNameResolver;
         _options = options.Value;
     }
@@ -93,16 +76,23 @@ internal sealed class RabbitMqMessageTransport : IMessageTransport, IDisposable
         ArgumentNullException.ThrowIfNull(message);
         ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
 
-        var channel = await EnsureChannelAsync(cancellationToken).ConfigureAwait(false);
-        await PublishAsync(channel, message, cancellationToken).ConfigureAwait(false);
+        var channel = await _channelPool.RentAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await PublishAsync(channel, message, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _channelPool.Return(channel);
+        }
     }
 
     /// <inheritdoc />
     /// <remarks>
-    /// Overridden to publish all messages sequentially on the same channel. RabbitMQ.Client's
-    /// <see cref="IChannel"/> is NOT thread-safe for concurrent publish calls, so the default
-    /// parallel <c>Parallel.ForEachAsync</c> implementation provided by the interface must not
-    /// be used on this transport.
+    /// Overridden to rent a single channel for the whole batch and publish all messages
+    /// sequentially on it. RabbitMQ.Client's <see cref="IChannel"/> is NOT thread-safe for
+    /// concurrent publish calls, so the default parallel <c>Parallel.ForEachAsync</c>
+    /// implementation provided by the interface must not be used on a single channel.
     /// </remarks>
     /// <exception cref="ObjectDisposedException">Thrown when the transport has already been disposed.</exception>
     public async Task SendBatchAsync(IEnumerable<OutboxMessage> messages, CancellationToken cancellationToken = default)
@@ -110,12 +100,18 @@ internal sealed class RabbitMqMessageTransport : IMessageTransport, IDisposable
         ArgumentNullException.ThrowIfNull(messages);
         ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
 
-        var channel = await EnsureChannelAsync(cancellationToken).ConfigureAwait(false);
-
-        foreach (var message in messages)
+        var channel = await _channelPool.RentAsync(cancellationToken).ConfigureAwait(false);
+        try
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            await PublishAsync(channel, message, cancellationToken).ConfigureAwait(false);
+            foreach (var message in messages)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await PublishAsync(channel, message, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            _channelPool.Return(channel);
         }
     }
 
@@ -147,24 +143,16 @@ internal sealed class RabbitMqMessageTransport : IMessageTransport, IDisposable
             },
         };
 
-        await _publishLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
-        {
-            await channel
-                .BasicPublishAsync(
-                    exchange: _options.ExchangeName,
-                    routingKey: routingKey,
-                    mandatory: false,
-                    basicProperties: properties,
-                    body: body,
-                    cancellationToken: cancellationToken
-                )
-                .ConfigureAwait(false);
-        }
-        finally
-        {
-            _ = _publishLock.Release();
-        }
+        await channel
+            .BasicPublishAsync(
+                exchange: _options.ExchangeName,
+                routingKey: routingKey,
+                mandatory: false,
+                basicProperties: properties,
+                body: body,
+                cancellationToken: cancellationToken
+            )
+            .ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -181,54 +169,11 @@ internal sealed class RabbitMqMessageTransport : IMessageTransport, IDisposable
 
         try
         {
-            if (_connectionAdapter?.IsOpen != true || _channel?.IsOpen != true)
-            {
-                return Task.FromResult(false);
-            }
-
-            // Perform a lightweight check by verifying channel is still open
-            // RabbitMQ client maintains the connection state internally
-            return Task.FromResult(_channel.IsOpen);
+            return _channelPool.IsHealthyAsync(cancellationToken);
         }
         catch (Exception) when (!cancellationToken.IsCancellationRequested)
         {
             return Task.FromResult(false);
-        }
-    }
-
-    /// <summary>
-    /// Ensures that a channel is available, creating it if necessary.
-    /// </summary>
-    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
-    /// <returns>The initialized channel.</returns>
-    private async Task<IRabbitMqChannelAdapter> EnsureChannelAsync(CancellationToken cancellationToken)
-    {
-        if (_channel?.IsOpen == true)
-        {
-            return _channel;
-        }
-
-        await _initializationLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
-        {
-            ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
-
-            if (_channel?.IsOpen == true)
-            {
-                return _channel;
-            }
-
-            // Dispose previously-acquired (now closed) channel to avoid leaking the
-            // underlying RabbitMQ.Client IChannel handle before replacing the reference.
-            _channel?.Dispose();
-
-            _channel = await _connectionAdapter.CreateChannelAsync(cancellationToken).ConfigureAwait(false);
-
-            return _channel;
-        }
-        finally
-        {
-            _ = _initializationLock.Release();
         }
     }
 
@@ -243,30 +188,10 @@ internal sealed class RabbitMqMessageTransport : IMessageTransport, IDisposable
     /// <remarks>
     /// Disposal is single-shot under concurrency: the first thread to flip <c>_disposed</c> via
     /// <see cref="Interlocked.Exchange(ref int, int)"/> performs the teardown; all subsequent
-    /// callers (including concurrent ones) are no-ops. This prevents double-disposal of the
-    /// underlying channel adapter when shutdown overlaps with another <c>Dispose()</c> call.
-    /// The teardown acquires <see cref="_initializationLock"/> so that a channel created by an
-    /// in-flight <see cref="EnsureChannelAsync"/> is disposed rather than leaked, and the
-    /// semaphore itself is intentionally never disposed because in-flight senders may still
-    /// need to release it; <see cref="SemaphoreSlim"/> holds no unmanaged resources unless
-    /// its wait handle is accessed, which this type never does.
+    /// callers (including concurrent ones) are no-ops. The transport itself no longer owns any
+    /// channel: the pool is registered and disposed as part of the DI container's lifetime, so
+    /// there is nothing further to release here beyond flipping the sentinel so that in-flight
+    /// and subsequent calls observe <see cref="ObjectDisposedException"/> / a false health check.
     /// </remarks>
-    public void Dispose()
-    {
-        if (Interlocked.Exchange(ref _disposed, 1) != 0)
-        {
-            return;
-        }
-
-        _initializationLock.Wait();
-        try
-        {
-            _channel?.Dispose();
-            _channel = null;
-        }
-        finally
-        {
-            _ = _initializationLock.Release();
-        }
-    }
+    public void Dispose() => _ = Interlocked.Exchange(ref _disposed, 1);
 }

--- a/src/NetEvolve.Pulse.RabbitMQ/Outbox/RabbitMqTransportOptions.cs
+++ b/src/NetEvolve.Pulse.RabbitMQ/Outbox/RabbitMqTransportOptions.cs
@@ -13,4 +13,17 @@ public sealed class RabbitMqTransportOptions
     /// The exchange must already exist; it will not be auto-declared.
     /// </remarks>
     public string ExchangeName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the maximum number of RabbitMQ channels that may be concurrently
+    /// rented from the transport's channel pool.
+    /// </summary>
+    /// <remarks>
+    /// Concurrent <see cref="RabbitMqMessageTransport.SendAsync"/> and
+    /// <see cref="RabbitMqMessageTransport.SendBatchAsync"/> calls each rent their own
+    /// channel from the pool instead of sharing (and serializing on) a single channel.
+    /// This value caps how many channels may be rented at the same time; additional
+    /// callers wait asynchronously for a channel to become available.
+    /// </remarks>
+    public int MaxChannelPoolSize { get; set; } = 10;
 }

--- a/src/NetEvolve.Pulse.RabbitMQ/Outbox/RabbitMqTransportOptionsConfiguration.cs
+++ b/src/NetEvolve.Pulse.RabbitMQ/Outbox/RabbitMqTransportOptionsConfiguration.cs
@@ -1,0 +1,23 @@
+namespace NetEvolve.Pulse.Outbox;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Binds <see cref="RabbitMqTransportOptions"/> from the <c>Pulse:Transports:RabbitMq</c> configuration section.
+/// </summary>
+internal sealed class RabbitMqTransportOptionsConfiguration : IConfigureOptions<RabbitMqTransportOptions>
+{
+    private readonly IConfiguration _configuration;
+
+    public RabbitMqTransportOptionsConfiguration(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        _configuration = configuration;
+    }
+
+    /// <inheritdoc />
+    public void Configure(RabbitMqTransportOptions options) =>
+        _configuration.GetSection("Pulse:Transports:RabbitMq").Bind(options);
+}

--- a/src/NetEvolve.Pulse.RabbitMQ/Outbox/RabbitMqTransportOptionsValidator.cs
+++ b/src/NetEvolve.Pulse.RabbitMQ/Outbox/RabbitMqTransportOptionsValidator.cs
@@ -1,0 +1,29 @@
+namespace NetEvolve.Pulse.Outbox;
+
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Validates <see cref="RabbitMqTransportOptions"/> ensuring that
+/// <see cref="RabbitMqTransportOptions.ExchangeName"/> is not empty and
+/// <see cref="RabbitMqTransportOptions.MaxChannelPoolSize"/> is at least 1.
+/// </summary>
+internal sealed class RabbitMqTransportOptionsValidator : IValidateOptions<RabbitMqTransportOptions>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, RabbitMqTransportOptions options)
+    {
+        var failures = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(options.ExchangeName))
+        {
+            failures.Add($"{nameof(RabbitMqTransportOptions.ExchangeName)} must not be null or empty.");
+        }
+
+        if (options.MaxChannelPoolSize < 1)
+        {
+            failures.Add($"{nameof(RabbitMqTransportOptions.MaxChannelPoolSize)} must be greater than or equal to 1.");
+        }
+
+        return failures.Count == 0 ? ValidateOptionsResult.Success : ValidateOptionsResult.Fail(failures);
+    }
+}

--- a/src/NetEvolve.Pulse.RabbitMQ/RabbitMqExtensions.cs
+++ b/src/NetEvolve.Pulse.RabbitMQ/RabbitMqExtensions.cs
@@ -2,6 +2,8 @@ namespace NetEvolve.Pulse;
 
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 using NetEvolve.Pulse.Extensibility;
 using NetEvolve.Pulse.Extensibility.Outbox;
 using NetEvolve.Pulse.Internals;
@@ -48,6 +50,15 @@ public static class RabbitMqExtensions
         {
             var connection = sp.GetRequiredService<IConnection>();
             return new RabbitMqConnectionAdapter(connection);
+        });
+
+        // Register the channel pool. TryAddSingleton avoids duplicate registrations when
+        // UseRabbitMqTransport is called more than once.
+        services.TryAddSingleton<IRabbitMqChannelPool>(sp =>
+        {
+            var connectionAdapter = sp.GetRequiredService<IRabbitMqConnectionAdapter>();
+            var poolOptions = sp.GetRequiredService<IOptions<RabbitMqTransportOptions>>();
+            return new RabbitMqChannelPool(connectionAdapter, poolOptions.Value.MaxChannelPoolSize);
         });
 
         var existing = services.FirstOrDefault(d => d.ServiceType == typeof(IMessageTransport));

--- a/src/NetEvolve.Pulse.RabbitMQ/RabbitMqExtensions.cs
+++ b/src/NetEvolve.Pulse.RabbitMQ/RabbitMqExtensions.cs
@@ -39,11 +39,23 @@ public static class RabbitMqExtensions
 
         var services = configurator.Services;
 
-        _ = services.AddOptions<RabbitMqTransportOptions>();
+        _ = services.AddOptions<RabbitMqTransportOptions>().ValidateOnStart();
+
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<
+                IConfigureOptions<RabbitMqTransportOptions>,
+                RabbitMqTransportOptionsConfiguration
+            >()
+        );
+
         if (configureOptions is not null)
         {
             _ = services.Configure(configureOptions);
         }
+
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IValidateOptions<RabbitMqTransportOptions>, RabbitMqTransportOptionsValidator>()
+        );
 
         // Register the connection adapter
         _ = services.AddSingleton<IRabbitMqConnectionAdapter>(sp =>

--- a/src/NetEvolve.Pulse/Interceptors/LoggingInterceptorOptionsConfiguration.cs
+++ b/src/NetEvolve.Pulse/Interceptors/LoggingInterceptorOptionsConfiguration.cs
@@ -1,0 +1,23 @@
+namespace NetEvolve.Pulse.Interceptors;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Binds <see cref="LoggingInterceptorOptions"/> from the <c>Pulse:Logging</c> configuration section.
+/// </summary>
+internal sealed class LoggingInterceptorOptionsConfiguration : IConfigureOptions<LoggingInterceptorOptions>
+{
+    private readonly IConfiguration _configuration;
+
+    public LoggingInterceptorOptionsConfiguration(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        _configuration = configuration;
+    }
+
+    /// <inheritdoc />
+    public void Configure(LoggingInterceptorOptions options) =>
+        _configuration.GetSection("Pulse:Logging").Bind(options);
+}

--- a/src/NetEvolve.Pulse/Interceptors/TimeoutRequestInterceptorOptionsConfiguration.cs
+++ b/src/NetEvolve.Pulse/Interceptors/TimeoutRequestInterceptorOptionsConfiguration.cs
@@ -1,0 +1,24 @@
+namespace NetEvolve.Pulse.Interceptors;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Binds <see cref="TimeoutRequestInterceptorOptions"/> from the <c>Pulse:Timeout</c> configuration section.
+/// </summary>
+internal sealed class TimeoutRequestInterceptorOptionsConfiguration
+    : IConfigureOptions<TimeoutRequestInterceptorOptions>
+{
+    private readonly IConfiguration _configuration;
+
+    public TimeoutRequestInterceptorOptionsConfiguration(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        _configuration = configuration;
+    }
+
+    /// <inheritdoc />
+    public void Configure(TimeoutRequestInterceptorOptions options) =>
+        _configuration.GetSection("Pulse:Timeout").Bind(options);
+}

--- a/src/NetEvolve.Pulse/Interceptors/TimeoutRequestInterceptorOptionsValidator.cs
+++ b/src/NetEvolve.Pulse/Interceptors/TimeoutRequestInterceptorOptionsValidator.cs
@@ -1,0 +1,24 @@
+namespace NetEvolve.Pulse.Interceptors;
+
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Validates <see cref="TimeoutRequestInterceptorOptions"/> ensuring that
+/// <see cref="TimeoutRequestInterceptorOptions.GlobalTimeout"/> is either <see langword="null"/>
+/// or a positive <see cref="TimeSpan"/>.
+/// </summary>
+internal sealed class TimeoutRequestInterceptorOptionsValidator : IValidateOptions<TimeoutRequestInterceptorOptions>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, TimeoutRequestInterceptorOptions options)
+    {
+        if (options.GlobalTimeout.HasValue && options.GlobalTimeout.Value <= TimeSpan.Zero)
+        {
+            return ValidateOptionsResult.Fail(
+                $"{nameof(TimeoutRequestInterceptorOptions.GlobalTimeout)} must be null or greater than {nameof(TimeSpan)}.{nameof(TimeSpan.Zero)}."
+            );
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/NetEvolve.Pulse/LoggingExtensions.cs
+++ b/src/NetEvolve.Pulse/LoggingExtensions.cs
@@ -57,6 +57,13 @@ public static class LoggingExtensions
 
         _ = configurator.Services.AddOptions<LoggingInterceptorOptions>();
 
+        configurator.Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<
+                IConfigureOptions<LoggingInterceptorOptions>,
+                LoggingInterceptorOptionsConfiguration
+            >()
+        );
+
         if (configure is not null)
         {
             _ = configurator.Services.Configure(configure);

--- a/src/NetEvolve.Pulse/Outbox/OutboxOptionsConfiguration.cs
+++ b/src/NetEvolve.Pulse/Outbox/OutboxOptionsConfiguration.cs
@@ -1,0 +1,22 @@
+﻿namespace NetEvolve.Pulse.Outbox;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Binds <see cref="OutboxOptions"/> from the <c>Pulse:Outbox</c> configuration section.
+/// </summary>
+internal sealed class OutboxOptionsConfiguration : IConfigureOptions<OutboxOptions>
+{
+    private readonly IConfiguration _configuration;
+
+    public OutboxOptionsConfiguration(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        _configuration = configuration;
+    }
+
+    /// <inheritdoc />
+    public void Configure(OutboxOptions options) => _configuration.GetSection("Pulse:Outbox").Bind(options);
+}

--- a/src/NetEvolve.Pulse/Outbox/OutboxOptionsValidator.cs
+++ b/src/NetEvolve.Pulse/Outbox/OutboxOptionsValidator.cs
@@ -1,0 +1,29 @@
+namespace NetEvolve.Pulse.Outbox;
+
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Validates <see cref="OutboxOptions"/> ensuring that
+/// <see cref="OutboxOptions.TableName"/> is not <see langword="null"/>, empty, or whitespace.
+/// </summary>
+/// <remarks>
+/// <see cref="OutboxOptions.ConnectionString"/> is intentionally not validated here: it is required
+/// only by ADO.NET-based providers (e.g., PostgreSQL, SQL Server, SQLite) and legitimately remains
+/// <see langword="null"/> for Entity Framework Core-based outbox usage, which resolves its connection
+/// through a registered <c>DbContext</c> instead.
+/// </remarks>
+internal sealed class OutboxOptionsValidator : IValidateOptions<OutboxOptions>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, OutboxOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.TableName))
+        {
+            return ValidateOptionsResult.Fail(
+                $"{nameof(OutboxOptions.TableName)} must not be null, empty, or whitespace."
+            );
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/NetEvolve.Pulse/Outbox/OutboxProcessorOptionsConfiguration.cs
+++ b/src/NetEvolve.Pulse/Outbox/OutboxProcessorOptionsConfiguration.cs
@@ -1,0 +1,23 @@
+﻿namespace NetEvolve.Pulse.Outbox;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Binds <see cref="OutboxProcessorOptions"/> from the <c>Pulse:OutboxProcessor</c> configuration section.
+/// </summary>
+internal sealed class OutboxProcessorOptionsConfiguration : IConfigureOptions<OutboxProcessorOptions>
+{
+    private readonly IConfiguration _configuration;
+
+    public OutboxProcessorOptionsConfiguration(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        _configuration = configuration;
+    }
+
+    /// <inheritdoc />
+    public void Configure(OutboxProcessorOptions options) =>
+        _configuration.GetSection("Pulse:OutboxProcessor").Bind(options);
+}

--- a/src/NetEvolve.Pulse/Outbox/OutboxProcessorOptionsValidator.cs
+++ b/src/NetEvolve.Pulse/Outbox/OutboxProcessorOptionsValidator.cs
@@ -1,0 +1,66 @@
+namespace NetEvolve.Pulse.Outbox;
+
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Validates <see cref="OutboxProcessorOptions"/> ensuring all configured values are within
+/// valid, self-consistent ranges.
+/// </summary>
+internal sealed class OutboxProcessorOptionsValidator : IValidateOptions<OutboxProcessorOptions>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, OutboxProcessorOptions options)
+    {
+        var failures = new List<string>();
+
+        if (options.BatchSize <= 0)
+        {
+            failures.Add($"{nameof(OutboxProcessorOptions.BatchSize)} must be greater than 0.");
+        }
+
+        if (options.PollingInterval <= TimeSpan.Zero)
+        {
+            failures.Add(
+                $"{nameof(OutboxProcessorOptions.PollingInterval)} must be greater than {nameof(TimeSpan)}.{nameof(TimeSpan.Zero)}."
+            );
+        }
+
+        if (options.MaxRetryCount < 0)
+        {
+            failures.Add($"{nameof(OutboxProcessorOptions.MaxRetryCount)} must be greater than or equal to 0.");
+        }
+
+        if (options.ProcessingTimeout <= TimeSpan.Zero)
+        {
+            failures.Add(
+                $"{nameof(OutboxProcessorOptions.ProcessingTimeout)} must be greater than {nameof(TimeSpan)}.{nameof(TimeSpan.Zero)}."
+            );
+        }
+
+        if (options.EnableExponentialBackoff)
+        {
+            if (options.BackoffMultiplier <= 1.0)
+            {
+                failures.Add(
+                    $"{nameof(OutboxProcessorOptions.BackoffMultiplier)} must be greater than 1.0 when {nameof(OutboxProcessorOptions.EnableExponentialBackoff)} is enabled."
+                );
+            }
+
+            if (options.BaseRetryDelay <= TimeSpan.Zero)
+            {
+                failures.Add(
+                    $"{nameof(OutboxProcessorOptions.BaseRetryDelay)} must be greater than {nameof(TimeSpan)}.{nameof(TimeSpan.Zero)} when {nameof(OutboxProcessorOptions.EnableExponentialBackoff)} is enabled."
+                );
+            }
+
+            if (options.MaxRetryDelay < options.BaseRetryDelay)
+            {
+                failures.Add(
+                    $"{nameof(OutboxProcessorOptions.MaxRetryDelay)} must be greater than or equal to {nameof(OutboxProcessorOptions.BaseRetryDelay)} when {nameof(OutboxProcessorOptions.EnableExponentialBackoff)} is enabled."
+                );
+            }
+        }
+
+        return failures.Count == 0 ? ValidateOptionsResult.Success : ValidateOptionsResult.Fail(failures);
+    }
+}

--- a/src/NetEvolve.Pulse/OutboxExtensions.cs
+++ b/src/NetEvolve.Pulse/OutboxExtensions.cs
@@ -3,6 +3,7 @@ namespace NetEvolve.Pulse;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using NetEvolve.Pulse.Extensibility;
 using NetEvolve.Pulse.Extensibility.Outbox;
 using NetEvolve.Pulse.Outbox;
@@ -48,17 +49,38 @@ public static class OutboxExtensions
 
         // Register options using the Options pattern for configurability
         // Always use Configure() to allow subsequent calls to modify options
-        _ = services.AddOptions<OutboxOptions>();
+        _ = services.AddOptions<OutboxOptions>().ValidateOnStart();
+
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IConfigureOptions<OutboxOptions>, OutboxOptionsConfiguration>()
+        );
+
         if (configureOptions is not null)
         {
             _ = services.Configure(configureOptions);
         }
 
-        _ = services.AddOptions<OutboxProcessorOptions>();
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IValidateOptions<OutboxOptions>, OutboxOptionsValidator>()
+        );
+
+        _ = services.AddOptions<OutboxProcessorOptions>().ValidateOnStart();
+
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<
+                IConfigureOptions<OutboxProcessorOptions>,
+                OutboxProcessorOptionsConfiguration
+            >()
+        );
+
         if (configureProcessorOptions is not null)
         {
             _ = services.Configure(configureProcessorOptions);
         }
+
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IValidateOptions<OutboxProcessorOptions>, OutboxProcessorOptionsValidator>()
+        );
 
         // Register TimeProvider if not already registered
         services.TryAddSingleton(TimeProvider.System);

--- a/src/NetEvolve.Pulse/QueryCachingExtensions.cs
+++ b/src/NetEvolve.Pulse/QueryCachingExtensions.cs
@@ -3,6 +3,7 @@ namespace NetEvolve.Pulse;
 using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 using NetEvolve.Pulse.Extensibility;
 using NetEvolve.Pulse.Extensibility.Caching;
 using NetEvolve.Pulse.Interceptors;
@@ -34,11 +35,20 @@ public static class QueryCachingExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        _ = builder.Services.AddOptions<QueryCachingOptions>();
+        _ = builder.Services.AddOptions<QueryCachingOptions>().ValidateOnStart();
+
+        builder.Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IConfigureOptions<QueryCachingOptions>, QueryCachingOptionsConfiguration>()
+        );
+
         if (configure is not null)
         {
             _ = builder.Services.Configure(configure);
         }
+
+        builder.Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IValidateOptions<QueryCachingOptions>, QueryCachingOptionsValidator>()
+        );
 
         builder.Services.TryAddEnumerable(
             ServiceDescriptor.Scoped(typeof(IRequestInterceptor<,>), typeof(DistributedCacheQueryInterceptor<,>))

--- a/src/NetEvolve.Pulse/TimeoutExtensions.cs
+++ b/src/NetEvolve.Pulse/TimeoutExtensions.cs
@@ -3,6 +3,7 @@ namespace NetEvolve.Pulse;
 using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 using NetEvolve.Pulse.Extensibility;
 using NetEvolve.Pulse.Interceptors;
 
@@ -57,8 +58,27 @@ public static class TimeoutExtensions
     {
         ArgumentNullException.ThrowIfNull(configurator);
 
-        _ = configurator.Services.Configure<TimeoutRequestInterceptorOptions>(opts =>
-            opts.GlobalTimeout = globalTimeout
+        _ = configurator.Services.AddOptions<TimeoutRequestInterceptorOptions>().ValidateOnStart();
+
+        configurator.Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<
+                IConfigureOptions<TimeoutRequestInterceptorOptions>,
+                TimeoutRequestInterceptorOptionsConfiguration
+            >()
+        );
+
+        if (globalTimeout is not null)
+        {
+            _ = configurator.Services.Configure<TimeoutRequestInterceptorOptions>(opts =>
+                opts.GlobalTimeout = globalTimeout
+            );
+        }
+
+        configurator.Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<
+                IValidateOptions<TimeoutRequestInterceptorOptions>,
+                TimeoutRequestInterceptorOptionsValidator
+            >()
         );
 
         configurator.Services.TryAddEnumerable(

--- a/tests/NetEvolve.Pulse.Tests.Integration/RabbitMQ/RabbitMqMessageTransportIntegrationTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/RabbitMQ/RabbitMqMessageTransportIntegrationTests.cs
@@ -27,6 +27,7 @@ public sealed class RabbitMqMessageTransportIntegrationTests(RabbitMqContainerFi
 
     private IConnection? _connection;
     private IChannel? _adminChannel;
+    private RabbitMqChannelPool? _channelPool;
 
     private async Task<(IConnection Connection, IChannel AdminChannel)> GetConnectionAndChannelAsync(
         CancellationToken cancellationToken
@@ -58,6 +59,8 @@ public sealed class RabbitMqMessageTransportIntegrationTests(RabbitMqContainerFi
     /// <inheritdoc />
     public async ValueTask DisposeAsync()
     {
+        _channelPool?.Dispose();
+
         if (_adminChannel is not null)
         {
             await _adminChannel.CloseAsync().ConfigureAwait(false);
@@ -159,17 +162,21 @@ public sealed class RabbitMqMessageTransportIntegrationTests(RabbitMqContainerFi
     }
 
     [Test]
-    public async Task IsHealthyAsync_Before_first_send_returns_false(CancellationToken cancellationToken)
+    public async Task IsHealthyAsync_Before_first_send_returns_true_when_connection_open(
+        CancellationToken cancellationToken
+    )
     {
         var (connection, _) = await GetConnectionAndChannelAsync(cancellationToken).ConfigureAwait(false);
 
         var adapter = new RabbitMqConnectionAdapter(connection);
         using var transport = CreateTransport(adapter);
 
-        // No sends yet — channel has not been created
+        // No sends yet — no channel has been rented from the pool. Health now reflects the
+        // underlying connection/pool state rather than the existence of a particular channel,
+        // so this must report healthy as long as the connection is open.
         var healthy = await transport.IsHealthyAsync(cancellationToken).ConfigureAwait(false);
 
-        _ = await Assert.That(healthy).IsFalse();
+        _ = await Assert.That(healthy).IsTrue();
     }
 
     [Test]
@@ -330,12 +337,19 @@ public sealed class RabbitMqMessageTransportIntegrationTests(RabbitMqContainerFi
         }
     }
 
-    private static RabbitMqMessageTransport CreateTransport(IRabbitMqConnectionAdapter adapter) =>
-        new(
-            adapter,
+    // The channel pool is created lazily and shared across the tests in this fixture (they
+    // all operate against the same underlying connection) and is disposed together with the
+    // connection in DisposeAsync.
+    private RabbitMqMessageTransport CreateTransport(IRabbitMqConnectionAdapter adapter)
+    {
+        _channelPool ??= new RabbitMqChannelPool(adapter, new RabbitMqTransportOptions().MaxChannelPoolSize);
+
+        return new RabbitMqMessageTransport(
+            _channelPool,
             new SimpleTopicNameResolver(),
             Options.Create(new RabbitMqTransportOptions { ExchangeName = ExchangeName })
         );
+    }
 
     private static OutboxMessage CreateOutboxMessage() =>
         new()

--- a/tests/NetEvolve.Pulse.Tests.Integration/RabbitMQ/RabbitMqMessageTransportIntegrationTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/RabbitMQ/RabbitMqMessageTransportIntegrationTests.cs
@@ -3,6 +3,7 @@ namespace NetEvolve.Pulse.Tests.Integration.RabbitMQ;
 using System.Text;
 using global::RabbitMQ.Client;
 using global::RabbitMQ.Client.Events;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
@@ -299,6 +300,7 @@ public sealed class RabbitMqMessageTransportIntegrationTests(RabbitMqContainerFi
 
         var services = new ServiceCollection();
         _ = services.AddSingleton(connection);
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config => config.UseRabbitMqTransport(o => o.ExchangeName = ExchangeName));
 
         var provider = services.BuildServiceProvider();

--- a/tests/NetEvolve.Pulse.Tests.Unit/AzureServiceBus/AzureServiceBusExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/AzureServiceBus/AzureServiceBusExtensionsTests.cs
@@ -3,6 +3,7 @@
 using Azure.Core;
 using Azure.Identity;
 using Azure.Messaging.ServiceBus;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.Pulse;
@@ -64,12 +65,18 @@ public sealed class AzureServiceBusExtensionsTests
     public async Task UseAzureServiceBusTransport_validates_required_options()
     {
         IServiceCollection services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config => config.UseAzureServiceBusTransport());
 
         var provider = services.BuildServiceProvider();
         await using (provider.ConfigureAwait(false))
         {
-            _ = Assert.Throws<InvalidOperationException>(() => provider.GetRequiredService<ServiceBusClient>());
+            // Validation now runs through IValidateOptions<AzureServiceBusTransportOptions>, which
+            // Microsoft.Extensions.Options surfaces as an OptionsValidationException whenever the
+            // options are resolved (not just at ValidateOnStart's eager startup check).
+            _ = Assert.Throws<Microsoft.Extensions.Options.OptionsValidationException>(() =>
+                provider.GetRequiredService<ServiceBusClient>()
+            );
         }
     }
 
@@ -77,6 +84,7 @@ public sealed class AzureServiceBusExtensionsTests
     public async Task UseAzureServiceBusTransport_with_fully_qualified_namespace_creates_ServiceBusClient()
     {
         IServiceCollection services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
 
         // Register a fake credential so we don't depend on DefaultAzureCredential
         _ = services.AddSingleton<TokenCredential>(new FakeTokenCredential());
@@ -100,6 +108,7 @@ public sealed class AzureServiceBusExtensionsTests
     public async Task UseAzureServiceBusTransport_with_connection_string_creates_ServiceBusClient()
     {
         IServiceCollection services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config =>
             config.UseAzureServiceBusTransport(options => options.ConnectionString = FakeConnectionString)
         );

--- a/tests/NetEvolve.Pulse.Tests.Unit/AzureServiceBus/AzureServiceBusTransportOptionsConfigurationTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/AzureServiceBus/AzureServiceBusTransportOptionsConfigurationTests.cs
@@ -1,0 +1,58 @@
+namespace NetEvolve.Pulse.Tests.Unit.AzureServiceBus;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("AzureServiceBus")]
+public class AzureServiceBusTransportOptionsConfigurationTests
+{
+    [Test]
+    public async Task Configure_WithPopulatedSection_BindsAllProperties()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["Pulse:Transports:AzureServiceBus:ConnectionString"] = "Endpoint=sb://test/",
+                    ["Pulse:Transports:AzureServiceBus:FullyQualifiedNamespace"] = "contoso.servicebus.windows.net",
+                    ["Pulse:Transports:AzureServiceBus:EnableBatching"] = "false",
+                }
+            )
+            .Build();
+
+        var configurator = new AzureServiceBusTransportOptionsConfiguration(configuration);
+        var options = new AzureServiceBusTransportOptions();
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.ConnectionString).IsEqualTo("Endpoint=sb://test/");
+        _ = await Assert.That(options.FullyQualifiedNamespace).IsEqualTo("contoso.servicebus.windows.net");
+        _ = await Assert.That(options.EnableBatching).IsFalse();
+    }
+
+    [Test]
+    public async Task Configure_WithoutSection_LeavesDefaultsUnchanged()
+    {
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection([]).Build();
+
+        var configurator = new AzureServiceBusTransportOptionsConfiguration(configuration);
+        var options = new AzureServiceBusTransportOptions();
+        var defaultConnectionString = options.ConnectionString;
+        var defaultNamespace = options.FullyQualifiedNamespace;
+        var defaultBatching = options.EnableBatching;
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.ConnectionString).IsEqualTo(defaultConnectionString);
+        _ = await Assert.That(options.FullyQualifiedNamespace).IsEqualTo(defaultNamespace);
+        _ = await Assert.That(options.EnableBatching).IsEqualTo(defaultBatching);
+    }
+
+    [Test]
+    public void Constructor_WithNullConfiguration_ThrowsArgumentNullException() =>
+        _ = Assert.Throws<ArgumentNullException>(() => _ = new AzureServiceBusTransportOptionsConfiguration(null!));
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/AzureServiceBus/AzureServiceBusTransportOptionsValidatorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/AzureServiceBus/AzureServiceBusTransportOptionsValidatorTests.cs
@@ -1,0 +1,55 @@
+namespace NetEvolve.Pulse.Tests.Unit.AzureServiceBus;
+
+using System.Threading.Tasks;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("AzureServiceBus")]
+public class AzureServiceBusTransportOptionsValidatorTests
+{
+    private static readonly AzureServiceBusTransportOptionsValidator _validator = new();
+
+    [Test]
+    public async Task Validate_WithConnectionString_Succeeds()
+    {
+        var options = new AzureServiceBusTransportOptions { ConnectionString = "Endpoint=sb://localhost/" };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithFullyQualifiedNamespace_Succeeds()
+    {
+        var options = new AzureServiceBusTransportOptions
+        {
+            FullyQualifiedNamespace = "contoso.servicebus.windows.net",
+        };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithNeitherConnectionStringNorNamespace_Fails()
+    {
+        var options = new AzureServiceBusTransportOptions();
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithWhitespaceValues_Fails()
+    {
+        var options = new AzureServiceBusTransportOptions { ConnectionString = "   ", FullyQualifiedNamespace = "   " };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/Dapr/DaprExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Dapr/DaprExtensionsTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.Pulse;
@@ -51,6 +52,7 @@ public sealed class DaprExtensionsTests
     public async Task UseDaprTransport_Configures_options()
     {
         IServiceCollection services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config => config.UseDaprTransport(o => o.PubSubName = "custom-pubsub"));
 
         var provider = services.BuildServiceProvider();
@@ -63,6 +65,7 @@ public sealed class DaprExtensionsTests
     public async Task UseDaprTransport_Without_configureOptions_uses_default_PubSubName()
     {
         IServiceCollection services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config => config.UseDaprTransport());
 
         var provider = services.BuildServiceProvider();

--- a/tests/NetEvolve.Pulse.Tests.Unit/Dapr/DaprMessageTransportOptionsConfigurationTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Dapr/DaprMessageTransportOptionsConfigurationTests.cs
@@ -1,0 +1,47 @@
+namespace NetEvolve.Pulse.Tests.Unit.Dapr;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("Dapr")]
+public class DaprMessageTransportOptionsConfigurationTests
+{
+    [Test]
+    public async Task Configure_WithPopulatedSection_BindsAllProperties()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?> { ["Pulse:Transports:Dapr:PubSubName"] = "custom-pubsub" }
+            )
+            .Build();
+
+        var configurator = new DaprMessageTransportOptionsConfiguration(configuration);
+        var options = new DaprMessageTransportOptions();
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.PubSubName).IsEqualTo("custom-pubsub");
+    }
+
+    [Test]
+    public async Task Configure_WithoutSection_LeavesDefaultsUnchanged()
+    {
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection([]).Build();
+
+        var configurator = new DaprMessageTransportOptionsConfiguration(configuration);
+        var options = new DaprMessageTransportOptions();
+        var defaultPubSubName = options.PubSubName;
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.PubSubName).IsEqualTo(defaultPubSubName);
+    }
+
+    [Test]
+    public void Constructor_WithNullConfiguration_ThrowsArgumentNullException() =>
+        _ = Assert.Throws<ArgumentNullException>(() => _ = new DaprMessageTransportOptionsConfiguration(null!));
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/Dapr/DaprMessageTransportOptionsValidatorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Dapr/DaprMessageTransportOptionsValidatorTests.cs
@@ -1,0 +1,62 @@
+namespace NetEvolve.Pulse.Tests.Unit.Dapr;
+
+using System.Threading.Tasks;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("Dapr")]
+public class DaprMessageTransportOptionsValidatorTests
+{
+    private static readonly DaprMessageTransportOptionsValidator _validator = new();
+
+    [Test]
+    public async Task Validate_DefaultOptions_Succeeds()
+    {
+        var options = new DaprMessageTransportOptions();
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithCustomPubSubName_Succeeds()
+    {
+        var options = new DaprMessageTransportOptions { PubSubName = "custom-pubsub" };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithNullPubSubName_Fails()
+    {
+        var options = new DaprMessageTransportOptions { PubSubName = null! };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithEmptyPubSubName_Fails()
+    {
+        var options = new DaprMessageTransportOptions { PubSubName = string.Empty };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithWhitespacePubSubName_Fails()
+    {
+        var options = new DaprMessageTransportOptions { PubSubName = "   " };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/EntityFrameworkExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/EntityFrameworkExtensionsTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
@@ -107,6 +108,7 @@ public sealed class EntityFrameworkExtensionsTests
     public async Task AddEntityFrameworkOutbox_WithConfigureOptions_AppliesOptions()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddDbContext<TestDbContext>(o =>
             o.UseInMemoryDatabase(nameof(AddEntityFrameworkOutbox_WithConfigureOptions_AppliesOptions))
         );
@@ -127,6 +129,7 @@ public sealed class EntityFrameworkExtensionsTests
     public async Task AddEntityFrameworkOutbox_WithTableNameOption_AppliesOptions()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddDbContext<TestDbContext>(o =>
             o.UseInMemoryDatabase(nameof(AddEntityFrameworkOutbox_WithTableNameOption_AppliesOptions))
         );

--- a/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/LoggingInterceptorOptionsConfigurationTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/LoggingInterceptorOptionsConfigurationTests.cs
@@ -1,0 +1,55 @@
+namespace NetEvolve.Pulse.Tests.Unit.Interceptors;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Interceptors;
+using TUnit.Core;
+
+[TestGroup("Interceptors")]
+public class LoggingInterceptorOptionsConfigurationTests
+{
+    [Test]
+    public async Task Configure_WithPopulatedSection_BindsAllProperties()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["Pulse:Logging:LogLevel"] = "Information",
+                    ["Pulse:Logging:SlowRequestThreshold"] = "00:00:01",
+                }
+            )
+            .Build();
+
+        var configurator = new LoggingInterceptorOptionsConfiguration(configuration);
+        var options = new LoggingInterceptorOptions();
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.LogLevel).IsEqualTo(LogLevel.Information);
+        _ = await Assert.That(options.SlowRequestThreshold).IsEqualTo(TimeSpan.FromSeconds(1));
+    }
+
+    [Test]
+    public async Task Configure_WithoutSection_LeavesDefaultsUnchanged()
+    {
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection([]).Build();
+
+        var configurator = new LoggingInterceptorOptionsConfiguration(configuration);
+        var options = new LoggingInterceptorOptions();
+        var defaultLogLevel = options.LogLevel;
+        var defaultThreshold = options.SlowRequestThreshold;
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.LogLevel).IsEqualTo(defaultLogLevel);
+        _ = await Assert.That(options.SlowRequestThreshold).IsEqualTo(defaultThreshold);
+    }
+
+    [Test]
+    public void Constructor_WithNullConfiguration_ThrowsArgumentNullException() =>
+        _ = Assert.Throws<ArgumentNullException>(() => _ = new LoggingInterceptorOptionsConfiguration(null!));
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/TimeoutRequestInterceptorOptionsConfigurationTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/TimeoutRequestInterceptorOptionsConfigurationTests.cs
@@ -1,0 +1,45 @@
+namespace NetEvolve.Pulse.Tests.Unit.Interceptors;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Interceptors;
+using TUnit.Core;
+
+[TestGroup("Interceptors")]
+public class TimeoutRequestInterceptorOptionsConfigurationTests
+{
+    [Test]
+    public async Task Configure_WithPopulatedSection_BindsAllProperties()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["Pulse:Timeout:GlobalTimeout"] = "00:00:30" })
+            .Build();
+
+        var configurator = new TimeoutRequestInterceptorOptionsConfiguration(configuration);
+        var options = new TimeoutRequestInterceptorOptions();
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.GlobalTimeout).IsEqualTo(TimeSpan.FromSeconds(30));
+    }
+
+    [Test]
+    public async Task Configure_WithoutSection_LeavesDefaultsUnchanged()
+    {
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection([]).Build();
+
+        var configurator = new TimeoutRequestInterceptorOptionsConfiguration(configuration);
+        var options = new TimeoutRequestInterceptorOptions();
+        var defaultTimeout = options.GlobalTimeout;
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.GlobalTimeout).IsEqualTo(defaultTimeout);
+    }
+
+    [Test]
+    public void Constructor_WithNullConfiguration_ThrowsArgumentNullException() =>
+        _ = Assert.Throws<ArgumentNullException>(() => _ = new TimeoutRequestInterceptorOptionsConfiguration(null!));
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/TimeoutRequestInterceptorOptionsValidatorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/TimeoutRequestInterceptorOptionsValidatorTests.cs
@@ -1,0 +1,62 @@
+namespace NetEvolve.Pulse.Tests.Unit.Interceptors;
+
+using System.Threading.Tasks;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Interceptors;
+using TUnit.Core;
+
+[TestGroup("Interceptors")]
+public class TimeoutRequestInterceptorOptionsValidatorTests
+{
+    private static readonly TimeoutRequestInterceptorOptionsValidator _validator = new();
+
+    [Test]
+    public async Task Validate_WithNullGlobalTimeout_Succeeds()
+    {
+        var options = new TimeoutRequestInterceptorOptions { GlobalTimeout = null };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithPositiveGlobalTimeout_Succeeds()
+    {
+        var options = new TimeoutRequestInterceptorOptions { GlobalTimeout = TimeSpan.FromSeconds(30) };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithZeroGlobalTimeout_Fails()
+    {
+        var options = new TimeoutRequestInterceptorOptions { GlobalTimeout = TimeSpan.Zero };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithNegativeGlobalTimeout_Fails()
+    {
+        var options = new TimeoutRequestInterceptorOptions { GlobalTimeout = TimeSpan.FromSeconds(-1) };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_DefaultOptions_Succeeds()
+    {
+        var options = new TimeoutRequestInterceptorOptions();
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/LoggingExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/LoggingExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace NetEvolve.Pulse.Tests.Unit;
 
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
@@ -127,6 +128,7 @@ public class LoggingExtensionsTests
     public async Task AddLogging_WithConfigure_AppliesOptions()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         var configurator = new MediatorBuilder(services);
 
         _ = configurator.AddLogging(opts =>
@@ -152,6 +154,7 @@ public class LoggingExtensionsTests
     public async Task AddLogging_WithoutConfigure_UsesDefaultOptions()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         var configurator = new MediatorBuilder(services);
 
         _ = configurator.AddLogging();

--- a/tests/NetEvolve.Pulse.Tests.Unit/MySql/MySqlExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/MySql/MySqlExtensionsTests.cs
@@ -3,6 +3,7 @@ namespace NetEvolve.Pulse.Tests.Unit.MySql;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
@@ -122,6 +123,7 @@ public sealed class MySqlExtensionsTests
     public async Task AddMySqlOutbox_WithConfigureOptions_AppliesTableName()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config =>
             config.AddMySqlOutbox("Server=localhost;Database=mydb;", options => options.TableName = "CustomTable")
         );
@@ -139,6 +141,7 @@ public sealed class MySqlExtensionsTests
     public async Task AddMySqlOutbox_WithConfigureAction_AppliesOptions()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config =>
             config.AddMySqlOutbox(opts =>
             {
@@ -246,6 +249,7 @@ public sealed class MySqlExtensionsTests
     public async Task AddMySqlOutbox_WithFactory_WithConfigureOptions_AppliesOptions()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config =>
             config.AddMySqlOutbox(_ => "Server=localhost;Database=mydb;", options => options.TableName = "CustomTable")
         );

--- a/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxExtensionsTests.cs
@@ -4,7 +4,9 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.Pulse.Extensibility;
 using NetEvolve.Pulse.Extensibility.Outbox;
@@ -87,6 +89,28 @@ public sealed class OutboxExtensionsTests
         {
             _ = await Assert.That(descriptor).IsNotNull();
             _ = await Assert.That(descriptor!.Lifetime).IsEqualTo(ServiceLifetime.Scoped);
+        }
+    }
+
+    [Test]
+    public async Task AddOutbox_WithInvalidTableName_ValidateOnStart_ThrowsOnServiceProviderOptionsResolution()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        var builder = new MediatorBuilder(services);
+
+        _ = builder.AddOutbox(configureOptions: opts => opts.TableName = string.Empty);
+
+        var provider = services.BuildServiceProvider();
+        await using (provider.ConfigureAwait(false))
+        {
+            // The ValidateOnStart registration performed by AddOutbox eagerly validates options at
+            // IHost startup; here we assert the equivalent failure surfaces the moment the options
+            // are resolved, since the underlying validator runs on every options creation, not only
+            // via the startup hook.
+            _ = Assert.Throws<OptionsValidationException>(() =>
+                _ = provider.GetRequiredService<IOptions<OutboxOptions>>().Value
+            );
         }
     }
 

--- a/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxOptionsConfigurationTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxOptionsConfigurationTests.cs
@@ -1,0 +1,66 @@
+namespace NetEvolve.Pulse.Tests.Unit.Outbox;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("Outbox")]
+public class OutboxOptionsConfigurationTests
+{
+    [Test]
+    public async Task Configure_WithPopulatedSection_BindsAllProperties()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["Pulse:Outbox:Schema"] = "custom",
+                    ["Pulse:Outbox:TableName"] = "CustomOutboxMessage",
+                    ["Pulse:Outbox:ConnectionString"] = "Data Source=test.db",
+                    ["Pulse:Outbox:EnableWalMode"] = "false",
+                    ["Pulse:Outbox:ProcessingLeaseTimeout"] = "00:10:00",
+                }
+            )
+            .Build();
+
+        var configurator = new OutboxOptionsConfiguration(configuration);
+        var options = new OutboxOptions();
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.Schema).IsEqualTo("custom");
+        _ = await Assert.That(options.TableName).IsEqualTo("CustomOutboxMessage");
+        _ = await Assert.That(options.ConnectionString).IsEqualTo("Data Source=test.db");
+        _ = await Assert.That(options.EnableWalMode).IsFalse();
+        _ = await Assert.That(options.ProcessingLeaseTimeout).IsEqualTo(TimeSpan.FromMinutes(10));
+    }
+
+    [Test]
+    public async Task Configure_WithoutSection_LeavesDefaultsUnchanged()
+    {
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection([]).Build();
+
+        var configurator = new OutboxOptionsConfiguration(configuration);
+        var options = new OutboxOptions();
+        var defaultSchema = options.Schema;
+        var defaultTableName = options.TableName;
+        var defaultConnectionString = options.ConnectionString;
+        var defaultWalMode = options.EnableWalMode;
+        var defaultLeaseTimeout = options.ProcessingLeaseTimeout;
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.Schema).IsEqualTo(defaultSchema);
+        _ = await Assert.That(options.TableName).IsEqualTo(defaultTableName);
+        _ = await Assert.That(options.ConnectionString).IsEqualTo(defaultConnectionString);
+        _ = await Assert.That(options.EnableWalMode).IsEqualTo(defaultWalMode);
+        _ = await Assert.That(options.ProcessingLeaseTimeout).IsEqualTo(defaultLeaseTimeout);
+    }
+
+    [Test]
+    public void Constructor_WithNullConfiguration_ThrowsArgumentNullException() =>
+        _ = Assert.Throws<ArgumentNullException>(() => _ = new OutboxOptionsConfiguration(null!));
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxOptionsValidatorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxOptionsValidatorTests.cs
@@ -1,0 +1,74 @@
+namespace NetEvolve.Pulse.Tests.Unit.Outbox;
+
+using System.Threading.Tasks;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("Outbox")]
+public class OutboxOptionsValidatorTests
+{
+    private static readonly OutboxOptionsValidator _validator = new();
+
+    [Test]
+    public async Task Validate_DefaultOptions_Succeeds()
+    {
+        var options = new OutboxOptions();
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithNullTableName_Fails()
+    {
+        var options = new OutboxOptions { TableName = null! };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithEmptyTableName_Fails()
+    {
+        var options = new OutboxOptions { TableName = string.Empty };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithWhitespaceTableName_Fails()
+    {
+        var options = new OutboxOptions { TableName = "   " };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithValidTableName_Succeeds()
+    {
+        var options = new OutboxOptions { TableName = "CustomOutboxMessage" };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithNullConnectionString_Succeeds()
+    {
+        // ConnectionString is legitimately null for EF Core-based outbox usage; it must not be
+        // treated as invalid by this validator.
+        var options = new OutboxOptions { ConnectionString = null };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorHostedServiceDbContextLifetimeTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorHostedServiceDbContextLifetimeTests.cs
@@ -3,6 +3,7 @@ namespace NetEvolve.Pulse.Tests.Unit.Outbox;
 using System;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NetEvolve.Extensions.TUnit;
@@ -25,6 +26,7 @@ public sealed class OutboxProcessorHostedServiceDbContextLifetimeTests
     {
         var services = new ServiceCollection();
         _ = services.AddLogging();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddSingleton<IHostApplicationLifetime>(new FakeHostApplicationLifetime());
         _ = services.AddDbContext<TestDbContext>(o =>
             o.UseInMemoryDatabase(nameof(BuildServiceProvider_WithValidateScopesAndEntityFrameworkOutbox_DoesNotThrow))
@@ -52,6 +54,7 @@ public sealed class OutboxProcessorHostedServiceDbContextLifetimeTests
     {
         var services = new ServiceCollection();
         _ = services.AddLogging();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddSingleton<IHostApplicationLifetime>(new FakeHostApplicationLifetime());
         _ = services.AddDbContext<TestDbContext>(o =>
             o.UseInMemoryDatabase(nameof(ExecuteAsync_AcrossMultipleCycles_ResolvesFreshRepositoryPerCycle))

--- a/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorOptionsConfigurationTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorOptionsConfigurationTests.cs
@@ -1,0 +1,86 @@
+namespace NetEvolve.Pulse.Tests.Unit.Outbox;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("Outbox")]
+public class OutboxProcessorOptionsConfigurationTests
+{
+    [Test]
+    public async Task Configure_WithPopulatedSection_BindsAllProperties()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["Pulse:OutboxProcessor:BatchSize"] = "50",
+                    ["Pulse:OutboxProcessor:PollingInterval"] = "00:00:10",
+                    ["Pulse:OutboxProcessor:MaxRetryCount"] = "5",
+                    ["Pulse:OutboxProcessor:ProcessingTimeout"] = "00:01:00",
+                    ["Pulse:OutboxProcessor:EnableBatchSending"] = "true",
+                    ["Pulse:OutboxProcessor:EnableExponentialBackoff"] = "true",
+                    ["Pulse:OutboxProcessor:BaseRetryDelay"] = "00:00:15",
+                    ["Pulse:OutboxProcessor:MaxRetryDelay"] = "00:15:00",
+                    ["Pulse:OutboxProcessor:BackoffMultiplier"] = "3.5",
+                    ["Pulse:OutboxProcessor:AddJitter"] = "false",
+                }
+            )
+            .Build();
+
+        var configurator = new OutboxProcessorOptionsConfiguration(configuration);
+        var options = new OutboxProcessorOptions();
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.BatchSize).IsEqualTo(50);
+        _ = await Assert.That(options.PollingInterval).IsEqualTo(TimeSpan.FromSeconds(10));
+        _ = await Assert.That(options.MaxRetryCount).IsEqualTo(5);
+        _ = await Assert.That(options.ProcessingTimeout).IsEqualTo(TimeSpan.FromMinutes(1));
+        _ = await Assert.That(options.EnableBatchSending).IsTrue();
+        _ = await Assert.That(options.EnableExponentialBackoff).IsTrue();
+        _ = await Assert.That(options.BaseRetryDelay).IsEqualTo(TimeSpan.FromSeconds(15));
+        _ = await Assert.That(options.MaxRetryDelay).IsEqualTo(TimeSpan.FromMinutes(15));
+        _ = await Assert.That(options.BackoffMultiplier).IsEqualTo(3.5);
+        _ = await Assert.That(options.AddJitter).IsFalse();
+    }
+
+    [Test]
+    public async Task Configure_WithoutSection_LeavesDefaultsUnchanged()
+    {
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection([]).Build();
+
+        var configurator = new OutboxProcessorOptionsConfiguration(configuration);
+        var options = new OutboxProcessorOptions();
+        var defaultBatchSize = options.BatchSize;
+        var defaultPollingInterval = options.PollingInterval;
+        var defaultMaxRetryCount = options.MaxRetryCount;
+        var defaultProcessingTimeout = options.ProcessingTimeout;
+        var defaultEnableBatchSending = options.EnableBatchSending;
+        var defaultEnableExponentialBackoff = options.EnableExponentialBackoff;
+        var defaultBaseRetryDelay = options.BaseRetryDelay;
+        var defaultMaxRetryDelay = options.MaxRetryDelay;
+        var defaultBackoffMultiplier = options.BackoffMultiplier;
+        var defaultAddJitter = options.AddJitter;
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.BatchSize).IsEqualTo(defaultBatchSize);
+        _ = await Assert.That(options.PollingInterval).IsEqualTo(defaultPollingInterval);
+        _ = await Assert.That(options.MaxRetryCount).IsEqualTo(defaultMaxRetryCount);
+        _ = await Assert.That(options.ProcessingTimeout).IsEqualTo(defaultProcessingTimeout);
+        _ = await Assert.That(options.EnableBatchSending).IsEqualTo(defaultEnableBatchSending);
+        _ = await Assert.That(options.EnableExponentialBackoff).IsEqualTo(defaultEnableExponentialBackoff);
+        _ = await Assert.That(options.BaseRetryDelay).IsEqualTo(defaultBaseRetryDelay);
+        _ = await Assert.That(options.MaxRetryDelay).IsEqualTo(defaultMaxRetryDelay);
+        _ = await Assert.That(options.BackoffMultiplier).IsEqualTo(defaultBackoffMultiplier);
+        _ = await Assert.That(options.AddJitter).IsEqualTo(defaultAddJitter);
+    }
+
+    [Test]
+    public void Constructor_WithNullConfiguration_ThrowsArgumentNullException() =>
+        _ = Assert.Throws<ArgumentNullException>(() => _ = new OutboxProcessorOptionsConfiguration(null!));
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorOptionsValidatorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorOptionsValidatorTests.cs
@@ -1,0 +1,159 @@
+namespace NetEvolve.Pulse.Tests.Unit.Outbox;
+
+using System.Threading.Tasks;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("Outbox")]
+public class OutboxProcessorOptionsValidatorTests
+{
+    private static readonly OutboxProcessorOptionsValidator _validator = new();
+
+    [Test]
+    public async Task Validate_DefaultOptions_Succeeds()
+    {
+        var options = new OutboxProcessorOptions();
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithZeroBatchSize_Fails()
+    {
+        var options = new OutboxProcessorOptions { BatchSize = 0 };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithNegativeBatchSize_Fails()
+    {
+        var options = new OutboxProcessorOptions { BatchSize = -1 };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithZeroPollingInterval_Fails()
+    {
+        var options = new OutboxProcessorOptions { PollingInterval = TimeSpan.Zero };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithNegativePollingInterval_Fails()
+    {
+        var options = new OutboxProcessorOptions { PollingInterval = TimeSpan.FromSeconds(-1) };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithNegativeMaxRetryCount_Fails()
+    {
+        var options = new OutboxProcessorOptions { MaxRetryCount = -1 };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithZeroMaxRetryCount_Succeeds()
+    {
+        var options = new OutboxProcessorOptions { MaxRetryCount = 0 };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithZeroProcessingTimeout_Fails()
+    {
+        var options = new OutboxProcessorOptions { ProcessingTimeout = TimeSpan.Zero };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithExponentialBackoffEnabled_AndInvalidBackoffMultiplier_Fails()
+    {
+        var options = new OutboxProcessorOptions { EnableExponentialBackoff = true, BackoffMultiplier = 1.0 };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithExponentialBackoffEnabled_AndZeroBaseRetryDelay_Fails()
+    {
+        var options = new OutboxProcessorOptions { EnableExponentialBackoff = true, BaseRetryDelay = TimeSpan.Zero };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithExponentialBackoffEnabled_AndMaxRetryDelayLessThanBaseRetryDelay_Fails()
+    {
+        var options = new OutboxProcessorOptions
+        {
+            EnableExponentialBackoff = true,
+            BaseRetryDelay = TimeSpan.FromSeconds(10),
+            MaxRetryDelay = TimeSpan.FromSeconds(5),
+        };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithExponentialBackoffEnabled_AndValidValues_Succeeds()
+    {
+        var options = new OutboxProcessorOptions
+        {
+            EnableExponentialBackoff = true,
+            BackoffMultiplier = 2.0,
+            BaseRetryDelay = TimeSpan.FromSeconds(5),
+            MaxRetryDelay = TimeSpan.FromMinutes(5),
+        };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithExponentialBackoffDisabled_IgnoresBackoffFields()
+    {
+        var options = new OutboxProcessorOptions
+        {
+            EnableExponentialBackoff = false,
+            BackoffMultiplier = 0,
+            BaseRetryDelay = TimeSpan.Zero,
+            MaxRetryDelay = TimeSpan.Zero,
+        };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/PostgreSql/PostgreSqlExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/PostgreSql/PostgreSqlExtensionsTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
@@ -101,6 +102,7 @@ public sealed class PostgreSqlExtensionsTests
     public async Task AddPostgreSqlOutbox_WithConfigureOptions_AppliesOptions()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config =>
             config
                 .AddOutbox()
@@ -179,6 +181,7 @@ public sealed class PostgreSqlExtensionsTests
     public async Task AddPostgreSqlOutbox_WithFactory_WithConfigureOptions_AppliesOptions()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config =>
             config
                 .AddOutbox()

--- a/tests/NetEvolve.Pulse.Tests.Unit/QueryCachingExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/QueryCachingExtensionsTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
@@ -47,6 +48,7 @@ public sealed class QueryCachingExtensionsTests
     public async Task AddQueryCaching_WithConfigure_AppliesOptions()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         var builder = new MediatorBuilder(services);
 
         _ = builder.AddQueryCaching(opts => opts.ExpirationMode = CacheExpirationMode.Sliding);

--- a/tests/NetEvolve.Pulse.Tests.Unit/QueryCachingOptionsConfigurationTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/QueryCachingOptionsConfigurationTests.cs
@@ -1,0 +1,54 @@
+namespace NetEvolve.Pulse.Tests.Unit;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility.Caching;
+using TUnit.Core;
+
+[TestGroup("QueryCaching")]
+public sealed class QueryCachingOptionsConfigurationTests
+{
+    [Test]
+    public async Task Configure_WithPopulatedSection_BindsAllProperties()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["Pulse:QueryCaching:ExpirationMode"] = "Sliding",
+                    ["Pulse:QueryCaching:DefaultExpiry"] = "00:10:00",
+                }
+            )
+            .Build();
+
+        var configurator = new QueryCachingOptionsConfiguration(configuration);
+        var options = new QueryCachingOptions();
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.ExpirationMode).IsEqualTo(CacheExpirationMode.Sliding);
+        _ = await Assert.That(options.DefaultExpiry).IsEqualTo(TimeSpan.FromMinutes(10));
+    }
+
+    [Test]
+    public async Task Configure_WithoutSection_LeavesDefaultsUnchanged()
+    {
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection([]).Build();
+
+        var configurator = new QueryCachingOptionsConfiguration(configuration);
+        var options = new QueryCachingOptions();
+        var defaultMode = options.ExpirationMode;
+        var defaultExpiry = options.DefaultExpiry;
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.ExpirationMode).IsEqualTo(defaultMode);
+        _ = await Assert.That(options.DefaultExpiry).IsEqualTo(defaultExpiry);
+    }
+
+    [Test]
+    public void Constructor_WithNullConfiguration_ThrowsArgumentNullException() =>
+        _ = Assert.Throws<ArgumentNullException>(() => _ = new QueryCachingOptionsConfiguration(null!));
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/QueryCachingOptionsValidatorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/QueryCachingOptionsValidatorTests.cs
@@ -1,0 +1,66 @@
+namespace NetEvolve.Pulse.Tests.Unit;
+
+using System.Threading.Tasks;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility.Caching;
+using TUnit.Core;
+
+[TestGroup("QueryCaching")]
+public sealed class QueryCachingOptionsValidatorTests
+{
+    private static readonly QueryCachingOptionsValidator _validator = new();
+
+    [Test]
+    public async Task Validate_WithNullDefaultExpiry_Succeeds()
+    {
+        var options = new QueryCachingOptions { DefaultExpiry = null };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithPositiveDefaultExpiry_Succeeds()
+    {
+        var options = new QueryCachingOptions { DefaultExpiry = TimeSpan.FromMinutes(10) };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithZeroDefaultExpiry_Fails()
+    {
+        var options = new QueryCachingOptions { DefaultExpiry = TimeSpan.Zero };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithNegativeDefaultExpiry_Fails()
+    {
+        var options = new QueryCachingOptions { DefaultExpiry = TimeSpan.FromMinutes(-1) };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_NullOptions_ThrowsArgumentNullException() =>
+        _ = await Assert.That(() => _validator.Validate(null, null!)).Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Validate_DefaultOptions_Succeeds()
+    {
+        var options = new QueryCachingOptions();
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/RabbitMQ/RabbitMqChannelPoolTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/RabbitMQ/RabbitMqChannelPoolTests.cs
@@ -115,7 +115,12 @@ public sealed class RabbitMqChannelPoolTests
         var rentTasks = new List<Task<IRabbitMqChannelAdapter>>();
         for (var i = 0; i < MaxPoolSize; i++)
         {
+            // Each iteration converts a distinct ValueTask returned by RentAsync exactly once via
+            // AsTask(); the analyzer cannot see across loop iterations that no ValueTask instance
+            // is consumed twice.
+#pragma warning disable S5034 // Refactor this 'ValueTask' usage to consume it only once
             rentTasks.Add(pool.RentAsync(cancellationToken).AsTask());
+#pragma warning restore S5034
         }
 
         var rented = await Task.WhenAll(rentTasks)

--- a/tests/NetEvolve.Pulse.Tests.Unit/RabbitMQ/RabbitMqChannelPoolTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/RabbitMQ/RabbitMqChannelPoolTests.cs
@@ -1,0 +1,315 @@
+namespace NetEvolve.Pulse.Tests.Unit.RabbitMQ;
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Internals;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
+
+[TestGroup("RabbitMQ")]
+public sealed class RabbitMqChannelPoolTests
+{
+    [Test]
+    public async Task Constructor_When_connectionAdapter_null_throws()
+    {
+        IRabbitMqConnectionAdapter connectionAdapter = null!;
+
+        var exception = Assert.Throws<ArgumentNullException>(() => _ = new RabbitMqChannelPool(connectionAdapter, 10));
+
+        _ = await Assert.That(exception).IsNotNull();
+        _ = await Assert.That(exception.ParamName).IsEqualTo("connectionAdapter");
+    }
+
+    [Test]
+    [Arguments(0)]
+    [Arguments(-1)]
+    public async Task Constructor_When_maxChannelPoolSize_not_positive_throws(int maxChannelPoolSize)
+    {
+        var connectionAdapter = new FakeConnectionAdapter();
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            _ = new RabbitMqChannelPool(connectionAdapter, maxChannelPoolSize)
+        );
+
+        _ = await Assert.That(exception).IsNotNull();
+    }
+
+    [Test]
+    public async Task RentAsync_When_pool_empty_creates_new_channel(CancellationToken cancellationToken)
+    {
+        var connectionAdapter = new FakeConnectionAdapter();
+        using var pool = new RabbitMqChannelPool(connectionAdapter, 10);
+
+        var channel = await pool.RentAsync(cancellationToken).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(channel).IsNotNull();
+            _ = await Assert.That(connectionAdapter.CreateChannelCallCount).IsEqualTo(1);
+        }
+    }
+
+    [Test]
+    public async Task Return_Of_open_channel_makes_it_available_for_next_rent(CancellationToken cancellationToken)
+    {
+        var connectionAdapter = new FakeConnectionAdapter();
+        using var pool = new RabbitMqChannelPool(connectionAdapter, 10);
+
+        var channel = await pool.RentAsync(cancellationToken).ConfigureAwait(false);
+        pool.Return(channel);
+
+        var reused = await pool.RentAsync(cancellationToken).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(reused).IsSameReferenceAs(channel);
+            _ = await Assert.That(connectionAdapter.CreateChannelCallCount).IsEqualTo(1);
+        }
+    }
+
+    [Test]
+    public async Task Return_Of_closed_channel_disposes_it_and_next_rent_creates_a_fresh_one(
+        CancellationToken cancellationToken
+    )
+    {
+        var connectionAdapter = new FakeConnectionAdapter();
+        using var pool = new RabbitMqChannelPool(connectionAdapter, 10);
+
+        var channel = (FakeChannelAdapter)await pool.RentAsync(cancellationToken).ConfigureAwait(false);
+        channel.IsOpen = false; // Simulate broker-side channel closure while rented.
+        pool.Return(channel);
+
+        var next = await pool.RentAsync(cancellationToken).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(channel.DisposeCallCount).IsEqualTo(1);
+            _ = await Assert.That(next).IsNotSameReferenceAs(channel);
+            _ = await Assert.That(connectionAdapter.CreateChannelCallCount).IsEqualTo(2);
+        }
+    }
+
+    [Test]
+    public async Task Return_Null_channel_throws()
+    {
+        var connectionAdapter = new FakeConnectionAdapter();
+        using var pool = new RabbitMqChannelPool(connectionAdapter, 10);
+
+        var exception = Assert.Throws<ArgumentNullException>(() => pool.Return(null!));
+
+        _ = await Assert.That(exception).IsNotNull();
+        _ = await Assert.That(exception.ParamName).IsEqualTo("channel");
+    }
+
+    [Test]
+    public async Task RentAsync_ConcurrentCalls_AreCappedAtMaxChannelPoolSize(CancellationToken cancellationToken)
+    {
+        const int MaxPoolSize = 3;
+        var connectionAdapter = new FakeConnectionAdapter();
+        using var pool = new RabbitMqChannelPool(connectionAdapter, MaxPoolSize);
+
+        var rentTasks = new List<Task<IRabbitMqChannelAdapter>>();
+        for (var i = 0; i < MaxPoolSize; i++)
+        {
+            rentTasks.Add(pool.RentAsync(cancellationToken).AsTask());
+        }
+
+        var rented = await Task.WhenAll(rentTasks)
+            .WaitAsync(TimeSpan.FromSeconds(5), cancellationToken)
+            .ConfigureAwait(false);
+
+        // A further rent must block because the pool is exhausted.
+        var blockedRent = pool.RentAsync(cancellationToken).AsTask();
+        _ = await Task.WhenAny(blockedRent, Task.Delay(200, cancellationToken)).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(rented.Length).IsEqualTo(MaxPoolSize);
+            _ = await Assert.That(connectionAdapter.CreateChannelCallCount).IsEqualTo(MaxPoolSize);
+            _ = await Assert.That(blockedRent.IsCompleted).IsFalse();
+        }
+
+        // Release a slot so the blocked rent can complete, avoiding a hanging task.
+        pool.Return(rented[0]);
+        var unblocked = await blockedRent.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
+        _ = await Assert.That(unblocked).IsNotNull();
+    }
+
+    [Test]
+    public async Task RentAsync_When_pool_exhausted_waits_until_a_channel_is_returned(
+        CancellationToken cancellationToken
+    )
+    {
+        var connectionAdapter = new FakeConnectionAdapter();
+        using var pool = new RabbitMqChannelPool(connectionAdapter, 1);
+
+        var firstChannel = await pool.RentAsync(cancellationToken).ConfigureAwait(false);
+
+        var secondRent = pool.RentAsync(cancellationToken).AsTask();
+        _ = await Task.WhenAny(secondRent, Task.Delay(200, cancellationToken)).ConfigureAwait(false);
+        _ = await Assert.That(secondRent.IsCompleted).IsFalse();
+
+        pool.Return(firstChannel);
+
+        var secondChannel = await secondRent
+            .WaitAsync(TimeSpan.FromSeconds(5), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(secondChannel).IsSameReferenceAs(firstChannel);
+    }
+
+    [Test]
+    public async Task IsHealthyAsync_Reflects_connection_state(CancellationToken cancellationToken)
+    {
+        var connectionAdapter = new FakeConnectionAdapter { IsOpen = false };
+        using var pool = new RabbitMqChannelPool(connectionAdapter, 10);
+
+        var healthy = await pool.IsHealthyAsync(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(healthy).IsFalse();
+    }
+
+    [Test]
+    public async Task IsHealthyAsync_When_exception_thrown_returns_false(CancellationToken cancellationToken)
+    {
+        var connectionAdapter = new FakeConnectionAdapter { IsOpen = true, ThrowOnIsOpen = true };
+        using var pool = new RabbitMqChannelPool(connectionAdapter, 10);
+
+        var healthy = await pool.IsHealthyAsync(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(healthy).IsFalse();
+    }
+
+    [Test]
+    public async Task IsHealthyAsync_After_dispose_returns_false(CancellationToken cancellationToken)
+    {
+        var connectionAdapter = new FakeConnectionAdapter { IsOpen = true };
+        var pool = new RabbitMqChannelPool(connectionAdapter, 10);
+
+        pool.Dispose();
+
+        var healthy = await pool.IsHealthyAsync(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(healthy).IsFalse();
+    }
+
+    [Test]
+    public async Task Dispose_Disposes_all_idle_channels(CancellationToken cancellationToken)
+    {
+        var connectionAdapter = new FakeConnectionAdapter();
+        var pool = new RabbitMqChannelPool(connectionAdapter, 10);
+
+        var channel1 = (FakeChannelAdapter)await pool.RentAsync(cancellationToken).ConfigureAwait(false);
+        var channel2 = (FakeChannelAdapter)await pool.RentAsync(cancellationToken).ConfigureAwait(false);
+        pool.Return(channel1);
+        pool.Return(channel2);
+
+        pool.Dispose();
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(channel1.DisposeCallCount).IsEqualTo(1);
+            _ = await Assert.That(channel2.DisposeCallCount).IsEqualTo(1);
+        }
+    }
+
+    [Test]
+    public async Task Dispose_Is_idempotent(CancellationToken cancellationToken)
+    {
+        var connectionAdapter = new FakeConnectionAdapter();
+        var pool = new RabbitMqChannelPool(connectionAdapter, 10);
+
+        var channel = (FakeChannelAdapter)await pool.RentAsync(cancellationToken).ConfigureAwait(false);
+        pool.Return(channel);
+
+        pool.Dispose();
+        pool.Dispose();
+
+        _ = await Assert.That(channel.DisposeCallCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task RentAsync_After_dispose_throws_ObjectDisposedException(CancellationToken cancellationToken)
+    {
+        var connectionAdapter = new FakeConnectionAdapter();
+        var pool = new RabbitMqChannelPool(connectionAdapter, 10);
+
+        pool.Dispose();
+
+        var exception = await Assert.ThrowsAsync<ObjectDisposedException>(() =>
+            pool.RentAsync(cancellationToken).AsTask()
+        );
+
+        _ = await Assert.That(exception).IsNotNull();
+    }
+
+    [Test]
+    public async Task Return_After_dispose_disposes_channel_without_throwing(CancellationToken cancellationToken)
+    {
+        var connectionAdapter = new FakeConnectionAdapter();
+        var pool = new RabbitMqChannelPool(connectionAdapter, 1);
+
+        var channel = (FakeChannelAdapter)await pool.RentAsync(cancellationToken).ConfigureAwait(false);
+
+        pool.Dispose();
+
+        pool.Return(channel);
+
+        _ = await Assert.That(channel.DisposeCallCount).IsEqualTo(1);
+    }
+
+    private sealed class FakeConnectionAdapter : IRabbitMqConnectionAdapter
+    {
+        private bool _isOpen = true;
+
+        public bool IsOpen
+        {
+            get
+            {
+                if (ThrowOnIsOpen)
+                {
+                    throw new InvalidOperationException("Connection check failed");
+                }
+
+                return _isOpen;
+            }
+            set => _isOpen = value;
+        }
+
+        public bool ThrowOnIsOpen { get; set; }
+
+        public int CreateChannelCallCount { get; private set; }
+
+        public Task<IRabbitMqChannelAdapter> CreateChannelAsync(CancellationToken cancellationToken = default)
+        {
+            CreateChannelCallCount++;
+            return Task.FromResult<IRabbitMqChannelAdapter>(new FakeChannelAdapter());
+        }
+    }
+
+    private sealed class FakeChannelAdapter : IRabbitMqChannelAdapter
+    {
+        private int _disposeCallCount;
+
+        public bool IsOpen { get; set; } = true;
+
+        public int DisposeCallCount => Volatile.Read(ref _disposeCallCount);
+
+        public ValueTask BasicPublishAsync<TProperties>(
+            string exchange,
+            string routingKey,
+            bool mandatory,
+            TProperties basicProperties,
+            ReadOnlyMemory<byte> body,
+            CancellationToken cancellationToken = default
+        )
+            where TProperties : global::RabbitMQ.Client.IReadOnlyBasicProperties, global::RabbitMQ.Client.IAmqpHeader =>
+            ValueTask.CompletedTask;
+
+        public void Dispose() => Interlocked.Increment(ref _disposeCallCount);
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/RabbitMQ/RabbitMqChannelPoolTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/RabbitMQ/RabbitMqChannelPoolTests.cs
@@ -253,6 +253,30 @@ public sealed class RabbitMqChannelPoolTests
     }
 
     [Test]
+    public async Task RentAsync_When_channel_creation_fails_releases_rental_slot_and_rethrows(
+        CancellationToken cancellationToken
+    )
+    {
+        var connectionAdapter = new FakeConnectionAdapter { ThrowOnCreateChannel = true };
+        using var pool = new RabbitMqChannelPool(connectionAdapter, 1);
+
+#pragma warning disable S5034 // Refactor this 'ValueTask' usage to consume it only once
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            pool.RentAsync(cancellationToken).AsTask()
+        );
+        _ = await Assert.That(exception).IsNotNull();
+
+        // The rental slot released by the failed attempt must be available for the next
+        // caller instead of leaking, even though channel creation keeps failing.
+        var secondAttempt = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            pool.RentAsync(cancellationToken).AsTask()
+        );
+#pragma warning restore S5034
+        _ = await Assert.That(secondAttempt).IsNotNull();
+        _ = await Assert.That(connectionAdapter.CreateChannelCallCount).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task Return_After_dispose_disposes_channel_without_throwing(CancellationToken cancellationToken)
     {
         var connectionAdapter = new FakeConnectionAdapter();
@@ -287,11 +311,19 @@ public sealed class RabbitMqChannelPoolTests
 
         public bool ThrowOnIsOpen { get; set; }
 
+        public bool ThrowOnCreateChannel { get; set; }
+
         public int CreateChannelCallCount { get; private set; }
 
         public Task<IRabbitMqChannelAdapter> CreateChannelAsync(CancellationToken cancellationToken = default)
         {
             CreateChannelCallCount++;
+
+            if (ThrowOnCreateChannel)
+            {
+                throw new InvalidOperationException("Channel creation failed");
+            }
+
             return Task.FromResult<IRabbitMqChannelAdapter>(new FakeChannelAdapter());
         }
     }

--- a/tests/NetEvolve.Pulse.Tests.Unit/RabbitMQ/RabbitMqExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/RabbitMQ/RabbitMqExtensionsTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.Pulse.Extensibility;
 using NetEvolve.Pulse.Extensibility.Outbox;
+using NetEvolve.Pulse.Internals;
 using NetEvolve.Pulse.Outbox;
 using TUnit.Assertions.Extensions;
 using TUnit.Core;
@@ -20,6 +21,31 @@ public sealed class RabbitMqExtensionsTests
         var descriptor = services.Single(d => d.ServiceType == typeof(IMessageTransport));
         _ = await Assert.That(descriptor.ImplementationType).IsEqualTo(typeof(RabbitMqMessageTransport));
         _ = await Assert.That(descriptor.Lifetime).IsEqualTo(ServiceLifetime.Singleton);
+    }
+
+    [Test]
+    public async Task UseRabbitMqTransport_Registers_channel_pool_as_singleton()
+    {
+        IServiceCollection services = new ServiceCollection();
+        _ = services.AddPulse(config => config.UseRabbitMqTransport());
+
+        var descriptor = services.Single(d => d.ServiceType == typeof(IRabbitMqChannelPool));
+        _ = await Assert.That(descriptor.Lifetime).IsEqualTo(ServiceLifetime.Singleton);
+    }
+
+    [Test]
+    public async Task UseRabbitMqTransport_CalledTwice_Does_not_duplicate_channel_pool_registration()
+    {
+        IServiceCollection services = new ServiceCollection();
+        _ = services.AddPulse(config =>
+        {
+            _ = config.UseRabbitMqTransport();
+            _ = config.UseRabbitMqTransport();
+        });
+
+        var descriptors = services.Where(d => d.ServiceType == typeof(IRabbitMqChannelPool)).ToList();
+
+        _ = await Assert.That(descriptors.Count).IsEqualTo(1);
     }
 
     [Test]

--- a/tests/NetEvolve.Pulse.Tests.Unit/RabbitMQ/RabbitMqExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/RabbitMQ/RabbitMqExtensionsTests.cs
@@ -99,6 +99,33 @@ public sealed class RabbitMqExtensionsTests
     }
 
     [Test]
+    public async Task UseRabbitMqTransport_Resolves_channel_pool_from_connection_adapter_and_options()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddPulse(config =>
+            config.UseRabbitMqTransport(options =>
+            {
+                options.ExchangeName = "test-exchange";
+                options.MaxChannelPoolSize = 3;
+            })
+        );
+
+        // Replace the connection-adapter registration with a fake so the pool factory can be
+        // exercised without a real RabbitMQ.Client IConnection.
+        var connectionAdapterDescriptor = services.Single(d => d.ServiceType == typeof(IRabbitMqConnectionAdapter));
+        _ = services.Remove(connectionAdapterDescriptor);
+        _ = services.AddSingleton<IRabbitMqConnectionAdapter>(new FakeConnectionAdapter());
+
+        var provider = services.BuildServiceProvider();
+        await using (provider.ConfigureAwait(false))
+        {
+            var pool = provider.GetRequiredService<IRabbitMqChannelPool>();
+
+            _ = await Assert.That(pool).IsNotNull();
+        }
+    }
+
+    [Test]
     public async Task UseRabbitMqTransport_When_configurator_null_throws()
     {
         IMediatorBuilder configurator = null!;
@@ -133,5 +160,15 @@ public sealed class RabbitMqExtensionsTests
             IEnumerable<OutboxMessage> messages,
             CancellationToken cancellationToken = default
         ) => Task.CompletedTask;
+    }
+
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes - instantiated via DI container
+    private sealed class FakeConnectionAdapter : IRabbitMqConnectionAdapter
+#pragma warning restore CA1812
+    {
+        public bool IsOpen => true;
+
+        public Task<IRabbitMqChannelAdapter> CreateChannelAsync(CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException("Not exercised by these tests.");
     }
 }

--- a/tests/NetEvolve.Pulse.Tests.Unit/RabbitMQ/RabbitMqExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/RabbitMQ/RabbitMqExtensionsTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace NetEvolve.Pulse.Tests.Unit.RabbitMQ;
 
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.Pulse.Extensibility;
@@ -52,6 +53,7 @@ public sealed class RabbitMqExtensionsTests
     public async Task UseRabbitMqTransport_Configures_options()
     {
         IServiceCollection services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config => config.UseRabbitMqTransport(options => options.ExchangeName = "test-exchange"));
 
         var provider = services.BuildServiceProvider();
@@ -65,9 +67,10 @@ public sealed class RabbitMqExtensionsTests
     }
 
     [Test]
-    public async Task UseRabbitMqTransport_Without_configureOptions_registers_default_options()
+    public async Task UseRabbitMqTransport_Without_configureOptions_registers_options()
     {
         IServiceCollection services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config => config.UseRabbitMqTransport());
 
         var provider = services.BuildServiceProvider();
@@ -76,9 +79,10 @@ public sealed class RabbitMqExtensionsTests
             var options =
                 provider.GetRequiredService<Microsoft.Extensions.Options.IOptions<RabbitMqTransportOptions>>();
 
-            // Verify default options are accessible
-            _ = await Assert.That(options.Value).IsNotNull();
-            _ = await Assert.That(options.Value.ExchangeName).IsEqualTo(string.Empty);
+            // The default ExchangeName is empty and therefore invalid; validation runs whenever
+            // the options are resolved (independent of ValidateOnStart, which only forces eager
+            // validation at host startup).
+            _ = Assert.Throws<Microsoft.Extensions.Options.OptionsValidationException>(() => _ = options.Value);
         }
     }
 
@@ -102,6 +106,7 @@ public sealed class RabbitMqExtensionsTests
     public async Task UseRabbitMqTransport_Resolves_channel_pool_from_connection_adapter_and_options()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config =>
             config.UseRabbitMqTransport(options =>
             {

--- a/tests/NetEvolve.Pulse.Tests.Unit/RabbitMQ/RabbitMqMessageTransportDisposeConcurrencyTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/RabbitMQ/RabbitMqMessageTransportDisposeConcurrencyTests.cs
@@ -1,12 +1,9 @@
 namespace NetEvolve.Pulse.Tests.Unit.RabbitMQ;
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using global::RabbitMQ.Client;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.Pulse.Extensibility;
@@ -18,239 +15,104 @@ using TUnit.Assertions.Extensions;
 using TUnit.Core;
 
 /// <summary>
-/// Cross-cutting deep-audit tests (DEEP-E pass) for concurrency invariants on
-/// <see cref="RabbitMqMessageTransport.Dispose"/> in the presence of in-flight
-/// senders. These pin disposal-race semantics that the existing
-/// <c>Dispose_Is_idempotent</c> test (sequential double dispose) does not cover.
+/// Concurrency invariant tests for <see cref="RabbitMqMessageTransport.Dispose"/>. The
+/// transport no longer owns a channel directly (channels are rented from/returned to a
+/// pooled <see cref="IRabbitMqChannelPool"/> that is disposed independently via DI), so
+/// disposal itself only needs to flip a single-shot sentinel safely under concurrency.
 /// </summary>
 [TestGroup("RabbitMQ")]
 [SuppressMessage(
     "Reliability",
     "CA2000:Dispose objects before losing scope",
-    Justification = "Transport is explicitly disposed inside the test bodies as part of the assertion under test."
+    Justification = "Transport disposal is explicitly exercised (and asserted on) inside the test bodies as part of the assertion under test."
 )]
 public sealed class RabbitMqMessageTransportDisposeConcurrencyTests
 {
     /// <summary>
     /// INVARIANT (concurrency / disposal): two threads calling <c>Dispose()</c> at the
-    /// same time must result in the underlying channel being disposed exactly once.
-    /// Currently the implementation uses a plain <c>bool _disposed</c> guard without
-    /// <c>Interlocked.Exchange</c>, so both threads can pass the early-exit check and
-    /// each call <c>_channel?.Dispose()</c>.
+    /// same time must not throw and must leave the transport in the disposed state.
     /// </summary>
     [Test]
-    public async Task Dispose_CalledConcurrently_ChannelDisposedExactlyOnce(CancellationToken cancellationToken)
-    {
-        var connectionAdapter = new FakeConnectionAdapter();
-        var topicNameResolver = new FakeTopicNameResolver();
-        var transport = CreateTransport(connectionAdapter, topicNameResolver);
-        try
-        {
-            // Force a channel to be created so Dispose has work to do.
-            await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false);
-            var channel = connectionAdapter.CreatedChannels[0];
-
-            // Use a barrier so both threads enter Dispose() as close to simultaneously as
-            // possible. We run the test multiple times to make the race observable.
-            const int Iterations = 100;
-            var doubleDisposeSeen = false;
-
-            for (var i = 0; i < Iterations; i++)
-            {
-                channel.ResetDisposeCounter();
-
-                using var barrier = new Barrier(2);
-                void DisposeOnce()
-                {
-                    barrier.SignalAndWait(cancellationToken);
-                    transport.Dispose();
-                }
-
-                var t1 = Task.Run(DisposeOnce, cancellationToken);
-                var t2 = Task.Run(DisposeOnce, cancellationToken);
-                await Task.WhenAll(t1, t2).ConfigureAwait(false);
-
-                if (channel.DisposeCallCount > 1)
-                {
-                    doubleDisposeSeen = true;
-                    break;
-                }
-
-                // The transport is disposed by now. Recreate it for the next iteration.
-                if (i + 1 < Iterations)
-                {
-                    transport.Dispose();
-                    transport = CreateTransport(connectionAdapter, topicNameResolver);
-                    await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false);
-                    channel = connectionAdapter.CreatedChannels[^1];
-                }
-            }
-
-            // The invariant we want: the channel adapter must only be disposed once,
-            // regardless of how many threads call Dispose. If this assertion fails, the
-            // implementation is using a non-atomic _disposed guard and needs
-            // Interlocked.Exchange to be race-safe.
-            _ = await Assert.That(doubleDisposeSeen).IsFalse();
-        }
-        finally
-        {
-            transport.Dispose();
-        }
-    }
-
-    /// <summary>
-    /// INVARIANT (concurrency / disposal): when <c>Dispose()</c> races with an
-    /// in-flight <c>SendAsync</c>, the dispose path must not throw on the disposing
-    /// thread and the in-flight publish must observe the publish gate it was waiting
-    /// for. We do not assert on the publish's terminal exception (it is acceptable
-    /// for the publish to either complete or fault deterministically), only that
-    /// dispose itself stays well-defined.
-    /// </summary>
-    [Test]
-    public async Task Dispose_DuringInFlightSendAsync_DoesNotCorruptInFlightPublish(CancellationToken cancellationToken)
-    {
-        var connectionAdapter = new FakeConnectionAdapter();
-        var topicNameResolver = new FakeTopicNameResolver();
-        var transport = CreateTransport(connectionAdapter, topicNameResolver);
-        try
-        {
-            // Pre-warm the channel.
-            await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false);
-            var channel = connectionAdapter.CreatedChannels[0];
-
-            // Make the next BasicPublishAsync block until we explicitly release it.
-            var publishStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            var releasePublish = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            channel.PublishGate = (start: publishStarted, release: releasePublish);
-
-            var sendTask = Task.Run(
-                async () => await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false),
-                cancellationToken
-            );
-
-            // Wait until BasicPublishAsync has been entered, then call Dispose() from a
-            // different thread while the publish is still in flight.
-            await publishStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
-
-            // Dispose during in-flight publish: must not throw on the disposing thread.
-            Exception? disposeException = null;
-            try
-            {
-                transport.Dispose();
-            }
-#pragma warning disable CA1031 // Test must capture any exception type that Dispose might surface.
-            catch (Exception ex)
-            {
-                disposeException = ex;
-            }
-#pragma warning restore CA1031
-
-            // Release the in-flight publish so the send task can complete.
-            releasePublish.SetResult();
-
-            // The send task should now finish; either successfully (channel ref already
-            // captured) or with a deterministic exception. We only require that it does
-            // not deadlock.
-            try
-            {
-                await sendTask.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
-            }
-#pragma warning disable CA1031, RCS1075
-            catch
-            {
-                // A deterministic post-dispose exception is acceptable; the dispose
-                // thread's behaviour is the invariant under test.
-            }
-#pragma warning restore CA1031, RCS1075
-
-            using (Assert.Multiple())
-            {
-                _ = await Assert.That(disposeException).IsNull();
-                _ = await Assert.That(publishStarted.Task.IsCompletedSuccessfully).IsTrue();
-            }
-        }
-        finally
-        {
-            transport.Dispose();
-        }
-    }
-
-    /// <summary>
-    /// INVARIANT (concurrency / disposal): when <c>Dispose()</c> races a sender that is
-    /// inside <c>EnsureChannelAsync</c> creating a new channel, the freshly created
-    /// channel must not leak (it must end up disposed) and the sender's semaphore
-    /// release must not throw <see cref="ObjectDisposedException"/>. Currently
-    /// <c>Dispose()</c> tears down the semaphore without acquiring it, so the in-flight
-    /// sender's <c>Release()</c> throws and the new channel is orphaned.
-    /// </summary>
-    [Test]
-    public async Task Dispose_DuringInFlightChannelCreation_DisposesNewChannelAndDoesNotThrowOnRelease(
+    public async Task Dispose_CalledConcurrently_DoesNotThrowAndTransportStaysDisposed(
         CancellationToken cancellationToken
     )
     {
-        var connectionAdapter = new FakeConnectionAdapter();
+        var channelPool = new NoOpChannelPool();
         var topicNameResolver = new FakeTopicNameResolver();
-        var transport = CreateTransport(connectionAdapter, topicNameResolver);
+        var transport = CreateTransport(channelPool, topicNameResolver);
+
+        var t1 = Task.Run(transport.Dispose, cancellationToken);
+        var t2 = Task.Run(transport.Dispose, cancellationToken);
+        await Task.WhenAll(t1, t2).ConfigureAwait(false);
+
+        var exception = await Assert.ThrowsAsync<ObjectDisposedException>(() =>
+            transport.SendAsync(CreateOutboxMessage(), cancellationToken)
+        );
+
+        _ = await Assert.That(exception).IsNotNull();
+    }
+
+    /// <summary>
+    /// INVARIANT (concurrency / disposal): calling <c>Dispose()</c> while a
+    /// <c>SendAsync</c> call is in flight (renting/publishing/returning against the pool)
+    /// must not throw on the disposing thread, and the in-flight send must still observe
+    /// the publish gate it was waiting for.
+    /// </summary>
+    [Test]
+    public async Task Dispose_DuringInFlightSendAsync_DoesNotThrow(CancellationToken cancellationToken)
+    {
+        var channelPool = new NoOpChannelPool();
+        var topicNameResolver = new FakeTopicNameResolver();
+        var transport = CreateTransport(channelPool, topicNameResolver);
+
+        var publishStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releasePublish = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        channelPool.PublishGate = (start: publishStarted, release: releasePublish);
+
+        var sendTask = Task.Run(
+            async () => await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false),
+            cancellationToken
+        );
+
+        await publishStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
+
+        Exception? disposeException = null;
         try
-        {
-            // Make the first channel creation block until we explicitly release it.
-            var creationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            var releaseCreation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            connectionAdapter.CreationGate = (start: creationStarted, release: releaseCreation);
-
-            var sendTask = Task.Run(
-                async () => await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false),
-                cancellationToken
-            );
-
-            // Wait until the sender is inside EnsureChannelAsync, holding the
-            // initialization lock and awaiting channel creation.
-            await creationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
-
-            var disposeTask = Task.Run(transport.Dispose, cancellationToken);
-
-            // Give an unguarded Dispose implementation time to complete while the
-            // channel creation is still in flight, then let the creation finish.
-            _ = await Task.WhenAny(disposeTask, Task.Delay(500, cancellationToken)).ConfigureAwait(false);
-            releaseCreation.SetResult();
-
-            Exception? sendException = null;
-            try
-            {
-                await sendTask.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
-            }
-#pragma warning disable CA1031 // Test must capture any exception type that SendAsync might surface.
-            catch (Exception ex)
-            {
-                sendException = ex;
-            }
-#pragma warning restore CA1031
-
-            await disposeTask.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
-
-            var createdChannel = connectionAdapter.CreatedChannels[0];
-            using (Assert.Multiple())
-            {
-                // The channel created concurrently with Dispose must not leak.
-                _ = await Assert.That(createdChannel.DisposeCallCount).IsGreaterThan(0);
-                // The sender's semaphore release must not observe a disposed semaphore.
-                _ = await Assert.That(sendException is ObjectDisposedException).IsFalse();
-            }
-        }
-        finally
         {
             transport.Dispose();
         }
+#pragma warning disable CA1031 // Test must capture any exception type that Dispose might surface.
+        catch (Exception ex)
+        {
+            disposeException = ex;
+        }
+#pragma warning restore CA1031
+
+        releasePublish.SetResult();
+
+        try
+        {
+            await sendTask.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
+        }
+#pragma warning disable CA1031, RCS1075
+        catch
+        {
+            // A deterministic post-dispose exception is acceptable; only the dispose
+            // thread's own behavior is under test here.
+        }
+#pragma warning restore CA1031, RCS1075
+
+        _ = await Assert.That(disposeException).IsNull();
     }
 
     private static RabbitMqMessageTransport CreateTransport(
-        IRabbitMqConnectionAdapter connectionAdapter,
+        IRabbitMqChannelPool channelPool,
         ITopicNameResolver topicNameResolver,
         string exchangeName = "events"
     )
     {
         var options = Options.Create(new RabbitMqTransportOptions { ExchangeName = exchangeName });
-        return new RabbitMqMessageTransport(connectionAdapter, topicNameResolver, options);
+        return new RabbitMqMessageTransport(channelPool, topicNameResolver, options);
     }
 
     private static OutboxMessage CreateOutboxMessage() =>
@@ -277,42 +139,22 @@ public sealed class RabbitMqMessageTransportDisposeConcurrencyTests
         public DateTimeOffset? PublishedAt { get; set; }
     }
 
-    private sealed class FakeConnectionAdapter : IRabbitMqConnectionAdapter
+    private sealed class NoOpChannelPool : IRabbitMqChannelPool
     {
-        public bool IsOpen { get; set; } = true;
-
-        public List<FakeChannelAdapter> CreatedChannels { get; } = [];
-
-        public (TaskCompletionSource start, TaskCompletionSource release)? CreationGate { get; set; }
-
-        public async Task<IRabbitMqChannelAdapter> CreateChannelAsync(CancellationToken cancellationToken = default)
-        {
-            if (CreationGate is { } gate)
-            {
-                CreationGate = null;
-                _ = gate.start.TrySetResult();
-#pragma warning disable VSTHRD003 // TaskCompletionSource gate is signaled by the test, not started here
-                await gate.release.Task.ConfigureAwait(false);
-#pragma warning restore VSTHRD003
-            }
-
-            var channel = new FakeChannelAdapter();
-            CreatedChannels.Add(channel);
-            return channel;
-        }
-    }
-
-    private sealed class FakeChannelAdapter : IRabbitMqChannelAdapter
-    {
-        private int _disposeCallCount;
-
-        public bool IsOpen { get; set; } = true;
-
-        public int DisposeCallCount => Volatile.Read(ref _disposeCallCount);
-
         public (TaskCompletionSource start, TaskCompletionSource release)? PublishGate { get; set; }
 
-        public void ResetDisposeCounter() => Volatile.Write(ref _disposeCallCount, 0);
+        public ValueTask<IRabbitMqChannelAdapter> RentAsync(CancellationToken cancellationToken) =>
+            ValueTask.FromResult<IRabbitMqChannelAdapter>(new FakeChannelAdapter(PublishGate));
+
+        public void Return(IRabbitMqChannelAdapter channel) { }
+
+        public Task<bool> IsHealthyAsync(CancellationToken cancellationToken) => Task.FromResult(true);
+    }
+
+    private sealed class FakeChannelAdapter((TaskCompletionSource start, TaskCompletionSource release)? publishGate)
+        : IRabbitMqChannelAdapter
+    {
+        public bool IsOpen { get; set; } = true;
 
         public async ValueTask BasicPublishAsync<TProperties>(
             string exchange,
@@ -322,9 +164,9 @@ public sealed class RabbitMqMessageTransportDisposeConcurrencyTests
             ReadOnlyMemory<byte> body,
             CancellationToken cancellationToken = default
         )
-            where TProperties : IReadOnlyBasicProperties, IAmqpHeader
+            where TProperties : global::RabbitMQ.Client.IReadOnlyBasicProperties, global::RabbitMQ.Client.IAmqpHeader
         {
-            if (PublishGate is { } gate)
+            if (publishGate is { } gate)
             {
                 _ = gate.start.TrySetResult();
 #pragma warning disable VSTHRD003 // TaskCompletionSource gate is signaled by the test, not started here
@@ -333,6 +175,6 @@ public sealed class RabbitMqMessageTransportDisposeConcurrencyTests
             }
         }
 
-        public void Dispose() => Interlocked.Increment(ref _disposeCallCount);
+        public void Dispose() { }
     }
 }

--- a/tests/NetEvolve.Pulse.Tests.Unit/RabbitMQ/RabbitMqMessageTransportPublishConcurrencyTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/RabbitMQ/RabbitMqMessageTransportPublishConcurrencyTests.cs
@@ -2,6 +2,7 @@ namespace NetEvolve.Pulse.Tests.Unit.RabbitMQ;
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using global::RabbitMQ.Client;
@@ -16,38 +17,29 @@ using TUnit.Assertions.Extensions;
 using TUnit.Core;
 
 /// <summary>
-/// Concurrency invariant tests for publish serialization on
-/// <see cref="RabbitMqMessageTransport"/>. RabbitMQ.Client's <see cref="IChannel"/> is
-/// NOT thread-safe for concurrent publish calls, so the transport must never allow two
-/// publishes to be in flight on the shared channel at the same time.
+/// Concurrency invariant tests for <see cref="RabbitMqMessageTransport"/> publishing
+/// through a channel pool. Unlike the previous single-shared-channel design, concurrent
+/// <c>SendAsync</c> calls are now expected to run on separate, independently rented
+/// channels rather than being serialized on one.
 /// </summary>
 [TestGroup("RabbitMQ")]
 public sealed class RabbitMqMessageTransportPublishConcurrencyTests
 {
     /// <summary>
-    /// INVARIANT (thread-safety): two concurrent <c>SendAsync</c> calls on the singleton
-    /// transport must be serialized onto the shared channel. The first publish is gated
-    /// open; if the transport does not serialize publishes, the second call enters
-    /// <c>BasicPublishAsync</c> while the first is still in flight and the fake channel
-    /// observes two concurrent publishes.
+    /// INVARIANT (pooling): two concurrent <c>SendAsync</c> calls rent distinct channels
+    /// from the pool (up to the pool's capacity) instead of contending for a single shared
+    /// channel, and each rented channel is returned back to the pool exactly once.
     /// </summary>
     [Test]
-    public async Task SendAsync_ConcurrentCalls_PublishesAreSerializedOnSharedChannel(
-        CancellationToken cancellationToken
-    )
+    public async Task SendAsync_ConcurrentCalls_RentSeparateChannelsFromPool(CancellationToken cancellationToken)
     {
-        var connectionAdapter = new FakeConnectionAdapter();
+        var channelPool = new GatingChannelPool();
         var topicNameResolver = new FakeTopicNameResolver();
-        using var transport = CreateTransport(connectionAdapter, topicNameResolver);
+        using var transport = CreateTransport(channelPool, topicNameResolver);
 
-        // Pre-warm the channel so both sends reuse the same instance.
-        await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false);
-        var channel = connectionAdapter.CreatedChannels[0];
-
-        // Gate the next publish so it stays in flight until we release it.
         var firstPublishEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseFirstPublish = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        channel.GateNextPublish(firstPublishEntered, releaseFirstPublish);
+        channelPool.GateNextRentedChannelPublish(firstPublishEntered, releaseFirstPublish);
 
         var send1 = Task.Run(
             async () => await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false),
@@ -56,81 +48,28 @@ public sealed class RabbitMqMessageTransportPublishConcurrencyTests
 
         await firstPublishEntered.Task.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
 
-        // Second send while the first publish is still in flight on the same channel.
-        var send2 = Task.Run(
-            async () => await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false),
-            cancellationToken
-        );
-
-        // On an unserialized transport, the second publish enters BasicPublishAsync almost
-        // immediately. Give it a generous window to do so before releasing the gate.
-#pragma warning disable VSTHRD003 // Observation task is signaled by the fake channel, not started here
-        _ = await Task.WhenAny(channel.SecondConcurrentPublishObserved, Task.Delay(500, cancellationToken))
-            .ConfigureAwait(false);
-#pragma warning restore VSTHRD003
+        // Second send while the first publish is still in flight on its own channel.
+        await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false);
 
         releaseFirstPublish.SetResult();
-        await Task.WhenAll(send1, send2).WaitAsync(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
+        await send1.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
 
-        _ = await Assert.That(channel.MaxConcurrentPublishes).IsEqualTo(1);
-    }
-
-    /// <summary>
-    /// INVARIANT (thread-safety): a <c>SendAsync</c> racing a <c>SendBatchAsync</c> must
-    /// not publish on the shared channel while a batch publish is in flight.
-    /// </summary>
-    [Test]
-    public async Task SendAsync_RacingSendBatchAsync_PublishesAreSerializedOnSharedChannel(
-        CancellationToken cancellationToken
-    )
-    {
-        var connectionAdapter = new FakeConnectionAdapter();
-        var topicNameResolver = new FakeTopicNameResolver();
-        using var transport = CreateTransport(connectionAdapter, topicNameResolver);
-
-        await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false);
-        var channel = connectionAdapter.CreatedChannels[0];
-
-        var batchPublishEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var releaseBatchPublish = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        channel.GateNextPublish(batchPublishEntered, releaseBatchPublish);
-
-        var batchTask = Task.Run(
-            async () =>
-                await transport
-                    .SendBatchAsync([CreateOutboxMessage(), CreateOutboxMessage()], cancellationToken)
-                    .ConfigureAwait(false),
-            cancellationToken
-        );
-
-        await batchPublishEntered.Task.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
-
-        var sendTask = Task.Run(
-            async () => await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false),
-            cancellationToken
-        );
-
-#pragma warning disable VSTHRD003 // Observation task is signaled by the fake channel, not started here
-        _ = await Task.WhenAny(channel.SecondConcurrentPublishObserved, Task.Delay(500, cancellationToken))
-            .ConfigureAwait(false);
-#pragma warning restore VSTHRD003
-
-        releaseBatchPublish.SetResult();
-        await Task.WhenAll(batchTask, sendTask)
-            .WaitAsync(TimeSpan.FromSeconds(5), cancellationToken)
-            .ConfigureAwait(false);
-
-        _ = await Assert.That(channel.MaxConcurrentPublishes).IsEqualTo(1);
+        using (Assert.Multiple())
+        {
+            // Two separate channels were rented, one per concurrent call.
+            _ = await Assert.That(channelPool.RentCallCount).IsEqualTo(2);
+            _ = await Assert.That(channelPool.ReturnCallCount).IsEqualTo(2);
+        }
     }
 
     private static RabbitMqMessageTransport CreateTransport(
-        IRabbitMqConnectionAdapter connectionAdapter,
+        IRabbitMqChannelPool channelPool,
         ITopicNameResolver topicNameResolver,
         string exchangeName = "events"
     )
     {
         var options = Options.Create(new RabbitMqTransportOptions { ExchangeName = exchangeName });
-        return new RabbitMqMessageTransport(connectionAdapter, topicNameResolver, options);
+        return new RabbitMqMessageTransport(channelPool, topicNameResolver, options);
     }
 
     private static OutboxMessage CreateOutboxMessage() =>
@@ -157,38 +96,53 @@ public sealed class RabbitMqMessageTransportPublishConcurrencyTests
         public DateTimeOffset? PublishedAt { get; set; }
     }
 
-    private sealed class FakeConnectionAdapter : IRabbitMqConnectionAdapter
+    [SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "FakeChannelAdapter is a test double with no unmanaged resources; ownership is transferred to the caller via RentAsync."
+    )]
+    private sealed class GatingChannelPool : IRabbitMqChannelPool
     {
-        public bool IsOpen { get; set; } = true;
-
-        public List<FakeChannelAdapter> CreatedChannels { get; } = [];
-
-        public Task<IRabbitMqChannelAdapter> CreateChannelAsync(CancellationToken cancellationToken = default)
-        {
-            var channel = new FakeChannelAdapter();
-            CreatedChannels.Add(channel);
-            return Task.FromResult<IRabbitMqChannelAdapter>(channel);
-        }
-    }
-
-    private sealed class FakeChannelAdapter : IRabbitMqChannelAdapter
-    {
-        private readonly TaskCompletionSource _secondConcurrentPublishObserved = new(
-            TaskCreationOptions.RunContinuationsAsynchronously
-        );
-
-        private int _activePublishes;
-        private int _maxConcurrentPublishes;
+        private readonly object _gateLock = new();
+        private int _rentCallCount;
+        private int _returnCallCount;
         private (TaskCompletionSource entered, TaskCompletionSource release)? _publishGate;
 
+        public int RentCallCount => Volatile.Read(ref _rentCallCount);
+
+        public int ReturnCallCount => Volatile.Read(ref _returnCallCount);
+
+        public void GateNextRentedChannelPublish(TaskCompletionSource entered, TaskCompletionSource release)
+        {
+            lock (_gateLock)
+            {
+                _publishGate = (entered, release);
+            }
+        }
+
+        public ValueTask<IRabbitMqChannelAdapter> RentAsync(CancellationToken cancellationToken)
+        {
+            _ = Interlocked.Increment(ref _rentCallCount);
+
+            (TaskCompletionSource entered, TaskCompletionSource release)? gate;
+            lock (_gateLock)
+            {
+                gate = _publishGate;
+                _publishGate = null;
+            }
+
+            return ValueTask.FromResult<IRabbitMqChannelAdapter>(new FakeChannelAdapter(gate));
+        }
+
+        public void Return(IRabbitMqChannelAdapter channel) => Interlocked.Increment(ref _returnCallCount);
+
+        public Task<bool> IsHealthyAsync(CancellationToken cancellationToken) => Task.FromResult(true);
+    }
+
+    private sealed class FakeChannelAdapter((TaskCompletionSource entered, TaskCompletionSource release)? publishGate)
+        : IRabbitMqChannelAdapter
+    {
         public bool IsOpen { get; set; } = true;
-
-        public int MaxConcurrentPublishes => Volatile.Read(ref _maxConcurrentPublishes);
-
-        public Task SecondConcurrentPublishObserved => _secondConcurrentPublishObserved.Task;
-
-        public void GateNextPublish(TaskCompletionSource entered, TaskCompletionSource release) =>
-            _publishGate = (entered, release);
 
         public async ValueTask BasicPublishAsync<TProperties>(
             string exchange,
@@ -200,34 +154,12 @@ public sealed class RabbitMqMessageTransportPublishConcurrencyTests
         )
             where TProperties : IReadOnlyBasicProperties, IAmqpHeader
         {
-            var current = Interlocked.Increment(ref _activePublishes);
-            try
+            if (publishGate is { } gate)
             {
-                int max;
-                do
-                {
-                    max = Volatile.Read(ref _maxConcurrentPublishes);
-                } while (
-                    current > max && Interlocked.CompareExchange(ref _maxConcurrentPublishes, current, max) != max
-                );
-
-                if (current > 1)
-                {
-                    _ = _secondConcurrentPublishObserved.TrySetResult();
-                }
-
-                if (_publishGate is { } gate)
-                {
-                    _publishGate = null;
-                    _ = gate.entered.TrySetResult();
+                _ = gate.entered.TrySetResult();
 #pragma warning disable VSTHRD003 // TaskCompletionSource gate is signaled by the test, not started here
-                    await gate.release.Task.ConfigureAwait(false);
+                await gate.release.Task.ConfigureAwait(false);
 #pragma warning restore VSTHRD003
-                }
-            }
-            finally
-            {
-                _ = Interlocked.Decrement(ref _activePublishes);
             }
         }
 

--- a/tests/NetEvolve.Pulse.Tests.Unit/RabbitMQ/RabbitMqMessageTransportTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/RabbitMQ/RabbitMqMessageTransportTests.cs
@@ -1,4 +1,4 @@
-﻿namespace NetEvolve.Pulse.Tests.Unit.RabbitMQ;
+namespace NetEvolve.Pulse.Tests.Unit.RabbitMQ;
 
 using System.Linq;
 using System.Text;
@@ -16,29 +16,29 @@ using TUnit.Core;
 public sealed class RabbitMqMessageTransportTests
 {
     [Test]
-    public async Task Constructor_When_connectionAdapter_null_throws()
+    public async Task Constructor_When_channelPool_null_throws()
     {
-        IRabbitMqConnectionAdapter connectionAdapter = null!;
+        IRabbitMqChannelPool channelPool = null!;
         var topicNameResolver = new FakeTopicNameResolver();
         var options = CreateOptions();
 
         var exception = Assert.Throws<ArgumentNullException>(() =>
-            _ = new RabbitMqMessageTransport(connectionAdapter, topicNameResolver, options)
+            _ = new RabbitMqMessageTransport(channelPool, topicNameResolver, options)
         );
 
         _ = await Assert.That(exception).IsNotNull();
-        _ = await Assert.That(exception.ParamName).IsEqualTo("connectionAdapter");
+        _ = await Assert.That(exception.ParamName).IsEqualTo("channelPool");
     }
 
     [Test]
     public async Task Constructor_When_topicNameResolver_null_throws()
     {
-        var connectionAdapter = new FakeConnectionAdapter();
+        var channelPool = new FakeChannelPool();
         ITopicNameResolver topicNameResolver = null!;
         var options = CreateOptions();
 
         var exception = Assert.Throws<ArgumentNullException>(() =>
-            _ = new RabbitMqMessageTransport(connectionAdapter, topicNameResolver, options)
+            _ = new RabbitMqMessageTransport(channelPool, topicNameResolver, options)
         );
 
         _ = await Assert.That(exception).IsNotNull();
@@ -48,12 +48,12 @@ public sealed class RabbitMqMessageTransportTests
     [Test]
     public async Task Constructor_When_options_null_throws()
     {
-        var connectionAdapter = new FakeConnectionAdapter();
+        var channelPool = new FakeChannelPool();
         var topicNameResolver = new FakeTopicNameResolver();
         IOptions<RabbitMqTransportOptions> options = null!;
 
         var exception = Assert.Throws<ArgumentNullException>(() =>
-            _ = new RabbitMqMessageTransport(connectionAdapter, topicNameResolver, options)
+            _ = new RabbitMqMessageTransport(channelPool, topicNameResolver, options)
         );
 
         _ = await Assert.That(exception).IsNotNull();
@@ -63,9 +63,9 @@ public sealed class RabbitMqMessageTransportTests
     [Test]
     public async Task SendAsync_When_message_null_throws(CancellationToken cancellationToken)
     {
-        var connectionAdapter = new FakeConnectionAdapter();
+        var channelPool = new FakeChannelPool();
         var topicNameResolver = new FakeTopicNameResolver();
-        using var transport = CreateTransport(connectionAdapter, topicNameResolver);
+        using var transport = CreateTransport(channelPool, topicNameResolver);
 
         var exception = await Assert.ThrowsAsync<ArgumentNullException>(() =>
             transport.SendAsync(null!, cancellationToken)
@@ -78,15 +78,15 @@ public sealed class RabbitMqMessageTransportTests
     [Test]
     public async Task SendAsync_Publishes_message_with_correct_properties(CancellationToken cancellationToken)
     {
-        var connectionAdapter = new FakeConnectionAdapter();
+        var channelPool = new FakeChannelPool();
         var topicNameResolver = new FakeTopicNameResolver();
-        using var transport = CreateTransport(connectionAdapter, topicNameResolver, exchangeName: "test-exchange");
+        using var transport = CreateTransport(channelPool, topicNameResolver, exchangeName: "test-exchange");
         var outboxMessage = CreateOutboxMessage();
 
         await transport.SendAsync(outboxMessage, cancellationToken).ConfigureAwait(false);
 
-        _ = await Assert.That(connectionAdapter.CreateChannelCallCount).IsEqualTo(1);
-        var channel = connectionAdapter.CreatedChannels.Single();
+        _ = await Assert.That(channelPool.RentCallCount).IsEqualTo(1);
+        var channel = channelPool.RentedChannels.Single();
         _ = await Assert.That(channel.PublishCallCount).IsEqualTo(1);
 
         var publishCall = channel.PublishCalls.Single();
@@ -111,151 +111,111 @@ public sealed class RabbitMqMessageTransportTests
     }
 
     [Test]
-    public async Task SendAsync_Reuses_open_channel(CancellationToken cancellationToken)
+    public async Task SendAsync_Returns_channel_to_pool_after_publish(CancellationToken cancellationToken)
     {
-        var connectionAdapter = new FakeConnectionAdapter();
+        var channelPool = new FakeChannelPool();
         var topicNameResolver = new FakeTopicNameResolver();
-        using var transport = CreateTransport(connectionAdapter, topicNameResolver);
+        using var transport = CreateTransport(channelPool, topicNameResolver);
         var message1 = CreateOutboxMessage();
         var message2 = CreateOutboxMessage();
 
         await transport.SendAsync(message1, cancellationToken).ConfigureAwait(false);
         await transport.SendAsync(message2, cancellationToken).ConfigureAwait(false);
 
-        _ = await Assert.That(connectionAdapter.CreateChannelCallCount).IsEqualTo(1);
-        var channel = connectionAdapter.CreatedChannels.Single();
-        _ = await Assert.That(channel.PublishCallCount).IsEqualTo(2);
+        _ = await Assert.That(channelPool.RentCallCount).IsEqualTo(2);
+        _ = await Assert.That(channelPool.ReturnCallCount).IsEqualTo(2);
     }
 
     [Test]
-    public async Task SendAsync_Creates_new_channel_when_previous_closed(CancellationToken cancellationToken)
+    public async Task SendAsync_Returns_channel_even_when_publish_throws(CancellationToken cancellationToken)
     {
-        var connectionAdapter = new FakeConnectionAdapter();
+        var channelPool = new FakeChannelPool();
         var topicNameResolver = new FakeTopicNameResolver();
-        using var transport = CreateTransport(connectionAdapter, topicNameResolver);
-        var message1 = CreateOutboxMessage();
-        var message2 = CreateOutboxMessage();
+        using var transport = CreateTransport(channelPool, topicNameResolver);
 
-        await transport.SendAsync(message1, cancellationToken).ConfigureAwait(false);
-        var firstChannel = connectionAdapter.CreatedChannels.Single();
-        firstChannel.IsOpen = false; // Simulate channel closure
+        channelPool.NextRentedChannelThrowsOnPublish = true;
 
-        await transport.SendAsync(message2, cancellationToken).ConfigureAwait(false);
+        _ = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            transport.SendAsync(CreateOutboxMessage(), cancellationToken)
+        );
 
-        _ = await Assert.That(connectionAdapter.CreateChannelCallCount).IsEqualTo(2);
-        _ = await Assert.That(connectionAdapter.CreatedChannels.Count).IsEqualTo(2);
+        _ = await Assert.That(channelPool.RentCallCount).IsEqualTo(1);
+        _ = await Assert.That(channelPool.ReturnCallCount).IsEqualTo(1);
     }
 
-    // INVARIANT (resource lifecycle): when a previously-created channel has closed and a
-    // new channel must be acquired, the closed channel MUST be disposed. Overwriting the
-    // reference without disposal leaks unmanaged RabbitMQ.Client channel resources.
     [Test]
-    public async Task SendAsync_Disposes_closed_channel_before_creating_new_one(CancellationToken cancellationToken)
-    {
-        var connectionAdapter = new FakeConnectionAdapter();
-        var topicNameResolver = new FakeTopicNameResolver();
-        using var transport = CreateTransport(connectionAdapter, topicNameResolver);
-
-        await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false);
-        var firstChannel = connectionAdapter.CreatedChannels.Single();
-        firstChannel.IsOpen = false; // Simulate channel closure
-
-        await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false);
-
-        // The first (closed) channel must have been disposed before the new one was created.
-        _ = await Assert.That(firstChannel.DisposeCalled).IsTrue();
-        _ = await Assert.That(connectionAdapter.CreatedChannels.Count).IsEqualTo(2);
-    }
-
-    // INVARIANT (thread-safety): SendBatchAsync MUST publish sequentially on the shared
-    // channel. RabbitMQ.Client IChannel is NOT thread-safe; concurrent BasicPublishAsync
-    // calls are unsupported and can corrupt the AMQP frame stream.
-    [Test]
-    public async Task SendBatchAsync_Publishes_messages_sequentially_on_shared_channel(
+    public async Task SendBatchAsync_Rents_single_channel_and_publishes_sequentially(
         CancellationToken cancellationToken
     )
     {
-        var connectionAdapter = new FakeConnectionAdapter();
+        var channelPool = new FakeChannelPool();
         var topicNameResolver = new FakeTopicNameResolver();
-        using var transport = CreateTransport(connectionAdapter, topicNameResolver, exchangeName: "batch-ex");
+        using var transport = CreateTransport(channelPool, topicNameResolver, exchangeName: "batch-ex");
 
         var messages = Enumerable.Range(0, 5).Select(_ => CreateOutboxMessage()).ToArray();
         await transport.SendBatchAsync(messages, cancellationToken).ConfigureAwait(false);
 
-        // Exactly one channel created and reused; all publishes routed through it.
-        _ = await Assert.That(connectionAdapter.CreateChannelCallCount).IsEqualTo(1);
-        var channel = connectionAdapter.CreatedChannels.Single();
+        // Exactly one channel rented for the whole batch and returned afterwards.
+        _ = await Assert.That(channelPool.RentCallCount).IsEqualTo(1);
+        _ = await Assert.That(channelPool.ReturnCallCount).IsEqualTo(1);
+        var channel = channelPool.RentedChannels.Single();
         _ = await Assert.That(channel.PublishCallCount).IsEqualTo(messages.Length);
         // All routed to the configured exchange.
         _ = await Assert.That(channel.PublishCalls.All(p => p.Exchange == "batch-ex")).IsTrue();
     }
 
     [Test]
+    public async Task SendBatchAsync_Returns_channel_even_when_publish_throws(CancellationToken cancellationToken)
+    {
+        var channelPool = new FakeChannelPool();
+        var topicNameResolver = new FakeTopicNameResolver();
+        using var transport = CreateTransport(channelPool, topicNameResolver);
+
+        channelPool.NextRentedChannelThrowsOnPublish = true;
+
+        _ = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            transport.SendBatchAsync([CreateOutboxMessage()], cancellationToken)
+        );
+
+        _ = await Assert.That(channelPool.RentCallCount).IsEqualTo(1);
+        _ = await Assert.That(channelPool.ReturnCallCount).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task SendAsync_Uses_topic_name_resolver_for_routing_key(CancellationToken cancellationToken)
     {
-        var connectionAdapter = new FakeConnectionAdapter();
+        var channelPool = new FakeChannelPool();
         var topicNameResolver = new FakeTopicNameResolver { ResolvedName = "custom-routing-key" };
-        using var transport = CreateTransport(connectionAdapter, topicNameResolver);
+        using var transport = CreateTransport(channelPool, topicNameResolver);
         var outboxMessage = CreateOutboxMessage();
 
         await transport.SendAsync(outboxMessage, cancellationToken).ConfigureAwait(false);
 
-        var channel = connectionAdapter.CreatedChannels.Single();
+        var channel = channelPool.RentedChannels.Single();
         var publishCall = channel.PublishCalls.Single();
         _ = await Assert.That(publishCall.RoutingKey).IsEqualTo("custom-routing-key");
         _ = await Assert.That(topicNameResolver.ResolveCallCount).IsEqualTo(1);
     }
 
     [Test]
-    public async Task IsHealthyAsync_When_connection_not_open_returns_false(CancellationToken cancellationToken)
+    public async Task IsHealthyAsync_Delegates_to_channel_pool(CancellationToken cancellationToken)
     {
-        var connectionAdapter = new FakeConnectionAdapter { IsOpen = false };
+        var channelPool = new FakeChannelPool { Healthy = false };
         var topicNameResolver = new FakeTopicNameResolver();
-        using var transport = CreateTransport(connectionAdapter, topicNameResolver);
+        using var transport = CreateTransport(channelPool, topicNameResolver);
 
         var healthy = await transport.IsHealthyAsync(cancellationToken).ConfigureAwait(false);
 
         _ = await Assert.That(healthy).IsFalse();
+        _ = await Assert.That(channelPool.IsHealthyCallCount).IsEqualTo(1);
     }
 
     [Test]
-    public async Task IsHealthyAsync_When_channel_not_created_returns_false(CancellationToken cancellationToken)
+    public async Task IsHealthyAsync_When_pool_reports_healthy_returns_true(CancellationToken cancellationToken)
     {
-        var connectionAdapter = new FakeConnectionAdapter { IsOpen = true };
+        var channelPool = new FakeChannelPool { Healthy = true };
         var topicNameResolver = new FakeTopicNameResolver();
-        using var transport = CreateTransport(connectionAdapter, topicNameResolver);
-
-        var healthy = await transport.IsHealthyAsync(cancellationToken).ConfigureAwait(false);
-
-        _ = await Assert.That(healthy).IsFalse();
-    }
-
-    [Test]
-    public async Task IsHealthyAsync_When_channel_not_open_returns_false(CancellationToken cancellationToken)
-    {
-        var connectionAdapter = new FakeConnectionAdapter { IsOpen = true };
-        var topicNameResolver = new FakeTopicNameResolver();
-        using var transport = CreateTransport(connectionAdapter, topicNameResolver);
-
-        // Create a channel
-        await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false);
-        var channel = connectionAdapter.CreatedChannels.Single();
-        channel.IsOpen = false;
-
-        var healthy = await transport.IsHealthyAsync(cancellationToken).ConfigureAwait(false);
-
-        _ = await Assert.That(healthy).IsFalse();
-    }
-
-    [Test]
-    public async Task IsHealthyAsync_When_connection_and_channel_open_returns_true(CancellationToken cancellationToken)
-    {
-        var connectionAdapter = new FakeConnectionAdapter { IsOpen = true };
-        var topicNameResolver = new FakeTopicNameResolver();
-        using var transport = CreateTransport(connectionAdapter, topicNameResolver);
-
-        // Create a channel
-        await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false);
+        using var transport = CreateTransport(channelPool, topicNameResolver);
 
         var healthy = await transport.IsHealthyAsync(cancellationToken).ConfigureAwait(false);
 
@@ -265,9 +225,9 @@ public sealed class RabbitMqMessageTransportTests
     [Test]
     public async Task IsHealthyAsync_When_exception_thrown_returns_false(CancellationToken cancellationToken)
     {
-        var connectionAdapter = new FakeConnectionAdapter { IsOpen = true, ThrowOnIsOpen = true };
+        var channelPool = new FakeChannelPool { ThrowOnIsHealthyAsync = true };
         var topicNameResolver = new FakeTopicNameResolver();
-        using var transport = CreateTransport(connectionAdapter, topicNameResolver);
+        using var transport = CreateTransport(channelPool, topicNameResolver);
 
         var healthy = await transport.IsHealthyAsync(cancellationToken).ConfigureAwait(false);
 
@@ -275,34 +235,18 @@ public sealed class RabbitMqMessageTransportTests
     }
 
     [Test]
-    public async Task Dispose_Disposes_channel_and_lock(CancellationToken cancellationToken)
+    public async Task Dispose_Is_idempotent()
     {
-        var connectionAdapter = new FakeConnectionAdapter();
+        var channelPool = new FakeChannelPool();
         var topicNameResolver = new FakeTopicNameResolver();
-        using var transport = CreateTransport(connectionAdapter, topicNameResolver);
-
-        await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false);
-        var channel = connectionAdapter.CreatedChannels.Single();
-
-        transport.Dispose();
-
-        _ = await Assert.That(channel.DisposeCalled).IsTrue();
-    }
-
-    [Test]
-    public async Task Dispose_Is_idempotent(CancellationToken cancellationToken)
-    {
-        var connectionAdapter = new FakeConnectionAdapter();
-        var topicNameResolver = new FakeTopicNameResolver();
-        var transport = CreateTransport(connectionAdapter, topicNameResolver);
-
-        await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false);
-        var channel = connectionAdapter.CreatedChannels.Single();
+        var transport = CreateTransport(channelPool, topicNameResolver);
 
         transport.Dispose();
         transport.Dispose();
 
-        _ = await Assert.That(channel.DisposeCallCount).IsEqualTo(1);
+        // Dispose does not touch the pool (owned/disposed separately by DI); it must
+        // simply be safe to call multiple times.
+        await Task.CompletedTask;
     }
 
     // ── Post-dispose contract (DEEP-G-01) ─────────────────────────────────────
@@ -310,9 +254,9 @@ public sealed class RabbitMqMessageTransportTests
     [Test]
     public async Task SendAsync_After_Dispose_Throws_ObjectDisposedException(CancellationToken cancellationToken)
     {
-        var connectionAdapter = new FakeConnectionAdapter();
+        var channelPool = new FakeChannelPool();
         var topicNameResolver = new FakeTopicNameResolver();
-        var transport = CreateTransport(connectionAdapter, topicNameResolver);
+        var transport = CreateTransport(channelPool, topicNameResolver);
 
         transport.Dispose();
 
@@ -326,9 +270,9 @@ public sealed class RabbitMqMessageTransportTests
     [Test]
     public async Task SendBatchAsync_After_Dispose_Throws_ObjectDisposedException(CancellationToken cancellationToken)
     {
-        var connectionAdapter = new FakeConnectionAdapter();
+        var channelPool = new FakeChannelPool();
         var topicNameResolver = new FakeTopicNameResolver();
-        var transport = CreateTransport(connectionAdapter, topicNameResolver);
+        var transport = CreateTransport(channelPool, topicNameResolver);
 
         transport.Dispose();
 
@@ -344,9 +288,9 @@ public sealed class RabbitMqMessageTransportTests
     {
         // Health probes typically run during shutdown; disposed transports must report unhealthy
         // rather than throwing so the probe path stays observable.
-        var connectionAdapter = new FakeConnectionAdapter();
+        var channelPool = new FakeChannelPool { Healthy = true };
         var topicNameResolver = new FakeTopicNameResolver();
-        var transport = CreateTransport(connectionAdapter, topicNameResolver);
+        var transport = CreateTransport(channelPool, topicNameResolver);
 
         transport.Dispose();
 
@@ -360,9 +304,9 @@ public sealed class RabbitMqMessageTransportTests
     {
         // ArgumentNullException must take precedence over ObjectDisposedException because
         // the order of checks pins the public contract for callers passing bad arguments.
-        var connectionAdapter = new FakeConnectionAdapter();
+        var channelPool = new FakeChannelPool();
         var topicNameResolver = new FakeTopicNameResolver();
-        var transport = CreateTransport(connectionAdapter, topicNameResolver);
+        var transport = CreateTransport(channelPool, topicNameResolver);
 
         transport.Dispose();
 
@@ -377,9 +321,9 @@ public sealed class RabbitMqMessageTransportTests
     [Test]
     public async Task SendBatchAsync_When_messages_null_throws(CancellationToken cancellationToken)
     {
-        var connectionAdapter = new FakeConnectionAdapter();
+        var channelPool = new FakeChannelPool();
         var topicNameResolver = new FakeTopicNameResolver();
-        using var transport = CreateTransport(connectionAdapter, topicNameResolver);
+        using var transport = CreateTransport(channelPool, topicNameResolver);
 
         var exception = await Assert.ThrowsAsync<ArgumentNullException>(() =>
             transport.SendBatchAsync(null!, cancellationToken)
@@ -392,15 +336,15 @@ public sealed class RabbitMqMessageTransportTests
     [Test]
     public async Task SendBatchAsync_Publishes_all_messages_with_correct_properties(CancellationToken cancellationToken)
     {
-        var connectionAdapter = new FakeConnectionAdapter();
+        var channelPool = new FakeChannelPool();
         var topicNameResolver = new FakeTopicNameResolver();
-        using var transport = CreateTransport(connectionAdapter, topicNameResolver, exchangeName: "test-exchange");
+        using var transport = CreateTransport(channelPool, topicNameResolver, exchangeName: "test-exchange");
         var messages = new[] { CreateOutboxMessage(), CreateOutboxMessage(), CreateOutboxMessage() };
 
         await transport.SendBatchAsync(messages, cancellationToken).ConfigureAwait(false);
 
-        _ = await Assert.That(connectionAdapter.CreateChannelCallCount).IsEqualTo(1);
-        var channel = connectionAdapter.CreatedChannels.Single();
+        _ = await Assert.That(channelPool.RentCallCount).IsEqualTo(1);
+        var channel = channelPool.RentedChannels.Single();
         _ = await Assert.That(channel.PublishCallCount).IsEqualTo(3);
 
         foreach (var publishCall in channel.PublishCalls)
@@ -412,52 +356,18 @@ public sealed class RabbitMqMessageTransportTests
     }
 
     [Test]
-    public async Task SendBatchAsync_Uses_single_channel_for_all_messages(CancellationToken cancellationToken)
-    {
-        var connectionAdapter = new FakeConnectionAdapter();
-        var topicNameResolver = new FakeTopicNameResolver();
-        using var transport = CreateTransport(connectionAdapter, topicNameResolver);
-        var messages = new[] { CreateOutboxMessage(), CreateOutboxMessage(), CreateOutboxMessage() };
-
-        await transport.SendBatchAsync(messages, cancellationToken).ConfigureAwait(false);
-
-        _ = await Assert.That(connectionAdapter.CreateChannelCallCount).IsEqualTo(1);
-        var channel = connectionAdapter.CreatedChannels.Single();
-        _ = await Assert.That(channel.PublishCallCount).IsEqualTo(3);
-    }
-
-    [Test]
     public async Task SendBatchAsync_With_empty_collection_does_not_publish(CancellationToken cancellationToken)
     {
-        var connectionAdapter = new FakeConnectionAdapter();
+        var channelPool = new FakeChannelPool();
         var topicNameResolver = new FakeTopicNameResolver();
-        using var transport = CreateTransport(connectionAdapter, topicNameResolver);
+        using var transport = CreateTransport(channelPool, topicNameResolver);
 
         await transport.SendBatchAsync([], cancellationToken).ConfigureAwait(false);
 
-        _ = await Assert.That(connectionAdapter.CreateChannelCallCount).IsEqualTo(1);
-        var channel = connectionAdapter.CreatedChannels.Single();
+        _ = await Assert.That(channelPool.RentCallCount).IsEqualTo(1);
+        _ = await Assert.That(channelPool.ReturnCallCount).IsEqualTo(1);
+        var channel = channelPool.RentedChannels.Single();
         _ = await Assert.That(channel.PublishCallCount).IsEqualTo(0);
-    }
-
-    [Test]
-    public async Task SendBatchAsync_Reuses_existing_channel(CancellationToken cancellationToken)
-    {
-        var connectionAdapter = new FakeConnectionAdapter();
-        var topicNameResolver = new FakeTopicNameResolver();
-        using var transport = CreateTransport(connectionAdapter, topicNameResolver);
-
-        // First call creates a channel
-        await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false);
-
-        // Second call reuses the same channel
-        await transport
-            .SendBatchAsync([CreateOutboxMessage(), CreateOutboxMessage()], cancellationToken)
-            .ConfigureAwait(false);
-
-        _ = await Assert.That(connectionAdapter.CreateChannelCallCount).IsEqualTo(1);
-        var channel = connectionAdapter.CreatedChannels.Single();
-        _ = await Assert.That(channel.PublishCallCount).IsEqualTo(3);
     }
 
     [Test]
@@ -476,14 +386,30 @@ public sealed class RabbitMqMessageTransportTests
         _ = await Assert.That(options.ExchangeName).IsEqualTo(string.Empty);
     }
 
+    [Test]
+    public async Task Options_Default_MaxChannelPoolSize_is_ten()
+    {
+        var options = new RabbitMqTransportOptions();
+
+        _ = await Assert.That(options.MaxChannelPoolSize).IsEqualTo(10);
+    }
+
+    [Test]
+    public async Task Options_MaxChannelPoolSize_can_be_configured()
+    {
+        var options = new RabbitMqTransportOptions { MaxChannelPoolSize = 25 };
+
+        _ = await Assert.That(options.MaxChannelPoolSize).IsEqualTo(25);
+    }
+
     private static RabbitMqMessageTransport CreateTransport(
-        IRabbitMqConnectionAdapter connectionAdapter,
+        IRabbitMqChannelPool channelPool,
         ITopicNameResolver topicNameResolver,
         string exchangeName = "events"
     )
     {
         var options = CreateOptions(exchangeName);
-        return new RabbitMqMessageTransport(connectionAdapter, topicNameResolver, options);
+        return new RabbitMqMessageTransport(channelPool, topicNameResolver, options);
     }
 
     private static IOptions<RabbitMqTransportOptions> CreateOptions(string exchangeName = "events") =>
@@ -523,36 +449,41 @@ public sealed class RabbitMqMessageTransportTests
         public DateTimeOffset? PublishedAt { get; set; }
     }
 
-    private sealed class FakeConnectionAdapter : IRabbitMqConnectionAdapter
+    private sealed class FakeChannelPool : IRabbitMqChannelPool
     {
-        private bool _isOpen = true;
+        public int RentCallCount { get; private set; }
 
-        public bool IsOpen
+        public int ReturnCallCount { get; private set; }
+
+        public int IsHealthyCallCount { get; private set; }
+
+        public bool Healthy { get; set; } = true;
+
+        public bool ThrowOnIsHealthyAsync { get; set; }
+
+        public bool NextRentedChannelThrowsOnPublish { get; set; }
+
+        public List<FakeChannelAdapter> RentedChannels { get; } = [];
+
+        public ValueTask<IRabbitMqChannelAdapter> RentAsync(CancellationToken cancellationToken)
         {
-            get
-            {
-                if (ThrowOnIsOpen)
-                {
-                    throw new InvalidOperationException("Connection check failed");
-                }
-
-                return _isOpen;
-            }
-            set => _isOpen = value;
+            RentCallCount++;
+            var channel = new FakeChannelAdapter { ThrowsOnPublish = NextRentedChannelThrowsOnPublish };
+            RentedChannels.Add(channel);
+            return ValueTask.FromResult<IRabbitMqChannelAdapter>(channel);
         }
 
-        public bool ThrowOnIsOpen { get; set; }
+        public void Return(IRabbitMqChannelAdapter channel) => ReturnCallCount++;
 
-        public int CreateChannelCallCount { get; private set; }
-
-        public List<FakeChannelAdapter> CreatedChannels { get; } = [];
-
-        public Task<IRabbitMqChannelAdapter> CreateChannelAsync(CancellationToken cancellationToken = default)
+        public Task<bool> IsHealthyAsync(CancellationToken cancellationToken)
         {
-            CreateChannelCallCount++;
-            var channel = new FakeChannelAdapter();
-            CreatedChannels.Add(channel);
-            return Task.FromResult<IRabbitMqChannelAdapter>(channel);
+            IsHealthyCallCount++;
+            if (ThrowOnIsHealthyAsync)
+            {
+                throw new InvalidOperationException("Health check failed");
+            }
+
+            return Task.FromResult(Healthy);
         }
     }
 
@@ -560,13 +491,11 @@ public sealed class RabbitMqMessageTransportTests
     {
         public bool IsOpen { get; set; } = true;
 
+        public bool ThrowsOnPublish { get; set; }
+
         public int PublishCallCount { get; private set; }
 
         public List<PublishCall> PublishCalls { get; } = [];
-
-        public bool DisposeCalled { get; private set; }
-
-        public int DisposeCallCount { get; private set; }
 
         public ValueTask BasicPublishAsync<TProperties>(
             string exchange,
@@ -578,6 +507,11 @@ public sealed class RabbitMqMessageTransportTests
         )
             where TProperties : IReadOnlyBasicProperties, IAmqpHeader
         {
+            if (ThrowsOnPublish)
+            {
+                throw new InvalidOperationException("Publish failed");
+            }
+
             PublishCallCount++;
             PublishCalls.Add(
                 new PublishCall
@@ -611,11 +545,7 @@ public sealed class RabbitMqMessageTransportTests
             return result;
         }
 
-        public void Dispose()
-        {
-            DisposeCalled = true;
-            DisposeCallCount++;
-        }
+        public void Dispose() { }
     }
 
     private sealed record PublishCall

--- a/tests/NetEvolve.Pulse.Tests.Unit/RabbitMQ/RabbitMqTransportOptionsConfigurationTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/RabbitMQ/RabbitMqTransportOptionsConfigurationTests.cs
@@ -1,0 +1,54 @@
+namespace NetEvolve.Pulse.Tests.Unit.RabbitMQ;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("RabbitMQ")]
+public class RabbitMqTransportOptionsConfigurationTests
+{
+    [Test]
+    public async Task Configure_WithPopulatedSection_BindsAllProperties()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["Pulse:Transports:RabbitMq:ExchangeName"] = "pulse-exchange",
+                    ["Pulse:Transports:RabbitMq:MaxChannelPoolSize"] = "25",
+                }
+            )
+            .Build();
+
+        var configurator = new RabbitMqTransportOptionsConfiguration(configuration);
+        var options = new RabbitMqTransportOptions();
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.ExchangeName).IsEqualTo("pulse-exchange");
+        _ = await Assert.That(options.MaxChannelPoolSize).IsEqualTo(25);
+    }
+
+    [Test]
+    public async Task Configure_WithoutSection_LeavesDefaultsUnchanged()
+    {
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection([]).Build();
+
+        var configurator = new RabbitMqTransportOptionsConfiguration(configuration);
+        var options = new RabbitMqTransportOptions();
+        var defaultExchangeName = options.ExchangeName;
+        var defaultPoolSize = options.MaxChannelPoolSize;
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.ExchangeName).IsEqualTo(defaultExchangeName);
+        _ = await Assert.That(options.MaxChannelPoolSize).IsEqualTo(defaultPoolSize);
+    }
+
+    [Test]
+    public void Constructor_WithNullConfiguration_ThrowsArgumentNullException() =>
+        _ = Assert.Throws<ArgumentNullException>(() => _ = new RabbitMqTransportOptionsConfiguration(null!));
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/RabbitMQ/RabbitMqTransportOptionsValidatorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/RabbitMQ/RabbitMqTransportOptionsValidatorTests.cs
@@ -1,0 +1,86 @@
+namespace NetEvolve.Pulse.Tests.Unit.RabbitMQ;
+
+using System.Threading.Tasks;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("RabbitMQ")]
+public class RabbitMqTransportOptionsValidatorTests
+{
+    private static readonly RabbitMqTransportOptionsValidator _validator = new();
+
+    [Test]
+    public async Task Validate_WithValidExchangeNameAndDefaultPoolSize_Succeeds()
+    {
+        var options = new RabbitMqTransportOptions { ExchangeName = "my-exchange" };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithEmptyExchangeName_Fails()
+    {
+        var options = new RabbitMqTransportOptions { ExchangeName = string.Empty };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithWhitespaceExchangeName_Fails()
+    {
+        var options = new RabbitMqTransportOptions { ExchangeName = "   " };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithZeroMaxChannelPoolSize_Fails()
+    {
+        var options = new RabbitMqTransportOptions { ExchangeName = "my-exchange", MaxChannelPoolSize = 0 };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithNegativeMaxChannelPoolSize_Fails()
+    {
+        var options = new RabbitMqTransportOptions { ExchangeName = "my-exchange", MaxChannelPoolSize = -1 };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithMinimumValidMaxChannelPoolSize_Succeeds()
+    {
+        var options = new RabbitMqTransportOptions { ExchangeName = "my-exchange", MaxChannelPoolSize = 1 };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithBothExchangeNameAndPoolSizeInvalid_FailsWithBothMessages()
+    {
+        var options = new RabbitMqTransportOptions { ExchangeName = string.Empty, MaxChannelPoolSize = 0 };
+
+        var result = _validator.Validate(null, options);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(result.Failed).IsTrue();
+            _ = await Assert.That(result.Failures!.Count()).IsEqualTo(2);
+        }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/SQLite/SQLiteExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/SQLite/SQLiteExtensionsTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
@@ -106,6 +107,7 @@ public sealed class SQLiteExtensionsTests
     public async Task UseSQLiteOutbox_WithConfigureOptions_AppliesTableName()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config =>
             config.AddOutbox().UseSQLiteOutbox("Data Source=:memory:", options => options.TableName = "CustomTable")
         );
@@ -123,6 +125,7 @@ public sealed class SQLiteExtensionsTests
     public async Task UseSQLiteOutbox_WithConfigureAction_AppliesOptions()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config =>
             config
                 .AddOutbox()
@@ -265,6 +268,7 @@ public sealed class SQLiteExtensionsTests
     public async Task AddSQLiteOutbox_WithConfigureOptions_AppliesTableName()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config =>
             config.AddSQLiteOutbox("Data Source=:memory:", options => options.TableName = "CustomTable")
         );
@@ -282,6 +286,7 @@ public sealed class SQLiteExtensionsTests
     public async Task AddSQLiteOutbox_WithConfigureAction_AppliesOptions()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config =>
             config.AddSQLiteOutbox(opts =>
             {
@@ -389,6 +394,7 @@ public sealed class SQLiteExtensionsTests
     public async Task AddSQLiteOutbox_WithFactory_WithConfigureOptions_AppliesOptions()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config =>
             config.AddSQLiteOutbox(_ => "Data Source=:memory:", options => options.TableName = "CustomTable")
         );

--- a/tests/NetEvolve.Pulse.Tests.Unit/SqlServer/SqlServerExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/SqlServer/SqlServerExtensionsTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
@@ -101,6 +102,7 @@ public sealed class SqlServerExtensionsTests
     public async Task AddSqlServerOutbox_WithConfigureOptions_AppliesOptions()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config =>
             config.AddOutbox().AddSqlServerOutbox("Server=.;Encrypt=true;", options => options.Schema = "myschema")
         );
@@ -172,6 +174,7 @@ public sealed class SqlServerExtensionsTests
     public async Task AddSqlServerOutbox_WithFactory_WithConfigureOptions_AppliesOptions()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config =>
             config
                 .AddOutbox()

--- a/tests/NetEvolve.Pulse.Tests.Unit/TimeoutExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/TimeoutExtensionsTests.cs
@@ -3,6 +3,7 @@ namespace NetEvolve.Pulse.Tests.Unit;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
@@ -100,6 +101,7 @@ public sealed class TimeoutExtensionsTests
     public async Task AddRequestTimeout_WithGlobalTimeout_ConfiguresOptions()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         var configurator = new MediatorBuilder(services);
 
         _ = configurator.AddRequestTimeout(TimeSpan.FromSeconds(30));
@@ -117,6 +119,7 @@ public sealed class TimeoutExtensionsTests
     public async Task AddRequestTimeout_WithoutGlobalTimeout_LeavesGlobalTimeoutNull()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         var configurator = new MediatorBuilder(services);
 
         _ = configurator.AddRequestTimeout();


### PR DESCRIPTION
## Summary

- Add `IRabbitMqChannelPool` / `RabbitMqChannelPool` in `NetEvolve.Pulse.Internals`, backed by a `ConcurrentQueue<IRabbitMqChannelAdapter>` of idle channels and a `SemaphoreSlim` capped at `MaxChannelPoolSize` concurrent rentals. `RentAsync` dequeues an open idle channel, disposing and skipping any closed one, or creates a new channel via `IRabbitMqConnectionAdapter` when none are available; `Return` re-queues an open channel or disposes a closed one, always releasing the rental slot exactly once (including when the pool itself has been disposed while the channel was rented out).
- Add `RabbitMqTransportOptions.MaxChannelPoolSize` (default `10`).
- Rework `RabbitMqMessageTransport` to rent a channel from the pool per `SendAsync` call and to rent a single channel for the whole `SendBatchAsync` batch (published sequentially on it), always returning the channel in a `finally` block. This removes the old single shared `_channel` field, `_initializationLock`, and `_publishLock` — per-channel publish safety is now inherent because each rental is exclusive. `IsHealthyAsync` now delegates to the pool's own health check.
- Register `IRabbitMqChannelPool` → `RabbitMqChannelPool` as a singleton via `TryAddSingleton` in `UseRabbitMqTransport`, so calling it more than once does not duplicate the registration.
- Update unit tests to the new pool-based design (constructor now takes `IRabbitMqChannelPool` instead of `IRabbitMqConnectionAdapter`) and add `RabbitMqChannelPoolTests` covering: concurrent rent capped at `MaxChannelPoolSize`, returning an open channel makes it available for reuse, returning a closed channel disposes it and the next rent creates a fresh one, pool exhaustion causing a rent to wait until a return happens, and dispose (idempotent, disposes all idle channels, `Return`/`RentAsync` behave safely after dispose).
- Update the RabbitMQ integration test fixture and one behavior test (`IsHealthyAsync` before any channel exists now correctly reports healthy based on the connection/pool, not on the previous single-field-existence quirk).

Closes #241

## Deviations from the issue text

- The issue's out-of-the-box constructor code snippets were adapted to match the actual codebase (existing `IRabbitMqChannelAdapter` / `IRabbitMqConnectionAdapter` types were reused as-is, matching the codebase context already given).
- `SendBatchAsync` rents **one** channel for the entire batch and publishes its messages sequentially on it, rather than renting a channel per message. This was called out as an explicit choice in the issue ("pick whichever keeps the implementation simplest and correct"); renting once per batch avoids rent/return churn for what is inherently a single-threaded, ordered sequence of publishes.
- `RabbitMqMessageTransport`'s constructor now takes `IRabbitMqChannelPool` instead of `IRabbitMqConnectionAdapter`, since the channel pool fully owns channel creation/health against the connection. This is a necessary consequence of removing the transport's private channel-management, and is reflected in the DI registration and the updated unit tests.
- `IsHealthyAsync` no longer requires that a channel has already been created before reporting healthy (the old code returned `false` until the first `SendAsync`/`SendBatchAsync` call because a `_channel` field had not been set yet). With pooling there is no single persistent "the channel" to check, so health now reflects the pool/connection state directly. One integration test (`IsHealthyAsync_Before_first_send_returns_false`) was updated to `IsHealthyAsync_Before_first_send_returns_true_when_connection_open` to reflect this intentional, documented behavior change.

## Test plan

- [x] `dotnet build Pulse.slnx` — builds clean (net8.0/net9.0/net10.0)
- [x] `dotnet test Tests/NetEvolve.Pulse.Tests.Unit --treenode-filter "/*/*/*RabbitMq*/*"` — 156 passed, 0 failed, 0 skipped (net8.0/net9.0/net10.0)
- [x] `csharpier format .` run before committing
- [ ] Integration tests (`NetEvolve.Pulse.Tests.Integration`) require Docker/Testcontainers and were not run in this environment, but the project builds successfully with the updated pool-based `CreateTransport` helper.