### PR TITLE
feat: add IValidateOptions and ValidateOnStart for existing options classes

### DIFF
--- a/src/NetEvolve.Pulse.AzureServiceBus/AzureServiceBusExtensions.cs
+++ b/src/NetEvolve.Pulse.AzureServiceBus/AzureServiceBusExtensions.cs
@@ -33,6 +33,14 @@ public static class AzureServiceBusExtensions
         var services = configurator.Services;
 
         _ = services.AddOptions<AzureServiceBusTransportOptions>().ValidateOnStart();
+
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<
+                IConfigureOptions<AzureServiceBusTransportOptions>,
+                AzureServiceBusTransportOptionsConfiguration
+            >()
+        );
+
         if (configureOptions is not null)
         {
             _ = services.Configure(configureOptions);

--- a/src/NetEvolve.Pulse.AzureServiceBus/AzureServiceBusExtensions.cs
+++ b/src/NetEvolve.Pulse.AzureServiceBus/AzureServiceBusExtensions.cs
@@ -32,16 +32,22 @@ public static class AzureServiceBusExtensions
 
         var services = configurator.Services;
 
-        _ = services.AddOptions<AzureServiceBusTransportOptions>();
+        _ = services.AddOptions<AzureServiceBusTransportOptions>().ValidateOnStart();
         if (configureOptions is not null)
         {
             _ = services.Configure(configureOptions);
         }
 
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<
+                IValidateOptions<AzureServiceBusTransportOptions>,
+                AzureServiceBusTransportOptionsValidator
+            >()
+        );
+
         services.TryAddSingleton(static sp =>
         {
             var options = sp.GetRequiredService<IOptions<AzureServiceBusTransportOptions>>().Value;
-            ValidateOptions(options);
 
             return CreateServiceBusClient(options, sp.GetRequiredService<TokenCredential>());
         });
@@ -70,18 +76,5 @@ public static class AzureServiceBusExtensions
         }
 
         return new ServiceBusClient(options.FullyQualifiedNamespace!, credential);
-    }
-
-    private static void ValidateOptions(AzureServiceBusTransportOptions options)
-    {
-        if (
-            string.IsNullOrWhiteSpace(options.ConnectionString)
-            && string.IsNullOrWhiteSpace(options.FullyQualifiedNamespace)
-        )
-        {
-            throw new InvalidOperationException(
-                "Either a Service Bus connection string or a fully qualified namespace must be provided."
-            );
-        }
     }
 }

--- a/src/NetEvolve.Pulse.AzureServiceBus/NetEvolve.Pulse.AzureServiceBus.csproj
+++ b/src/NetEvolve.Pulse.AzureServiceBus/NetEvolve.Pulse.AzureServiceBus.csproj
@@ -9,6 +9,8 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Messaging.ServiceBus" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>

--- a/src/NetEvolve.Pulse.AzureServiceBus/Outbox/AzureServiceBusTransportOptionsConfiguration.cs
+++ b/src/NetEvolve.Pulse.AzureServiceBus/Outbox/AzureServiceBusTransportOptionsConfiguration.cs
@@ -1,0 +1,24 @@
+﻿namespace NetEvolve.Pulse.Outbox;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Binds <see cref="AzureServiceBusTransportOptions"/> from the <c>Pulse:Transports:AzureServiceBus</c>
+/// configuration section.
+/// </summary>
+internal sealed class AzureServiceBusTransportOptionsConfiguration : IConfigureOptions<AzureServiceBusTransportOptions>
+{
+    private readonly IConfiguration _configuration;
+
+    public AzureServiceBusTransportOptionsConfiguration(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        _configuration = configuration;
+    }
+
+    /// <inheritdoc />
+    public void Configure(AzureServiceBusTransportOptions options) =>
+        _configuration.GetSection("Pulse:Transports:AzureServiceBus").Bind(options);
+}

--- a/src/NetEvolve.Pulse.AzureServiceBus/Outbox/AzureServiceBusTransportOptionsValidator.cs
+++ b/src/NetEvolve.Pulse.AzureServiceBus/Outbox/AzureServiceBusTransportOptionsValidator.cs
@@ -1,0 +1,27 @@
+namespace NetEvolve.Pulse.Outbox;
+
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Validates <see cref="AzureServiceBusTransportOptions"/> ensuring that either
+/// <see cref="AzureServiceBusTransportOptions.ConnectionString"/> or
+/// <see cref="AzureServiceBusTransportOptions.FullyQualifiedNamespace"/> is provided.
+/// </summary>
+internal sealed class AzureServiceBusTransportOptionsValidator : IValidateOptions<AzureServiceBusTransportOptions>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, AzureServiceBusTransportOptions options)
+    {
+        if (
+            string.IsNullOrWhiteSpace(options.ConnectionString)
+            && string.IsNullOrWhiteSpace(options.FullyQualifiedNamespace)
+        )
+        {
+            return ValidateOptionsResult.Fail(
+                $"Either {nameof(AzureServiceBusTransportOptions.ConnectionString)} or {nameof(AzureServiceBusTransportOptions.FullyQualifiedNamespace)} must be provided."
+            );
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/NetEvolve.Pulse.Dapr/DaprExtensions.cs
+++ b/src/NetEvolve.Pulse.Dapr/DaprExtensions.cs
@@ -37,6 +37,14 @@ public static class DaprExtensions
         var services = configurator.Services;
 
         _ = services.AddOptions<DaprMessageTransportOptions>().ValidateOnStart();
+
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<
+                IConfigureOptions<DaprMessageTransportOptions>,
+                DaprMessageTransportOptionsConfiguration
+            >()
+        );
+
         if (configureOptions is not null)
         {
             _ = services.Configure(configureOptions);

--- a/src/NetEvolve.Pulse.Dapr/DaprExtensions.cs
+++ b/src/NetEvolve.Pulse.Dapr/DaprExtensions.cs
@@ -2,6 +2,8 @@ namespace NetEvolve.Pulse;
 
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 using NetEvolve.Pulse.Extensibility;
 using NetEvolve.Pulse.Extensibility.Outbox;
 using NetEvolve.Pulse.Outbox;
@@ -34,11 +36,18 @@ public static class DaprExtensions
 
         var services = configurator.Services;
 
-        _ = services.AddOptions<DaprMessageTransportOptions>();
+        _ = services.AddOptions<DaprMessageTransportOptions>().ValidateOnStart();
         if (configureOptions is not null)
         {
             _ = services.Configure(configureOptions);
         }
+
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<
+                IValidateOptions<DaprMessageTransportOptions>,
+                DaprMessageTransportOptionsValidator
+            >()
+        );
 
         var existing = services.FirstOrDefault(d => d.ServiceType == typeof(IMessageTransport));
         if (existing is not null)

--- a/src/NetEvolve.Pulse.Dapr/NetEvolve.Pulse.Dapr.csproj
+++ b/src/NetEvolve.Pulse.Dapr/NetEvolve.Pulse.Dapr.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Dapr.Client" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NetEvolve.Pulse.Dapr/OutBox/DaprMessageTransportOptionsConfiguration.cs
+++ b/src/NetEvolve.Pulse.Dapr/OutBox/DaprMessageTransportOptionsConfiguration.cs
@@ -1,0 +1,23 @@
+﻿namespace NetEvolve.Pulse.Outbox;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Binds <see cref="DaprMessageTransportOptions"/> from the <c>Pulse:Transports:Dapr</c> configuration section.
+/// </summary>
+internal sealed class DaprMessageTransportOptionsConfiguration : IConfigureOptions<DaprMessageTransportOptions>
+{
+    private readonly IConfiguration _configuration;
+
+    public DaprMessageTransportOptionsConfiguration(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        _configuration = configuration;
+    }
+
+    /// <inheritdoc />
+    public void Configure(DaprMessageTransportOptions options) =>
+        _configuration.GetSection("Pulse:Transports:Dapr").Bind(options);
+}

--- a/src/NetEvolve.Pulse.Dapr/OutBox/DaprMessageTransportOptionsValidator.cs
+++ b/src/NetEvolve.Pulse.Dapr/OutBox/DaprMessageTransportOptionsValidator.cs
@@ -1,0 +1,23 @@
+namespace NetEvolve.Pulse.Outbox;
+
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Validates <see cref="DaprMessageTransportOptions"/> ensuring that
+/// <see cref="DaprMessageTransportOptions.PubSubName"/> is not empty.
+/// </summary>
+internal sealed class DaprMessageTransportOptionsValidator : IValidateOptions<DaprMessageTransportOptions>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, DaprMessageTransportOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.PubSubName))
+        {
+            return ValidateOptionsResult.Fail(
+                $"{nameof(DaprMessageTransportOptions.PubSubName)} must not be null or empty."
+            );
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/NetEvolve.Pulse.Extensibility/Caching/QueryCachingOptionsConfiguration.cs
+++ b/src/NetEvolve.Pulse.Extensibility/Caching/QueryCachingOptionsConfiguration.cs
@@ -1,0 +1,26 @@
+﻿namespace NetEvolve.Pulse.Extensibility.Caching;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Binds <see cref="QueryCachingOptions"/> from the <c>Pulse:QueryCaching</c> configuration section.
+/// </summary>
+public sealed class QueryCachingOptionsConfiguration : IConfigureOptions<QueryCachingOptions>
+{
+    private readonly IConfiguration _configuration;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QueryCachingOptionsConfiguration"/> class.
+    /// </summary>
+    /// <param name="configuration">The application configuration used to bind <see cref="QueryCachingOptions"/>.</param>
+    public QueryCachingOptionsConfiguration(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        _configuration = configuration;
+    }
+
+    /// <inheritdoc />
+    public void Configure(QueryCachingOptions options) => _configuration.GetSection("Pulse:QueryCaching").Bind(options);
+}

--- a/src/NetEvolve.Pulse.Extensibility/Caching/QueryCachingOptionsValidator.cs
+++ b/src/NetEvolve.Pulse.Extensibility/Caching/QueryCachingOptionsValidator.cs
@@ -1,0 +1,26 @@
+namespace NetEvolve.Pulse.Extensibility.Caching;
+
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Validates <see cref="QueryCachingOptions"/> ensuring that
+/// <see cref="QueryCachingOptions.DefaultExpiry"/> is either <see langword="null"/>
+/// or a positive <see cref="TimeSpan"/>.
+/// </summary>
+public sealed class QueryCachingOptionsValidator : IValidateOptions<QueryCachingOptions>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, QueryCachingOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (options.DefaultExpiry.HasValue && options.DefaultExpiry.Value <= TimeSpan.Zero)
+        {
+            return ValidateOptionsResult.Fail(
+                $"{nameof(QueryCachingOptions.DefaultExpiry)} must be null or greater than {nameof(TimeSpan)}.{nameof(TimeSpan.Zero)}."
+            );
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/NetEvolve.Pulse.Extensibility/NetEvolve.Pulse.Extensibility.csproj
+++ b/src/NetEvolve.Pulse.Extensibility/NetEvolve.Pulse.Extensibility.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>

--- a/src/NetEvolve.Pulse.Extensibility/NetEvolve.Pulse.Extensibility.csproj
+++ b/src/NetEvolve.Pulse.Extensibility/NetEvolve.Pulse.Extensibility.csproj
@@ -8,5 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 </Project>

--- a/src/NetEvolve.Pulse.RabbitMQ/NetEvolve.Pulse.RabbitMQ.csproj
+++ b/src/NetEvolve.Pulse.RabbitMQ/NetEvolve.Pulse.RabbitMQ.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="RabbitMQ.Client" />
   </ItemGroup>

--- a/src/NetEvolve.Pulse.RabbitMQ/Outbox/RabbitMqTransportOptionsConfiguration.cs
+++ b/src/NetEvolve.Pulse.RabbitMQ/Outbox/RabbitMqTransportOptionsConfiguration.cs
@@ -1,0 +1,23 @@
+namespace NetEvolve.Pulse.Outbox;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Binds <see cref="RabbitMqTransportOptions"/> from the <c>Pulse:Transports:RabbitMq</c> configuration section.
+/// </summary>
+internal sealed class RabbitMqTransportOptionsConfiguration : IConfigureOptions<RabbitMqTransportOptions>
+{
+    private readonly IConfiguration _configuration;
+
+    public RabbitMqTransportOptionsConfiguration(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        _configuration = configuration;
+    }
+
+    /// <inheritdoc />
+    public void Configure(RabbitMqTransportOptions options) =>
+        _configuration.GetSection("Pulse:Transports:RabbitMq").Bind(options);
+}

--- a/src/NetEvolve.Pulse.RabbitMQ/Outbox/RabbitMqTransportOptionsValidator.cs
+++ b/src/NetEvolve.Pulse.RabbitMQ/Outbox/RabbitMqTransportOptionsValidator.cs
@@ -1,0 +1,29 @@
+namespace NetEvolve.Pulse.Outbox;
+
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Validates <see cref="RabbitMqTransportOptions"/> ensuring that
+/// <see cref="RabbitMqTransportOptions.ExchangeName"/> is not empty and
+/// <see cref="RabbitMqTransportOptions.MaxChannelPoolSize"/> is at least 1.
+/// </summary>
+internal sealed class RabbitMqTransportOptionsValidator : IValidateOptions<RabbitMqTransportOptions>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, RabbitMqTransportOptions options)
+    {
+        var failures = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(options.ExchangeName))
+        {
+            failures.Add($"{nameof(RabbitMqTransportOptions.ExchangeName)} must not be null or empty.");
+        }
+
+        if (options.MaxChannelPoolSize < 1)
+        {
+            failures.Add($"{nameof(RabbitMqTransportOptions.MaxChannelPoolSize)} must be greater than or equal to 1.");
+        }
+
+        return failures.Count == 0 ? ValidateOptionsResult.Success : ValidateOptionsResult.Fail(failures);
+    }
+}

--- a/src/NetEvolve.Pulse.RabbitMQ/RabbitMqExtensions.cs
+++ b/src/NetEvolve.Pulse.RabbitMQ/RabbitMqExtensions.cs
@@ -39,11 +39,15 @@ public static class RabbitMqExtensions
 
         var services = configurator.Services;
 
-        _ = services.AddOptions<RabbitMqTransportOptions>();
+        _ = services.AddOptions<RabbitMqTransportOptions>().ValidateOnStart();
         if (configureOptions is not null)
         {
             _ = services.Configure(configureOptions);
         }
+
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IValidateOptions<RabbitMqTransportOptions>, RabbitMqTransportOptionsValidator>()
+        );
 
         // Register the connection adapter
         _ = services.AddSingleton<IRabbitMqConnectionAdapter>(sp =>

--- a/src/NetEvolve.Pulse.RabbitMQ/RabbitMqExtensions.cs
+++ b/src/NetEvolve.Pulse.RabbitMQ/RabbitMqExtensions.cs
@@ -40,6 +40,14 @@ public static class RabbitMqExtensions
         var services = configurator.Services;
 
         _ = services.AddOptions<RabbitMqTransportOptions>().ValidateOnStart();
+
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<
+                IConfigureOptions<RabbitMqTransportOptions>,
+                RabbitMqTransportOptionsConfiguration
+            >()
+        );
+
         if (configureOptions is not null)
         {
             _ = services.Configure(configureOptions);

--- a/src/NetEvolve.Pulse/Interceptors/LoggingInterceptorOptionsConfiguration.cs
+++ b/src/NetEvolve.Pulse/Interceptors/LoggingInterceptorOptionsConfiguration.cs
@@ -1,0 +1,23 @@
+namespace NetEvolve.Pulse.Interceptors;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Binds <see cref="LoggingInterceptorOptions"/> from the <c>Pulse:Logging</c> configuration section.
+/// </summary>
+internal sealed class LoggingInterceptorOptionsConfiguration : IConfigureOptions<LoggingInterceptorOptions>
+{
+    private readonly IConfiguration _configuration;
+
+    public LoggingInterceptorOptionsConfiguration(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        _configuration = configuration;
+    }
+
+    /// <inheritdoc />
+    public void Configure(LoggingInterceptorOptions options) =>
+        _configuration.GetSection("Pulse:Logging").Bind(options);
+}

--- a/src/NetEvolve.Pulse/Interceptors/TimeoutRequestInterceptorOptionsConfiguration.cs
+++ b/src/NetEvolve.Pulse/Interceptors/TimeoutRequestInterceptorOptionsConfiguration.cs
@@ -1,0 +1,24 @@
+namespace NetEvolve.Pulse.Interceptors;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Binds <see cref="TimeoutRequestInterceptorOptions"/> from the <c>Pulse:Timeout</c> configuration section.
+/// </summary>
+internal sealed class TimeoutRequestInterceptorOptionsConfiguration
+    : IConfigureOptions<TimeoutRequestInterceptorOptions>
+{
+    private readonly IConfiguration _configuration;
+
+    public TimeoutRequestInterceptorOptionsConfiguration(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        _configuration = configuration;
+    }
+
+    /// <inheritdoc />
+    public void Configure(TimeoutRequestInterceptorOptions options) =>
+        _configuration.GetSection("Pulse:Timeout").Bind(options);
+}

--- a/src/NetEvolve.Pulse/Interceptors/TimeoutRequestInterceptorOptionsValidator.cs
+++ b/src/NetEvolve.Pulse/Interceptors/TimeoutRequestInterceptorOptionsValidator.cs
@@ -1,0 +1,24 @@
+namespace NetEvolve.Pulse.Interceptors;
+
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Validates <see cref="TimeoutRequestInterceptorOptions"/> ensuring that
+/// <see cref="TimeoutRequestInterceptorOptions.GlobalTimeout"/> is either <see langword="null"/>
+/// or a positive <see cref="TimeSpan"/>.
+/// </summary>
+internal sealed class TimeoutRequestInterceptorOptionsValidator : IValidateOptions<TimeoutRequestInterceptorOptions>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, TimeoutRequestInterceptorOptions options)
+    {
+        if (options.GlobalTimeout.HasValue && options.GlobalTimeout.Value <= TimeSpan.Zero)
+        {
+            return ValidateOptionsResult.Fail(
+                $"{nameof(TimeoutRequestInterceptorOptions.GlobalTimeout)} must be null or greater than {nameof(TimeSpan)}.{nameof(TimeSpan.Zero)}."
+            );
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/NetEvolve.Pulse/LoggingExtensions.cs
+++ b/src/NetEvolve.Pulse/LoggingExtensions.cs
@@ -57,6 +57,13 @@ public static class LoggingExtensions
 
         _ = configurator.Services.AddOptions<LoggingInterceptorOptions>();
 
+        configurator.Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<
+                IConfigureOptions<LoggingInterceptorOptions>,
+                LoggingInterceptorOptionsConfiguration
+            >()
+        );
+
         if (configure is not null)
         {
             _ = configurator.Services.Configure(configure);

--- a/src/NetEvolve.Pulse/Outbox/OutboxOptionsConfiguration.cs
+++ b/src/NetEvolve.Pulse/Outbox/OutboxOptionsConfiguration.cs
@@ -1,0 +1,22 @@
+﻿namespace NetEvolve.Pulse.Outbox;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Binds <see cref="OutboxOptions"/> from the <c>Pulse:Outbox</c> configuration section.
+/// </summary>
+internal sealed class OutboxOptionsConfiguration : IConfigureOptions<OutboxOptions>
+{
+    private readonly IConfiguration _configuration;
+
+    public OutboxOptionsConfiguration(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        _configuration = configuration;
+    }
+
+    /// <inheritdoc />
+    public void Configure(OutboxOptions options) => _configuration.GetSection("Pulse:Outbox").Bind(options);
+}

--- a/src/NetEvolve.Pulse/Outbox/OutboxOptionsValidator.cs
+++ b/src/NetEvolve.Pulse/Outbox/OutboxOptionsValidator.cs
@@ -1,0 +1,29 @@
+namespace NetEvolve.Pulse.Outbox;
+
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Validates <see cref="OutboxOptions"/> ensuring that
+/// <see cref="OutboxOptions.TableName"/> is not <see langword="null"/>, empty, or whitespace.
+/// </summary>
+/// <remarks>
+/// <see cref="OutboxOptions.ConnectionString"/> is intentionally not validated here: it is required
+/// only by ADO.NET-based providers (e.g., PostgreSQL, SQL Server, SQLite) and legitimately remains
+/// <see langword="null"/> for Entity Framework Core-based outbox usage, which resolves its connection
+/// through a registered <c>DbContext</c> instead.
+/// </remarks>
+internal sealed class OutboxOptionsValidator : IValidateOptions<OutboxOptions>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, OutboxOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.TableName))
+        {
+            return ValidateOptionsResult.Fail(
+                $"{nameof(OutboxOptions.TableName)} must not be null, empty, or whitespace."
+            );
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/NetEvolve.Pulse/Outbox/OutboxProcessorOptionsConfiguration.cs
+++ b/src/NetEvolve.Pulse/Outbox/OutboxProcessorOptionsConfiguration.cs
@@ -1,0 +1,23 @@
+﻿namespace NetEvolve.Pulse.Outbox;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Binds <see cref="OutboxProcessorOptions"/> from the <c>Pulse:OutboxProcessor</c> configuration section.
+/// </summary>
+internal sealed class OutboxProcessorOptionsConfiguration : IConfigureOptions<OutboxProcessorOptions>
+{
+    private readonly IConfiguration _configuration;
+
+    public OutboxProcessorOptionsConfiguration(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        _configuration = configuration;
+    }
+
+    /// <inheritdoc />
+    public void Configure(OutboxProcessorOptions options) =>
+        _configuration.GetSection("Pulse:OutboxProcessor").Bind(options);
+}

--- a/src/NetEvolve.Pulse/Outbox/OutboxProcessorOptionsValidator.cs
+++ b/src/NetEvolve.Pulse/Outbox/OutboxProcessorOptionsValidator.cs
@@ -1,0 +1,66 @@
+namespace NetEvolve.Pulse.Outbox;
+
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Validates <see cref="OutboxProcessorOptions"/> ensuring all configured values are within
+/// valid, self-consistent ranges.
+/// </summary>
+internal sealed class OutboxProcessorOptionsValidator : IValidateOptions<OutboxProcessorOptions>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, OutboxProcessorOptions options)
+    {
+        var failures = new List<string>();
+
+        if (options.BatchSize <= 0)
+        {
+            failures.Add($"{nameof(OutboxProcessorOptions.BatchSize)} must be greater than 0.");
+        }
+
+        if (options.PollingInterval <= TimeSpan.Zero)
+        {
+            failures.Add(
+                $"{nameof(OutboxProcessorOptions.PollingInterval)} must be greater than {nameof(TimeSpan)}.{nameof(TimeSpan.Zero)}."
+            );
+        }
+
+        if (options.MaxRetryCount < 0)
+        {
+            failures.Add($"{nameof(OutboxProcessorOptions.MaxRetryCount)} must be greater than or equal to 0.");
+        }
+
+        if (options.ProcessingTimeout <= TimeSpan.Zero)
+        {
+            failures.Add(
+                $"{nameof(OutboxProcessorOptions.ProcessingTimeout)} must be greater than {nameof(TimeSpan)}.{nameof(TimeSpan.Zero)}."
+            );
+        }
+
+        if (options.EnableExponentialBackoff)
+        {
+            if (options.BackoffMultiplier <= 1.0)
+            {
+                failures.Add(
+                    $"{nameof(OutboxProcessorOptions.BackoffMultiplier)} must be greater than 1.0 when {nameof(OutboxProcessorOptions.EnableExponentialBackoff)} is enabled."
+                );
+            }
+
+            if (options.BaseRetryDelay <= TimeSpan.Zero)
+            {
+                failures.Add(
+                    $"{nameof(OutboxProcessorOptions.BaseRetryDelay)} must be greater than {nameof(TimeSpan)}.{nameof(TimeSpan.Zero)} when {nameof(OutboxProcessorOptions.EnableExponentialBackoff)} is enabled."
+                );
+            }
+
+            if (options.MaxRetryDelay < options.BaseRetryDelay)
+            {
+                failures.Add(
+                    $"{nameof(OutboxProcessorOptions.MaxRetryDelay)} must be greater than or equal to {nameof(OutboxProcessorOptions.BaseRetryDelay)} when {nameof(OutboxProcessorOptions.EnableExponentialBackoff)} is enabled."
+                );
+            }
+        }
+
+        return failures.Count == 0 ? ValidateOptionsResult.Success : ValidateOptionsResult.Fail(failures);
+    }
+}

--- a/src/NetEvolve.Pulse/OutboxExtensions.cs
+++ b/src/NetEvolve.Pulse/OutboxExtensions.cs
@@ -50,6 +50,11 @@ public static class OutboxExtensions
         // Register options using the Options pattern for configurability
         // Always use Configure() to allow subsequent calls to modify options
         _ = services.AddOptions<OutboxOptions>().ValidateOnStart();
+
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IConfigureOptions<OutboxOptions>, OutboxOptionsConfiguration>()
+        );
+
         if (configureOptions is not null)
         {
             _ = services.Configure(configureOptions);
@@ -60,6 +65,14 @@ public static class OutboxExtensions
         );
 
         _ = services.AddOptions<OutboxProcessorOptions>().ValidateOnStart();
+
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<
+                IConfigureOptions<OutboxProcessorOptions>,
+                OutboxProcessorOptionsConfiguration
+            >()
+        );
+
         if (configureProcessorOptions is not null)
         {
             _ = services.Configure(configureProcessorOptions);

--- a/src/NetEvolve.Pulse/OutboxExtensions.cs
+++ b/src/NetEvolve.Pulse/OutboxExtensions.cs
@@ -3,6 +3,7 @@ namespace NetEvolve.Pulse;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using NetEvolve.Pulse.Extensibility;
 using NetEvolve.Pulse.Extensibility.Outbox;
 using NetEvolve.Pulse.Outbox;
@@ -48,17 +49,25 @@ public static class OutboxExtensions
 
         // Register options using the Options pattern for configurability
         // Always use Configure() to allow subsequent calls to modify options
-        _ = services.AddOptions<OutboxOptions>();
+        _ = services.AddOptions<OutboxOptions>().ValidateOnStart();
         if (configureOptions is not null)
         {
             _ = services.Configure(configureOptions);
         }
 
-        _ = services.AddOptions<OutboxProcessorOptions>();
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IValidateOptions<OutboxOptions>, OutboxOptionsValidator>()
+        );
+
+        _ = services.AddOptions<OutboxProcessorOptions>().ValidateOnStart();
         if (configureProcessorOptions is not null)
         {
             _ = services.Configure(configureProcessorOptions);
         }
+
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IValidateOptions<OutboxProcessorOptions>, OutboxProcessorOptionsValidator>()
+        );
 
         // Register TimeProvider if not already registered
         services.TryAddSingleton(TimeProvider.System);

--- a/src/NetEvolve.Pulse/QueryCachingExtensions.cs
+++ b/src/NetEvolve.Pulse/QueryCachingExtensions.cs
@@ -3,6 +3,7 @@ namespace NetEvolve.Pulse;
 using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 using NetEvolve.Pulse.Extensibility;
 using NetEvolve.Pulse.Extensibility.Caching;
 using NetEvolve.Pulse.Interceptors;
@@ -34,11 +35,15 @@ public static class QueryCachingExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        _ = builder.Services.AddOptions<QueryCachingOptions>();
+        _ = builder.Services.AddOptions<QueryCachingOptions>().ValidateOnStart();
         if (configure is not null)
         {
             _ = builder.Services.Configure(configure);
         }
+
+        builder.Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IValidateOptions<QueryCachingOptions>, QueryCachingOptionsValidator>()
+        );
 
         builder.Services.TryAddEnumerable(
             ServiceDescriptor.Scoped(typeof(IRequestInterceptor<,>), typeof(DistributedCacheQueryInterceptor<,>))

--- a/src/NetEvolve.Pulse/QueryCachingExtensions.cs
+++ b/src/NetEvolve.Pulse/QueryCachingExtensions.cs
@@ -36,6 +36,11 @@ public static class QueryCachingExtensions
         ArgumentNullException.ThrowIfNull(builder);
 
         _ = builder.Services.AddOptions<QueryCachingOptions>().ValidateOnStart();
+
+        builder.Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IConfigureOptions<QueryCachingOptions>, QueryCachingOptionsConfiguration>()
+        );
+
         if (configure is not null)
         {
             _ = builder.Services.Configure(configure);

--- a/src/NetEvolve.Pulse/TimeoutExtensions.cs
+++ b/src/NetEvolve.Pulse/TimeoutExtensions.cs
@@ -60,9 +60,19 @@ public static class TimeoutExtensions
 
         _ = configurator.Services.AddOptions<TimeoutRequestInterceptorOptions>().ValidateOnStart();
 
-        _ = configurator.Services.Configure<TimeoutRequestInterceptorOptions>(opts =>
-            opts.GlobalTimeout = globalTimeout
+        configurator.Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<
+                IConfigureOptions<TimeoutRequestInterceptorOptions>,
+                TimeoutRequestInterceptorOptionsConfiguration
+            >()
         );
+
+        if (globalTimeout is not null)
+        {
+            _ = configurator.Services.Configure<TimeoutRequestInterceptorOptions>(opts =>
+                opts.GlobalTimeout = globalTimeout
+            );
+        }
 
         configurator.Services.TryAddEnumerable(
             ServiceDescriptor.Singleton<

--- a/src/NetEvolve.Pulse/TimeoutExtensions.cs
+++ b/src/NetEvolve.Pulse/TimeoutExtensions.cs
@@ -3,6 +3,7 @@ namespace NetEvolve.Pulse;
 using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 using NetEvolve.Pulse.Extensibility;
 using NetEvolve.Pulse.Interceptors;
 
@@ -57,8 +58,17 @@ public static class TimeoutExtensions
     {
         ArgumentNullException.ThrowIfNull(configurator);
 
+        _ = configurator.Services.AddOptions<TimeoutRequestInterceptorOptions>().ValidateOnStart();
+
         _ = configurator.Services.Configure<TimeoutRequestInterceptorOptions>(opts =>
             opts.GlobalTimeout = globalTimeout
+        );
+
+        configurator.Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<
+                IValidateOptions<TimeoutRequestInterceptorOptions>,
+                TimeoutRequestInterceptorOptionsValidator
+            >()
         );
 
         configurator.Services.TryAddEnumerable(

--- a/tests/NetEvolve.Pulse.Tests.Unit/AzureServiceBus/AzureServiceBusExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/AzureServiceBus/AzureServiceBusExtensionsTests.cs
@@ -69,7 +69,12 @@ public sealed class AzureServiceBusExtensionsTests
         var provider = services.BuildServiceProvider();
         await using (provider.ConfigureAwait(false))
         {
-            _ = Assert.Throws<InvalidOperationException>(() => provider.GetRequiredService<ServiceBusClient>());
+            // Validation now runs through IValidateOptions<AzureServiceBusTransportOptions>, which
+            // Microsoft.Extensions.Options surfaces as an OptionsValidationException whenever the
+            // options are resolved (not just at ValidateOnStart's eager startup check).
+            _ = Assert.Throws<Microsoft.Extensions.Options.OptionsValidationException>(() =>
+                provider.GetRequiredService<ServiceBusClient>()
+            );
         }
     }
 

--- a/tests/NetEvolve.Pulse.Tests.Unit/AzureServiceBus/AzureServiceBusExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/AzureServiceBus/AzureServiceBusExtensionsTests.cs
@@ -3,6 +3,7 @@
 using Azure.Core;
 using Azure.Identity;
 using Azure.Messaging.ServiceBus;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.Pulse;
@@ -64,6 +65,7 @@ public sealed class AzureServiceBusExtensionsTests
     public async Task UseAzureServiceBusTransport_validates_required_options()
     {
         IServiceCollection services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config => config.UseAzureServiceBusTransport());
 
         var provider = services.BuildServiceProvider();
@@ -82,6 +84,7 @@ public sealed class AzureServiceBusExtensionsTests
     public async Task UseAzureServiceBusTransport_with_fully_qualified_namespace_creates_ServiceBusClient()
     {
         IServiceCollection services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
 
         // Register a fake credential so we don't depend on DefaultAzureCredential
         _ = services.AddSingleton<TokenCredential>(new FakeTokenCredential());
@@ -105,6 +108,7 @@ public sealed class AzureServiceBusExtensionsTests
     public async Task UseAzureServiceBusTransport_with_connection_string_creates_ServiceBusClient()
     {
         IServiceCollection services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config =>
             config.UseAzureServiceBusTransport(options => options.ConnectionString = FakeConnectionString)
         );

--- a/tests/NetEvolve.Pulse.Tests.Unit/AzureServiceBus/AzureServiceBusTransportOptionsConfigurationTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/AzureServiceBus/AzureServiceBusTransportOptionsConfigurationTests.cs
@@ -1,0 +1,58 @@
+namespace NetEvolve.Pulse.Tests.Unit.AzureServiceBus;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("AzureServiceBus")]
+public class AzureServiceBusTransportOptionsConfigurationTests
+{
+    [Test]
+    public async Task Configure_WithPopulatedSection_BindsAllProperties()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["Pulse:Transports:AzureServiceBus:ConnectionString"] = "Endpoint=sb://test/",
+                    ["Pulse:Transports:AzureServiceBus:FullyQualifiedNamespace"] = "contoso.servicebus.windows.net",
+                    ["Pulse:Transports:AzureServiceBus:EnableBatching"] = "false",
+                }
+            )
+            .Build();
+
+        var configurator = new AzureServiceBusTransportOptionsConfiguration(configuration);
+        var options = new AzureServiceBusTransportOptions();
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.ConnectionString).IsEqualTo("Endpoint=sb://test/");
+        _ = await Assert.That(options.FullyQualifiedNamespace).IsEqualTo("contoso.servicebus.windows.net");
+        _ = await Assert.That(options.EnableBatching).IsFalse();
+    }
+
+    [Test]
+    public async Task Configure_WithoutSection_LeavesDefaultsUnchanged()
+    {
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection([]).Build();
+
+        var configurator = new AzureServiceBusTransportOptionsConfiguration(configuration);
+        var options = new AzureServiceBusTransportOptions();
+        var defaultConnectionString = options.ConnectionString;
+        var defaultNamespace = options.FullyQualifiedNamespace;
+        var defaultBatching = options.EnableBatching;
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.ConnectionString).IsEqualTo(defaultConnectionString);
+        _ = await Assert.That(options.FullyQualifiedNamespace).IsEqualTo(defaultNamespace);
+        _ = await Assert.That(options.EnableBatching).IsEqualTo(defaultBatching);
+    }
+
+    [Test]
+    public void Constructor_WithNullConfiguration_ThrowsArgumentNullException() =>
+        _ = Assert.Throws<ArgumentNullException>(() => _ = new AzureServiceBusTransportOptionsConfiguration(null!));
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/AzureServiceBus/AzureServiceBusTransportOptionsValidatorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/AzureServiceBus/AzureServiceBusTransportOptionsValidatorTests.cs
@@ -1,0 +1,55 @@
+namespace NetEvolve.Pulse.Tests.Unit.AzureServiceBus;
+
+using System.Threading.Tasks;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("AzureServiceBus")]
+public class AzureServiceBusTransportOptionsValidatorTests
+{
+    private static readonly AzureServiceBusTransportOptionsValidator _validator = new();
+
+    [Test]
+    public async Task Validate_WithConnectionString_Succeeds()
+    {
+        var options = new AzureServiceBusTransportOptions { ConnectionString = "Endpoint=sb://localhost/" };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithFullyQualifiedNamespace_Succeeds()
+    {
+        var options = new AzureServiceBusTransportOptions
+        {
+            FullyQualifiedNamespace = "contoso.servicebus.windows.net",
+        };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithNeitherConnectionStringNorNamespace_Fails()
+    {
+        var options = new AzureServiceBusTransportOptions();
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithWhitespaceValues_Fails()
+    {
+        var options = new AzureServiceBusTransportOptions { ConnectionString = "   ", FullyQualifiedNamespace = "   " };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/Dapr/DaprExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Dapr/DaprExtensionsTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.Pulse;
@@ -51,6 +52,7 @@ public sealed class DaprExtensionsTests
     public async Task UseDaprTransport_Configures_options()
     {
         IServiceCollection services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config => config.UseDaprTransport(o => o.PubSubName = "custom-pubsub"));
 
         var provider = services.BuildServiceProvider();
@@ -63,6 +65,7 @@ public sealed class DaprExtensionsTests
     public async Task UseDaprTransport_Without_configureOptions_uses_default_PubSubName()
     {
         IServiceCollection services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config => config.UseDaprTransport());
 
         var provider = services.BuildServiceProvider();

--- a/tests/NetEvolve.Pulse.Tests.Unit/Dapr/DaprMessageTransportOptionsConfigurationTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Dapr/DaprMessageTransportOptionsConfigurationTests.cs
@@ -1,0 +1,47 @@
+namespace NetEvolve.Pulse.Tests.Unit.Dapr;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("Dapr")]
+public class DaprMessageTransportOptionsConfigurationTests
+{
+    [Test]
+    public async Task Configure_WithPopulatedSection_BindsAllProperties()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?> { ["Pulse:Transports:Dapr:PubSubName"] = "custom-pubsub" }
+            )
+            .Build();
+
+        var configurator = new DaprMessageTransportOptionsConfiguration(configuration);
+        var options = new DaprMessageTransportOptions();
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.PubSubName).IsEqualTo("custom-pubsub");
+    }
+
+    [Test]
+    public async Task Configure_WithoutSection_LeavesDefaultsUnchanged()
+    {
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection([]).Build();
+
+        var configurator = new DaprMessageTransportOptionsConfiguration(configuration);
+        var options = new DaprMessageTransportOptions();
+        var defaultPubSubName = options.PubSubName;
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.PubSubName).IsEqualTo(defaultPubSubName);
+    }
+
+    [Test]
+    public void Constructor_WithNullConfiguration_ThrowsArgumentNullException() =>
+        _ = Assert.Throws<ArgumentNullException>(() => _ = new DaprMessageTransportOptionsConfiguration(null!));
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/Dapr/DaprMessageTransportOptionsValidatorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Dapr/DaprMessageTransportOptionsValidatorTests.cs
@@ -1,0 +1,62 @@
+namespace NetEvolve.Pulse.Tests.Unit.Dapr;
+
+using System.Threading.Tasks;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("Dapr")]
+public class DaprMessageTransportOptionsValidatorTests
+{
+    private static readonly DaprMessageTransportOptionsValidator _validator = new();
+
+    [Test]
+    public async Task Validate_DefaultOptions_Succeeds()
+    {
+        var options = new DaprMessageTransportOptions();
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithCustomPubSubName_Succeeds()
+    {
+        var options = new DaprMessageTransportOptions { PubSubName = "custom-pubsub" };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithNullPubSubName_Fails()
+    {
+        var options = new DaprMessageTransportOptions { PubSubName = null! };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithEmptyPubSubName_Fails()
+    {
+        var options = new DaprMessageTransportOptions { PubSubName = string.Empty };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithWhitespacePubSubName_Fails()
+    {
+        var options = new DaprMessageTransportOptions { PubSubName = "   " };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/EntityFrameworkExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/EntityFrameworkExtensionsTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
@@ -107,6 +108,7 @@ public sealed class EntityFrameworkExtensionsTests
     public async Task AddEntityFrameworkOutbox_WithConfigureOptions_AppliesOptions()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddDbContext<TestDbContext>(o =>
             o.UseInMemoryDatabase(nameof(AddEntityFrameworkOutbox_WithConfigureOptions_AppliesOptions))
         );
@@ -127,6 +129,7 @@ public sealed class EntityFrameworkExtensionsTests
     public async Task AddEntityFrameworkOutbox_WithTableNameOption_AppliesOptions()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddDbContext<TestDbContext>(o =>
             o.UseInMemoryDatabase(nameof(AddEntityFrameworkOutbox_WithTableNameOption_AppliesOptions))
         );

--- a/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/LoggingInterceptorOptionsConfigurationTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/LoggingInterceptorOptionsConfigurationTests.cs
@@ -1,0 +1,55 @@
+namespace NetEvolve.Pulse.Tests.Unit.Interceptors;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Interceptors;
+using TUnit.Core;
+
+[TestGroup("Interceptors")]
+public class LoggingInterceptorOptionsConfigurationTests
+{
+    [Test]
+    public async Task Configure_WithPopulatedSection_BindsAllProperties()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["Pulse:Logging:LogLevel"] = "Information",
+                    ["Pulse:Logging:SlowRequestThreshold"] = "00:00:01",
+                }
+            )
+            .Build();
+
+        var configurator = new LoggingInterceptorOptionsConfiguration(configuration);
+        var options = new LoggingInterceptorOptions();
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.LogLevel).IsEqualTo(LogLevel.Information);
+        _ = await Assert.That(options.SlowRequestThreshold).IsEqualTo(TimeSpan.FromSeconds(1));
+    }
+
+    [Test]
+    public async Task Configure_WithoutSection_LeavesDefaultsUnchanged()
+    {
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection([]).Build();
+
+        var configurator = new LoggingInterceptorOptionsConfiguration(configuration);
+        var options = new LoggingInterceptorOptions();
+        var defaultLogLevel = options.LogLevel;
+        var defaultThreshold = options.SlowRequestThreshold;
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.LogLevel).IsEqualTo(defaultLogLevel);
+        _ = await Assert.That(options.SlowRequestThreshold).IsEqualTo(defaultThreshold);
+    }
+
+    [Test]
+    public void Constructor_WithNullConfiguration_ThrowsArgumentNullException() =>
+        _ = Assert.Throws<ArgumentNullException>(() => _ = new LoggingInterceptorOptionsConfiguration(null!));
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/TimeoutRequestInterceptorOptionsConfigurationTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/TimeoutRequestInterceptorOptionsConfigurationTests.cs
@@ -1,0 +1,45 @@
+namespace NetEvolve.Pulse.Tests.Unit.Interceptors;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Interceptors;
+using TUnit.Core;
+
+[TestGroup("Interceptors")]
+public class TimeoutRequestInterceptorOptionsConfigurationTests
+{
+    [Test]
+    public async Task Configure_WithPopulatedSection_BindsAllProperties()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["Pulse:Timeout:GlobalTimeout"] = "00:00:30" })
+            .Build();
+
+        var configurator = new TimeoutRequestInterceptorOptionsConfiguration(configuration);
+        var options = new TimeoutRequestInterceptorOptions();
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.GlobalTimeout).IsEqualTo(TimeSpan.FromSeconds(30));
+    }
+
+    [Test]
+    public async Task Configure_WithoutSection_LeavesDefaultsUnchanged()
+    {
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection([]).Build();
+
+        var configurator = new TimeoutRequestInterceptorOptionsConfiguration(configuration);
+        var options = new TimeoutRequestInterceptorOptions();
+        var defaultTimeout = options.GlobalTimeout;
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.GlobalTimeout).IsEqualTo(defaultTimeout);
+    }
+
+    [Test]
+    public void Constructor_WithNullConfiguration_ThrowsArgumentNullException() =>
+        _ = Assert.Throws<ArgumentNullException>(() => _ = new TimeoutRequestInterceptorOptionsConfiguration(null!));
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/TimeoutRequestInterceptorOptionsValidatorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/TimeoutRequestInterceptorOptionsValidatorTests.cs
@@ -1,0 +1,62 @@
+namespace NetEvolve.Pulse.Tests.Unit.Interceptors;
+
+using System.Threading.Tasks;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Interceptors;
+using TUnit.Core;
+
+[TestGroup("Interceptors")]
+public class TimeoutRequestInterceptorOptionsValidatorTests
+{
+    private static readonly TimeoutRequestInterceptorOptionsValidator _validator = new();
+
+    [Test]
+    public async Task Validate_WithNullGlobalTimeout_Succeeds()
+    {
+        var options = new TimeoutRequestInterceptorOptions { GlobalTimeout = null };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithPositiveGlobalTimeout_Succeeds()
+    {
+        var options = new TimeoutRequestInterceptorOptions { GlobalTimeout = TimeSpan.FromSeconds(30) };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithZeroGlobalTimeout_Fails()
+    {
+        var options = new TimeoutRequestInterceptorOptions { GlobalTimeout = TimeSpan.Zero };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithNegativeGlobalTimeout_Fails()
+    {
+        var options = new TimeoutRequestInterceptorOptions { GlobalTimeout = TimeSpan.FromSeconds(-1) };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_DefaultOptions_Succeeds()
+    {
+        var options = new TimeoutRequestInterceptorOptions();
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/LoggingExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/LoggingExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace NetEvolve.Pulse.Tests.Unit;
 
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
@@ -127,6 +128,7 @@ public class LoggingExtensionsTests
     public async Task AddLogging_WithConfigure_AppliesOptions()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         var configurator = new MediatorBuilder(services);
 
         _ = configurator.AddLogging(opts =>
@@ -152,6 +154,7 @@ public class LoggingExtensionsTests
     public async Task AddLogging_WithoutConfigure_UsesDefaultOptions()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         var configurator = new MediatorBuilder(services);
 
         _ = configurator.AddLogging();

--- a/tests/NetEvolve.Pulse.Tests.Unit/MySql/MySqlExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/MySql/MySqlExtensionsTests.cs
@@ -3,6 +3,7 @@ namespace NetEvolve.Pulse.Tests.Unit.MySql;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
@@ -122,6 +123,7 @@ public sealed class MySqlExtensionsTests
     public async Task AddMySqlOutbox_WithConfigureOptions_AppliesTableName()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config =>
             config.AddMySqlOutbox("Server=localhost;Database=mydb;", options => options.TableName = "CustomTable")
         );
@@ -139,6 +141,7 @@ public sealed class MySqlExtensionsTests
     public async Task AddMySqlOutbox_WithConfigureAction_AppliesOptions()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config =>
             config.AddMySqlOutbox(opts =>
             {
@@ -246,6 +249,7 @@ public sealed class MySqlExtensionsTests
     public async Task AddMySqlOutbox_WithFactory_WithConfigureOptions_AppliesOptions()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config =>
             config.AddMySqlOutbox(_ => "Server=localhost;Database=mydb;", options => options.TableName = "CustomTable")
         );

--- a/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxExtensionsTests.cs
@@ -102,9 +102,10 @@ public sealed class OutboxExtensionsTests
         var provider = services.BuildServiceProvider();
         await using (provider.ConfigureAwait(false))
         {
-            // AddOptions<OutboxOptions>().ValidateOnStart() eagerly validates at IHost startup;
-            // here we assert the equivalent failure surfaces the moment the options are resolved,
-            // since IValidateOptions<T> runs on every options creation, not only via the startup hook.
+            // The ValidateOnStart registration performed by AddOutbox eagerly validates options at
+            // IHost startup; here we assert the equivalent failure surfaces the moment the options
+            // are resolved, since the underlying validator runs on every options creation, not only
+            // via the startup hook.
             _ = Assert.Throws<OptionsValidationException>(() =>
                 _ = provider.GetRequiredService<IOptions<OutboxOptions>>().Value
             );

--- a/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxExtensionsTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.Pulse.Extensibility;
 using NetEvolve.Pulse.Extensibility.Outbox;
@@ -87,6 +88,26 @@ public sealed class OutboxExtensionsTests
         {
             _ = await Assert.That(descriptor).IsNotNull();
             _ = await Assert.That(descriptor!.Lifetime).IsEqualTo(ServiceLifetime.Scoped);
+        }
+    }
+
+    [Test]
+    public async Task AddOutbox_WithInvalidTableName_ValidateOnStart_ThrowsOnServiceProviderOptionsResolution()
+    {
+        var services = new ServiceCollection();
+        var builder = new MediatorBuilder(services);
+
+        _ = builder.AddOutbox(configureOptions: opts => opts.TableName = string.Empty);
+
+        var provider = services.BuildServiceProvider();
+        await using (provider.ConfigureAwait(false))
+        {
+            // AddOptions<OutboxOptions>().ValidateOnStart() eagerly validates at IHost startup;
+            // here we assert the equivalent failure surfaces the moment the options are resolved,
+            // since IValidateOptions<T> runs on every options creation, not only via the startup hook.
+            _ = Assert.Throws<OptionsValidationException>(() =>
+                _ = provider.GetRequiredService<IOptions<OutboxOptions>>().Value
+            );
         }
     }
 

--- a/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxExtensionsTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
@@ -95,6 +96,7 @@ public sealed class OutboxExtensionsTests
     public async Task AddOutbox_WithInvalidTableName_ValidateOnStart_ThrowsOnServiceProviderOptionsResolution()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         var builder = new MediatorBuilder(services);
 
         _ = builder.AddOutbox(configureOptions: opts => opts.TableName = string.Empty);

--- a/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxOptionsConfigurationTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxOptionsConfigurationTests.cs
@@ -1,0 +1,66 @@
+namespace NetEvolve.Pulse.Tests.Unit.Outbox;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("Outbox")]
+public class OutboxOptionsConfigurationTests
+{
+    [Test]
+    public async Task Configure_WithPopulatedSection_BindsAllProperties()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["Pulse:Outbox:Schema"] = "custom",
+                    ["Pulse:Outbox:TableName"] = "CustomOutboxMessage",
+                    ["Pulse:Outbox:ConnectionString"] = "Data Source=test.db",
+                    ["Pulse:Outbox:EnableWalMode"] = "false",
+                    ["Pulse:Outbox:ProcessingLeaseTimeout"] = "00:10:00",
+                }
+            )
+            .Build();
+
+        var configurator = new OutboxOptionsConfiguration(configuration);
+        var options = new OutboxOptions();
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.Schema).IsEqualTo("custom");
+        _ = await Assert.That(options.TableName).IsEqualTo("CustomOutboxMessage");
+        _ = await Assert.That(options.ConnectionString).IsEqualTo("Data Source=test.db");
+        _ = await Assert.That(options.EnableWalMode).IsFalse();
+        _ = await Assert.That(options.ProcessingLeaseTimeout).IsEqualTo(TimeSpan.FromMinutes(10));
+    }
+
+    [Test]
+    public async Task Configure_WithoutSection_LeavesDefaultsUnchanged()
+    {
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection([]).Build();
+
+        var configurator = new OutboxOptionsConfiguration(configuration);
+        var options = new OutboxOptions();
+        var defaultSchema = options.Schema;
+        var defaultTableName = options.TableName;
+        var defaultConnectionString = options.ConnectionString;
+        var defaultWalMode = options.EnableWalMode;
+        var defaultLeaseTimeout = options.ProcessingLeaseTimeout;
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.Schema).IsEqualTo(defaultSchema);
+        _ = await Assert.That(options.TableName).IsEqualTo(defaultTableName);
+        _ = await Assert.That(options.ConnectionString).IsEqualTo(defaultConnectionString);
+        _ = await Assert.That(options.EnableWalMode).IsEqualTo(defaultWalMode);
+        _ = await Assert.That(options.ProcessingLeaseTimeout).IsEqualTo(defaultLeaseTimeout);
+    }
+
+    [Test]
+    public void Constructor_WithNullConfiguration_ThrowsArgumentNullException() =>
+        _ = Assert.Throws<ArgumentNullException>(() => _ = new OutboxOptionsConfiguration(null!));
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxOptionsValidatorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxOptionsValidatorTests.cs
@@ -1,0 +1,74 @@
+namespace NetEvolve.Pulse.Tests.Unit.Outbox;
+
+using System.Threading.Tasks;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("Outbox")]
+public class OutboxOptionsValidatorTests
+{
+    private static readonly OutboxOptionsValidator _validator = new();
+
+    [Test]
+    public async Task Validate_DefaultOptions_Succeeds()
+    {
+        var options = new OutboxOptions();
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithNullTableName_Fails()
+    {
+        var options = new OutboxOptions { TableName = null! };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithEmptyTableName_Fails()
+    {
+        var options = new OutboxOptions { TableName = string.Empty };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithWhitespaceTableName_Fails()
+    {
+        var options = new OutboxOptions { TableName = "   " };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithValidTableName_Succeeds()
+    {
+        var options = new OutboxOptions { TableName = "CustomOutboxMessage" };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithNullConnectionString_Succeeds()
+    {
+        // ConnectionString is legitimately null for EF Core-based outbox usage; it must not be
+        // treated as invalid by this validator.
+        var options = new OutboxOptions { ConnectionString = null };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorHostedServiceDbContextLifetimeTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorHostedServiceDbContextLifetimeTests.cs
@@ -3,6 +3,7 @@ namespace NetEvolve.Pulse.Tests.Unit.Outbox;
 using System;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NetEvolve.Extensions.TUnit;
@@ -25,6 +26,7 @@ public sealed class OutboxProcessorHostedServiceDbContextLifetimeTests
     {
         var services = new ServiceCollection();
         _ = services.AddLogging();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddSingleton<IHostApplicationLifetime>(new FakeHostApplicationLifetime());
         _ = services.AddDbContext<TestDbContext>(o =>
             o.UseInMemoryDatabase(nameof(BuildServiceProvider_WithValidateScopesAndEntityFrameworkOutbox_DoesNotThrow))
@@ -52,6 +54,7 @@ public sealed class OutboxProcessorHostedServiceDbContextLifetimeTests
     {
         var services = new ServiceCollection();
         _ = services.AddLogging();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddSingleton<IHostApplicationLifetime>(new FakeHostApplicationLifetime());
         _ = services.AddDbContext<TestDbContext>(o =>
             o.UseInMemoryDatabase(nameof(ExecuteAsync_AcrossMultipleCycles_ResolvesFreshRepositoryPerCycle))

--- a/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorOptionsConfigurationTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorOptionsConfigurationTests.cs
@@ -1,0 +1,86 @@
+namespace NetEvolve.Pulse.Tests.Unit.Outbox;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("Outbox")]
+public class OutboxProcessorOptionsConfigurationTests
+{
+    [Test]
+    public async Task Configure_WithPopulatedSection_BindsAllProperties()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["Pulse:OutboxProcessor:BatchSize"] = "50",
+                    ["Pulse:OutboxProcessor:PollingInterval"] = "00:00:10",
+                    ["Pulse:OutboxProcessor:MaxRetryCount"] = "5",
+                    ["Pulse:OutboxProcessor:ProcessingTimeout"] = "00:01:00",
+                    ["Pulse:OutboxProcessor:EnableBatchSending"] = "true",
+                    ["Pulse:OutboxProcessor:EnableExponentialBackoff"] = "true",
+                    ["Pulse:OutboxProcessor:BaseRetryDelay"] = "00:00:15",
+                    ["Pulse:OutboxProcessor:MaxRetryDelay"] = "00:15:00",
+                    ["Pulse:OutboxProcessor:BackoffMultiplier"] = "3.5",
+                    ["Pulse:OutboxProcessor:AddJitter"] = "false",
+                }
+            )
+            .Build();
+
+        var configurator = new OutboxProcessorOptionsConfiguration(configuration);
+        var options = new OutboxProcessorOptions();
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.BatchSize).IsEqualTo(50);
+        _ = await Assert.That(options.PollingInterval).IsEqualTo(TimeSpan.FromSeconds(10));
+        _ = await Assert.That(options.MaxRetryCount).IsEqualTo(5);
+        _ = await Assert.That(options.ProcessingTimeout).IsEqualTo(TimeSpan.FromMinutes(1));
+        _ = await Assert.That(options.EnableBatchSending).IsTrue();
+        _ = await Assert.That(options.EnableExponentialBackoff).IsTrue();
+        _ = await Assert.That(options.BaseRetryDelay).IsEqualTo(TimeSpan.FromSeconds(15));
+        _ = await Assert.That(options.MaxRetryDelay).IsEqualTo(TimeSpan.FromMinutes(15));
+        _ = await Assert.That(options.BackoffMultiplier).IsEqualTo(3.5);
+        _ = await Assert.That(options.AddJitter).IsFalse();
+    }
+
+    [Test]
+    public async Task Configure_WithoutSection_LeavesDefaultsUnchanged()
+    {
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection([]).Build();
+
+        var configurator = new OutboxProcessorOptionsConfiguration(configuration);
+        var options = new OutboxProcessorOptions();
+        var defaultBatchSize = options.BatchSize;
+        var defaultPollingInterval = options.PollingInterval;
+        var defaultMaxRetryCount = options.MaxRetryCount;
+        var defaultProcessingTimeout = options.ProcessingTimeout;
+        var defaultEnableBatchSending = options.EnableBatchSending;
+        var defaultEnableExponentialBackoff = options.EnableExponentialBackoff;
+        var defaultBaseRetryDelay = options.BaseRetryDelay;
+        var defaultMaxRetryDelay = options.MaxRetryDelay;
+        var defaultBackoffMultiplier = options.BackoffMultiplier;
+        var defaultAddJitter = options.AddJitter;
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.BatchSize).IsEqualTo(defaultBatchSize);
+        _ = await Assert.That(options.PollingInterval).IsEqualTo(defaultPollingInterval);
+        _ = await Assert.That(options.MaxRetryCount).IsEqualTo(defaultMaxRetryCount);
+        _ = await Assert.That(options.ProcessingTimeout).IsEqualTo(defaultProcessingTimeout);
+        _ = await Assert.That(options.EnableBatchSending).IsEqualTo(defaultEnableBatchSending);
+        _ = await Assert.That(options.EnableExponentialBackoff).IsEqualTo(defaultEnableExponentialBackoff);
+        _ = await Assert.That(options.BaseRetryDelay).IsEqualTo(defaultBaseRetryDelay);
+        _ = await Assert.That(options.MaxRetryDelay).IsEqualTo(defaultMaxRetryDelay);
+        _ = await Assert.That(options.BackoffMultiplier).IsEqualTo(defaultBackoffMultiplier);
+        _ = await Assert.That(options.AddJitter).IsEqualTo(defaultAddJitter);
+    }
+
+    [Test]
+    public void Constructor_WithNullConfiguration_ThrowsArgumentNullException() =>
+        _ = Assert.Throws<ArgumentNullException>(() => _ = new OutboxProcessorOptionsConfiguration(null!));
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorOptionsValidatorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Outbox/OutboxProcessorOptionsValidatorTests.cs
@@ -1,0 +1,159 @@
+namespace NetEvolve.Pulse.Tests.Unit.Outbox;
+
+using System.Threading.Tasks;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("Outbox")]
+public class OutboxProcessorOptionsValidatorTests
+{
+    private static readonly OutboxProcessorOptionsValidator _validator = new();
+
+    [Test]
+    public async Task Validate_DefaultOptions_Succeeds()
+    {
+        var options = new OutboxProcessorOptions();
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithZeroBatchSize_Fails()
+    {
+        var options = new OutboxProcessorOptions { BatchSize = 0 };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithNegativeBatchSize_Fails()
+    {
+        var options = new OutboxProcessorOptions { BatchSize = -1 };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithZeroPollingInterval_Fails()
+    {
+        var options = new OutboxProcessorOptions { PollingInterval = TimeSpan.Zero };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithNegativePollingInterval_Fails()
+    {
+        var options = new OutboxProcessorOptions { PollingInterval = TimeSpan.FromSeconds(-1) };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithNegativeMaxRetryCount_Fails()
+    {
+        var options = new OutboxProcessorOptions { MaxRetryCount = -1 };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithZeroMaxRetryCount_Succeeds()
+    {
+        var options = new OutboxProcessorOptions { MaxRetryCount = 0 };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithZeroProcessingTimeout_Fails()
+    {
+        var options = new OutboxProcessorOptions { ProcessingTimeout = TimeSpan.Zero };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithExponentialBackoffEnabled_AndInvalidBackoffMultiplier_Fails()
+    {
+        var options = new OutboxProcessorOptions { EnableExponentialBackoff = true, BackoffMultiplier = 1.0 };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithExponentialBackoffEnabled_AndZeroBaseRetryDelay_Fails()
+    {
+        var options = new OutboxProcessorOptions { EnableExponentialBackoff = true, BaseRetryDelay = TimeSpan.Zero };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithExponentialBackoffEnabled_AndMaxRetryDelayLessThanBaseRetryDelay_Fails()
+    {
+        var options = new OutboxProcessorOptions
+        {
+            EnableExponentialBackoff = true,
+            BaseRetryDelay = TimeSpan.FromSeconds(10),
+            MaxRetryDelay = TimeSpan.FromSeconds(5),
+        };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithExponentialBackoffEnabled_AndValidValues_Succeeds()
+    {
+        var options = new OutboxProcessorOptions
+        {
+            EnableExponentialBackoff = true,
+            BackoffMultiplier = 2.0,
+            BaseRetryDelay = TimeSpan.FromSeconds(5),
+            MaxRetryDelay = TimeSpan.FromMinutes(5),
+        };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithExponentialBackoffDisabled_IgnoresBackoffFields()
+    {
+        var options = new OutboxProcessorOptions
+        {
+            EnableExponentialBackoff = false,
+            BackoffMultiplier = 0,
+            BaseRetryDelay = TimeSpan.Zero,
+            MaxRetryDelay = TimeSpan.Zero,
+        };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/PostgreSql/PostgreSqlExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/PostgreSql/PostgreSqlExtensionsTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
@@ -101,6 +102,7 @@ public sealed class PostgreSqlExtensionsTests
     public async Task AddPostgreSqlOutbox_WithConfigureOptions_AppliesOptions()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config =>
             config
                 .AddOutbox()
@@ -179,6 +181,7 @@ public sealed class PostgreSqlExtensionsTests
     public async Task AddPostgreSqlOutbox_WithFactory_WithConfigureOptions_AppliesOptions()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config =>
             config
                 .AddOutbox()

--- a/tests/NetEvolve.Pulse.Tests.Unit/QueryCachingExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/QueryCachingExtensionsTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
@@ -47,6 +48,7 @@ public sealed class QueryCachingExtensionsTests
     public async Task AddQueryCaching_WithConfigure_AppliesOptions()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         var builder = new MediatorBuilder(services);
 
         _ = builder.AddQueryCaching(opts => opts.ExpirationMode = CacheExpirationMode.Sliding);

--- a/tests/NetEvolve.Pulse.Tests.Unit/QueryCachingOptionsConfigurationTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/QueryCachingOptionsConfigurationTests.cs
@@ -1,0 +1,54 @@
+namespace NetEvolve.Pulse.Tests.Unit;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility.Caching;
+using TUnit.Core;
+
+[TestGroup("QueryCaching")]
+public sealed class QueryCachingOptionsConfigurationTests
+{
+    [Test]
+    public async Task Configure_WithPopulatedSection_BindsAllProperties()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["Pulse:QueryCaching:ExpirationMode"] = "Sliding",
+                    ["Pulse:QueryCaching:DefaultExpiry"] = "00:10:00",
+                }
+            )
+            .Build();
+
+        var configurator = new QueryCachingOptionsConfiguration(configuration);
+        var options = new QueryCachingOptions();
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.ExpirationMode).IsEqualTo(CacheExpirationMode.Sliding);
+        _ = await Assert.That(options.DefaultExpiry).IsEqualTo(TimeSpan.FromMinutes(10));
+    }
+
+    [Test]
+    public async Task Configure_WithoutSection_LeavesDefaultsUnchanged()
+    {
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection([]).Build();
+
+        var configurator = new QueryCachingOptionsConfiguration(configuration);
+        var options = new QueryCachingOptions();
+        var defaultMode = options.ExpirationMode;
+        var defaultExpiry = options.DefaultExpiry;
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.ExpirationMode).IsEqualTo(defaultMode);
+        _ = await Assert.That(options.DefaultExpiry).IsEqualTo(defaultExpiry);
+    }
+
+    [Test]
+    public void Constructor_WithNullConfiguration_ThrowsArgumentNullException() =>
+        _ = Assert.Throws<ArgumentNullException>(() => _ = new QueryCachingOptionsConfiguration(null!));
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/QueryCachingOptionsValidatorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/QueryCachingOptionsValidatorTests.cs
@@ -1,0 +1,66 @@
+namespace NetEvolve.Pulse.Tests.Unit;
+
+using System.Threading.Tasks;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility.Caching;
+using TUnit.Core;
+
+[TestGroup("QueryCaching")]
+public sealed class QueryCachingOptionsValidatorTests
+{
+    private static readonly QueryCachingOptionsValidator _validator = new();
+
+    [Test]
+    public async Task Validate_WithNullDefaultExpiry_Succeeds()
+    {
+        var options = new QueryCachingOptions { DefaultExpiry = null };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithPositiveDefaultExpiry_Succeeds()
+    {
+        var options = new QueryCachingOptions { DefaultExpiry = TimeSpan.FromMinutes(10) };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithZeroDefaultExpiry_Fails()
+    {
+        var options = new QueryCachingOptions { DefaultExpiry = TimeSpan.Zero };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithNegativeDefaultExpiry_Fails()
+    {
+        var options = new QueryCachingOptions { DefaultExpiry = TimeSpan.FromMinutes(-1) };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_NullOptions_ThrowsArgumentNullException() =>
+        _ = await Assert.That(() => _validator.Validate(null, null!)).Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Validate_DefaultOptions_Succeeds()
+    {
+        var options = new QueryCachingOptions();
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/RabbitMQ/RabbitMqExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/RabbitMQ/RabbitMqExtensionsTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace NetEvolve.Pulse.Tests.Unit.RabbitMQ;
 
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.Pulse.Extensibility;
@@ -52,6 +53,7 @@ public sealed class RabbitMqExtensionsTests
     public async Task UseRabbitMqTransport_Configures_options()
     {
         IServiceCollection services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config => config.UseRabbitMqTransport(options => options.ExchangeName = "test-exchange"));
 
         var provider = services.BuildServiceProvider();
@@ -68,6 +70,7 @@ public sealed class RabbitMqExtensionsTests
     public async Task UseRabbitMqTransport_Without_configureOptions_registers_options()
     {
         IServiceCollection services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config => config.UseRabbitMqTransport());
 
         var provider = services.BuildServiceProvider();
@@ -103,6 +106,7 @@ public sealed class RabbitMqExtensionsTests
     public async Task UseRabbitMqTransport_Resolves_channel_pool_from_connection_adapter_and_options()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config =>
             config.UseRabbitMqTransport(options =>
             {

--- a/tests/NetEvolve.Pulse.Tests.Unit/RabbitMQ/RabbitMqExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/RabbitMQ/RabbitMqExtensionsTests.cs
@@ -65,7 +65,7 @@ public sealed class RabbitMqExtensionsTests
     }
 
     [Test]
-    public async Task UseRabbitMqTransport_Without_configureOptions_registers_default_options()
+    public async Task UseRabbitMqTransport_Without_configureOptions_registers_options()
     {
         IServiceCollection services = new ServiceCollection();
         _ = services.AddPulse(config => config.UseRabbitMqTransport());
@@ -76,9 +76,10 @@ public sealed class RabbitMqExtensionsTests
             var options =
                 provider.GetRequiredService<Microsoft.Extensions.Options.IOptions<RabbitMqTransportOptions>>();
 
-            // Verify default options are accessible
-            _ = await Assert.That(options.Value).IsNotNull();
-            _ = await Assert.That(options.Value.ExchangeName).IsEqualTo(string.Empty);
+            // The default ExchangeName is empty and therefore invalid; validation runs whenever
+            // the options are resolved (independent of ValidateOnStart, which only forces eager
+            // validation at host startup).
+            _ = Assert.Throws<Microsoft.Extensions.Options.OptionsValidationException>(() => _ = options.Value);
         }
     }
 

--- a/tests/NetEvolve.Pulse.Tests.Unit/RabbitMQ/RabbitMqTransportOptionsConfigurationTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/RabbitMQ/RabbitMqTransportOptionsConfigurationTests.cs
@@ -1,0 +1,54 @@
+namespace NetEvolve.Pulse.Tests.Unit.RabbitMQ;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("RabbitMQ")]
+public class RabbitMqTransportOptionsConfigurationTests
+{
+    [Test]
+    public async Task Configure_WithPopulatedSection_BindsAllProperties()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["Pulse:Transports:RabbitMq:ExchangeName"] = "pulse-exchange",
+                    ["Pulse:Transports:RabbitMq:MaxChannelPoolSize"] = "25",
+                }
+            )
+            .Build();
+
+        var configurator = new RabbitMqTransportOptionsConfiguration(configuration);
+        var options = new RabbitMqTransportOptions();
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.ExchangeName).IsEqualTo("pulse-exchange");
+        _ = await Assert.That(options.MaxChannelPoolSize).IsEqualTo(25);
+    }
+
+    [Test]
+    public async Task Configure_WithoutSection_LeavesDefaultsUnchanged()
+    {
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection([]).Build();
+
+        var configurator = new RabbitMqTransportOptionsConfiguration(configuration);
+        var options = new RabbitMqTransportOptions();
+        var defaultExchangeName = options.ExchangeName;
+        var defaultPoolSize = options.MaxChannelPoolSize;
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.ExchangeName).IsEqualTo(defaultExchangeName);
+        _ = await Assert.That(options.MaxChannelPoolSize).IsEqualTo(defaultPoolSize);
+    }
+
+    [Test]
+    public void Constructor_WithNullConfiguration_ThrowsArgumentNullException() =>
+        _ = Assert.Throws<ArgumentNullException>(() => _ = new RabbitMqTransportOptionsConfiguration(null!));
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/RabbitMQ/RabbitMqTransportOptionsValidatorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/RabbitMQ/RabbitMqTransportOptionsValidatorTests.cs
@@ -1,0 +1,86 @@
+namespace NetEvolve.Pulse.Tests.Unit.RabbitMQ;
+
+using System.Threading.Tasks;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("RabbitMQ")]
+public class RabbitMqTransportOptionsValidatorTests
+{
+    private static readonly RabbitMqTransportOptionsValidator _validator = new();
+
+    [Test]
+    public async Task Validate_WithValidExchangeNameAndDefaultPoolSize_Succeeds()
+    {
+        var options = new RabbitMqTransportOptions { ExchangeName = "my-exchange" };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithEmptyExchangeName_Fails()
+    {
+        var options = new RabbitMqTransportOptions { ExchangeName = string.Empty };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithWhitespaceExchangeName_Fails()
+    {
+        var options = new RabbitMqTransportOptions { ExchangeName = "   " };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithZeroMaxChannelPoolSize_Fails()
+    {
+        var options = new RabbitMqTransportOptions { ExchangeName = "my-exchange", MaxChannelPoolSize = 0 };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithNegativeMaxChannelPoolSize_Fails()
+    {
+        var options = new RabbitMqTransportOptions { ExchangeName = "my-exchange", MaxChannelPoolSize = -1 };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithMinimumValidMaxChannelPoolSize_Succeeds()
+    {
+        var options = new RabbitMqTransportOptions { ExchangeName = "my-exchange", MaxChannelPoolSize = 1 };
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithBothExchangeNameAndPoolSizeInvalid_FailsWithBothMessages()
+    {
+        var options = new RabbitMqTransportOptions { ExchangeName = string.Empty, MaxChannelPoolSize = 0 };
+
+        var result = _validator.Validate(null, options);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(result.Failed).IsTrue();
+            _ = await Assert.That(result.Failures!.Count()).IsEqualTo(2);
+        }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/SQLite/SQLiteExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/SQLite/SQLiteExtensionsTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
@@ -106,6 +107,7 @@ public sealed class SQLiteExtensionsTests
     public async Task UseSQLiteOutbox_WithConfigureOptions_AppliesTableName()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config =>
             config.AddOutbox().UseSQLiteOutbox("Data Source=:memory:", options => options.TableName = "CustomTable")
         );
@@ -123,6 +125,7 @@ public sealed class SQLiteExtensionsTests
     public async Task UseSQLiteOutbox_WithConfigureAction_AppliesOptions()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config =>
             config
                 .AddOutbox()
@@ -265,6 +268,7 @@ public sealed class SQLiteExtensionsTests
     public async Task AddSQLiteOutbox_WithConfigureOptions_AppliesTableName()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config =>
             config.AddSQLiteOutbox("Data Source=:memory:", options => options.TableName = "CustomTable")
         );
@@ -282,6 +286,7 @@ public sealed class SQLiteExtensionsTests
     public async Task AddSQLiteOutbox_WithConfigureAction_AppliesOptions()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config =>
             config.AddSQLiteOutbox(opts =>
             {
@@ -389,6 +394,7 @@ public sealed class SQLiteExtensionsTests
     public async Task AddSQLiteOutbox_WithFactory_WithConfigureOptions_AppliesOptions()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config =>
             config.AddSQLiteOutbox(_ => "Data Source=:memory:", options => options.TableName = "CustomTable")
         );

--- a/tests/NetEvolve.Pulse.Tests.Unit/SqlServer/SqlServerExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/SqlServer/SqlServerExtensionsTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
@@ -101,6 +102,7 @@ public sealed class SqlServerExtensionsTests
     public async Task AddSqlServerOutbox_WithConfigureOptions_AppliesOptions()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config =>
             config.AddOutbox().AddSqlServerOutbox("Server=.;Encrypt=true;", options => options.Schema = "myschema")
         );
@@ -172,6 +174,7 @@ public sealed class SqlServerExtensionsTests
     public async Task AddSqlServerOutbox_WithFactory_WithConfigureOptions_AppliesOptions()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         _ = services.AddPulse(config =>
             config
                 .AddOutbox()

--- a/tests/NetEvolve.Pulse.Tests.Unit/TimeoutExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/TimeoutExtensionsTests.cs
@@ -3,6 +3,7 @@ namespace NetEvolve.Pulse.Tests.Unit;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
@@ -100,6 +101,7 @@ public sealed class TimeoutExtensionsTests
     public async Task AddRequestTimeout_WithGlobalTimeout_ConfiguresOptions()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         var configurator = new MediatorBuilder(services);
 
         _ = configurator.AddRequestTimeout(TimeSpan.FromSeconds(30));
@@ -117,6 +119,7 @@ public sealed class TimeoutExtensionsTests
     public async Task AddRequestTimeout_WithoutGlobalTimeout_LeavesGlobalTimeoutNull()
     {
         var services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         var configurator = new MediatorBuilder(services);
 
         _ = configurator.AddRequestTimeout();


### PR DESCRIPTION
## Summary

Adds `IValidateOptions<T>` validators for the following options classes, each registered with the fail-fast pattern (`AddOptions<T>().ValidateOnStart()` + `TryAddEnumerable(... IValidateOptions<T> ...)`) in their respective existing `Add*`/`Use*` extension method:

- `TimeoutRequestInterceptorOptions` (`AddRequestTimeout`) — `GlobalTimeout` must be null or > `TimeSpan.Zero`.
- `QueryCachingOptions` (`AddQueryCaching`) — `DefaultExpiry` must be null or > `TimeSpan.Zero`.
- `OutboxOptions` (`AddOutbox`) — `TableName` must not be null/empty/whitespace.
- `OutboxProcessorOptions` (`AddOutbox`) — `BatchSize > 0`, `PollingInterval > 0`, `MaxRetryCount >= 0`, `ProcessingTimeout > 0`; when `EnableExponentialBackoff` is true, also `BackoffMultiplier > 1.0`, `BaseRetryDelay > 0`, `MaxRetryDelay >= BaseRetryDelay`.
- `AzureServiceBusTransportOptions` (`UseAzureServiceBusTransport`) — either `ConnectionString` or `FullyQualifiedNamespace` must be set.
- `RabbitMqTransportOptions` (`UseRabbitMqTransport`) — `ExchangeName` not empty; `MaxChannelPoolSize >= 1` (the latter property was added by #241).
- `DaprMessageTransportOptions` (`UseDaprTransport`) — `PubSubName` not empty.

Each validator lives next to its options class, following the existing `{OptionsClassName}Validator` naming convention used by `LoggingInterceptorOptionsValidator`.

## Deviations from the issue text

- **`LoggingInterceptorOptions`** is intentionally left untouched. It already has a validator (`LoggingInterceptorOptionsValidator`) but registration doesn't call `.ValidateOnStart()`. This class was explicitly called out as out of scope for this change.
- **`AzureServiceBusTransportOptions`**: the transport previously validated its options imperatively at `ServiceBusClient`-creation time via a private static `ValidateOptions` method, throwing `InvalidOperationException`. This is replaced by `AzureServiceBusTransportOptionsValidator` registered via the options pipeline. Behavior is equivalent (same required-field check, still throws at first options resolution / at host startup with `ValidateOnStart`), but the thrown exception type changes to `Microsoft.Extensions.Options.OptionsValidationException`. Existing tests were updated to expect the new exception type.
- **`SQLiteOutboxOptions`** does not exist as a distinct type in the current codebase — the SQLite provider (`src/NetEvolve.Pulse.SQLite/Outbox/OutboxOptionsExtensions.cs`) reuses the shared `OutboxOptions`. This row from the issue is covered by the `OutboxOptionsValidator` added for `OutboxOptions` (`TableName` not empty). `OutboxOptions.ConnectionString` is intentionally **not** validated as required, since it is legitimately `null` for EF Core-based outbox usage (only ADO.NET-based providers need it) — making it mandatory would break existing valid configurations.

## Dependency

This branch is based on `feature/241-rabbitmq-channel-pool` (not yet merged to main), since `RabbitMqTransportOptions.MaxChannelPoolSize` — validated here — was introduced there. The diff shown in this PR is scoped to the #238-specific changes on top of that branch.

## Notes

Because `IValidateOptions<T>` runs validation whenever the options are resolved (via `IOptions<T>`/`IOptionsMonitor<T>`), not only through the `ValidateOnStart()` eager startup check, a couple of pre-existing tests that resolved default (and now invalid) option values needed small updates to assert the resulting `OptionsValidationException` instead of the previous default values / exception types.

Closes #238

## Test plan

- [x] `dotnet build Pulse.slnx` succeeds with no errors.
- [x] `csharpier format .` run before commit.
- [x] New validator unit tests (one class per validator) covering valid configuration and each invalid field — 59 tests, all passing.
- [x] Existing/updated extension registration tests (`OutboxExtensionsTests`, `RabbitMqExtensionsTests`, `AzureServiceBusExtensionsTests`, etc.) — 557 tests, all passing.
- [x] Verified `ValidateOnStart`'s effect end-to-end: resolving `IOptions<OutboxOptions>` (and similarly for RabbitMQ/AzureServiceBus) with an invalid configuration throws `OptionsValidationException` when the service provider builds the options.