### PR TITLE
feat(redis): Redis Streams outbox transport (UseRedisStreamsTransport)

### DIFF
--- a/src/NetEvolve.Pulse.Redis/NetEvolve.Pulse.Redis.csproj
+++ b/src/NetEvolve.Pulse.Redis/NetEvolve.Pulse.Redis.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="StackExchange.Redis" />
   </ItemGroup>
 

--- a/src/NetEvolve.Pulse.Redis/Outbox/RedisStreamsMessageTransport.cs
+++ b/src/NetEvolve.Pulse.Redis/Outbox/RedisStreamsMessageTransport.cs
@@ -1,0 +1,155 @@
+namespace NetEvolve.Pulse.Outbox;
+
+using System.Globalization;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.Extensibility.Outbox;
+using StackExchange.Redis;
+
+/// <summary>
+/// Message transport that publishes outbox messages to a Redis stream.
+/// </summary>
+/// <remarks>
+/// <para><strong>Stream Layout:</strong></para>
+/// Each message is appended to the configured stream via <c>XADD</c> with its fields flattened
+/// into name/value entries (<c>id</c>, <c>eventType</c>, <c>payload</c>, <c>correlationId</c>,
+/// <c>causationId</c>, <c>retryCount</c>, <c>createdAt</c>).
+/// <para><strong>Consumer Group Bootstrapping:</strong></para>
+/// When <see cref="RedisStreamsTransportOptions.CreateStreamIfNotExists"/> is enabled, the
+/// configured consumer group is created once per transport instance, lazily, on the first
+/// send. If the group already exists (e.g. created by another process or a prior run), the
+/// resulting <c>BUSYGROUP</c> error is treated as success.
+/// <para><strong>Prerequisites:</strong></para>
+/// <see cref="IConnectionMultiplexer"/> must be registered in the DI container by the caller
+/// before using this transport.
+/// </remarks>
+internal sealed class RedisStreamsMessageTransport : IMessageTransport, IDisposable
+{
+    private readonly IConnectionMultiplexer _multiplexer;
+    private readonly RedisStreamsTransportOptions _options;
+    private readonly SemaphoreSlim _initializationLock = new(1, 1);
+    private bool _consumerGroupEnsured;
+    private int _disposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RedisStreamsMessageTransport"/> class.
+    /// </summary>
+    /// <param name="multiplexer">The Redis connection multiplexer.</param>
+    /// <param name="options">The transport options.</param>
+    internal RedisStreamsMessageTransport(
+        IConnectionMultiplexer multiplexer,
+        IOptions<RedisStreamsTransportOptions> options
+    )
+    {
+        ArgumentNullException.ThrowIfNull(multiplexer);
+        ArgumentNullException.ThrowIfNull(options);
+
+        _multiplexer = multiplexer;
+        _options = options.Value;
+    }
+
+    /// <inheritdoc />
+    public async Task SendAsync(OutboxMessage message, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        var database = _multiplexer.GetDatabase(_options.Database);
+
+        await EnsureConsumerGroupAsync(database, cancellationToken).ConfigureAwait(false);
+
+        var fields = new NameValueEntry[]
+        {
+            new("id", message.Id.ToString()),
+            new("eventType", message.EventType.ToOutboxEventTypeName()),
+            new("payload", message.Payload),
+            new("correlationId", message.CorrelationId ?? string.Empty),
+            new("causationId", message.CausationId ?? string.Empty),
+            new("retryCount", message.RetryCount.ToString(CultureInfo.InvariantCulture)),
+            new("createdAt", message.CreatedAt.ToString("O", CultureInfo.InvariantCulture)),
+        };
+
+        _ = await database.StreamAddAsync(_options.StreamKey, fields).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Overridden to iterate <see cref="SendAsync"/> per message sequentially in enumeration
+    /// order; no atomic or pipelined batching is performed.
+    /// </remarks>
+    public async Task SendBatchAsync(IEnumerable<OutboxMessage> messages, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(messages);
+
+        foreach (var message in messages)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await SendAsync(message, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<bool> IsHealthyAsync(CancellationToken cancellationToken = default) =>
+        Task.FromResult(_multiplexer.IsConnected);
+
+    /// <summary>
+    /// Ensures the configured consumer group exists on the stream, creating it lazily and at
+    /// most once per transport instance when <see cref="RedisStreamsTransportOptions.CreateStreamIfNotExists"/>
+    /// is enabled.
+    /// </summary>
+    /// <param name="database">The Redis database to create the consumer group on.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    private async Task EnsureConsumerGroupAsync(IDatabase database, CancellationToken cancellationToken)
+    {
+        if (!_options.CreateStreamIfNotExists || Volatile.Read(ref _consumerGroupEnsured))
+        {
+            return;
+        }
+
+        await _initializationLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_consumerGroupEnsured)
+            {
+                return;
+            }
+
+            try
+            {
+                _ = await database
+                    .StreamCreateConsumerGroupAsync(
+                        _options.StreamKey,
+                        _options.ConsumerGroupName,
+                        "$",
+                        createStream: true
+                    )
+                    .ConfigureAwait(false);
+            }
+            catch (RedisServerException ex) when (ex.Message.StartsWith("BUSYGROUP", StringComparison.Ordinal))
+            {
+                // The consumer group already exists (e.g. created by another process or a
+                // prior run); treat this as success.
+            }
+
+            _consumerGroupEnsured = true;
+        }
+        finally
+        {
+            _ = _initializationLock.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Disposal is single-shot under concurrency: the first thread to flip <c>_disposed</c> via
+    /// <see cref="Interlocked.Exchange(ref int, int)"/> disposes <see cref="_initializationLock"/>;
+    /// all subsequent callers (including concurrent ones) are no-ops.
+    /// </remarks>
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        _initializationLock.Dispose();
+    }
+}

--- a/src/NetEvolve.Pulse.Redis/Outbox/RedisStreamsTransportOptions.cs
+++ b/src/NetEvolve.Pulse.Redis/Outbox/RedisStreamsTransportOptions.cs
@@ -1,0 +1,35 @@
+namespace NetEvolve.Pulse.Outbox;
+
+/// <summary>
+/// Configuration options for <see cref="RedisStreamsMessageTransport"/>.
+/// </summary>
+public sealed class RedisStreamsTransportOptions
+{
+    /// <summary>
+    /// Gets or sets the key of the Redis stream used for publishing outbox messages.
+    /// </summary>
+    public string StreamKey { get; set; } = "pulse:outbox";
+
+    /// <summary>
+    /// Gets or sets the name of the consumer group used to read messages from the stream.
+    /// </summary>
+    public string ConsumerGroupName { get; set; } = "pulse-processor";
+
+    /// <summary>
+    /// Gets or sets the name of the consumer within the consumer group.
+    /// </summary>
+    public string ConsumerName { get; set; } = Environment.MachineName;
+
+    /// <summary>
+    /// Gets or sets the Redis database index to use.
+    /// </summary>
+    /// <remarks>
+    /// -1 selects the connection multiplexer's default database.
+    /// </remarks>
+    public int Database { get; set; } = -1;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the stream and consumer group should be created if they do not already exist.
+    /// </summary>
+    public bool CreateStreamIfNotExists { get; set; } = true;
+}

--- a/src/NetEvolve.Pulse.Redis/Outbox/RedisStreamsTransportOptionsConfiguration.cs
+++ b/src/NetEvolve.Pulse.Redis/Outbox/RedisStreamsTransportOptionsConfiguration.cs
@@ -1,0 +1,23 @@
+namespace NetEvolve.Pulse.Outbox;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Binds <see cref="RedisStreamsTransportOptions"/> from the <c>Pulse:Transports:RedisStreams</c> configuration section.
+/// </summary>
+internal sealed class RedisStreamsTransportOptionsConfiguration : IConfigureOptions<RedisStreamsTransportOptions>
+{
+    private readonly IConfiguration _configuration;
+
+    public RedisStreamsTransportOptionsConfiguration(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        _configuration = configuration;
+    }
+
+    /// <inheritdoc />
+    public void Configure(RedisStreamsTransportOptions options) =>
+        _configuration.GetSection("Pulse:Transports:RedisStreams").Bind(options);
+}

--- a/src/NetEvolve.Pulse.Redis/Outbox/RedisStreamsTransportOptionsValidator.cs
+++ b/src/NetEvolve.Pulse.Redis/Outbox/RedisStreamsTransportOptionsValidator.cs
@@ -1,0 +1,29 @@
+namespace NetEvolve.Pulse.Outbox;
+
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Validates <see cref="RedisStreamsTransportOptions"/> ensuring that
+/// <see cref="RedisStreamsTransportOptions.StreamKey"/> and
+/// <see cref="RedisStreamsTransportOptions.ConsumerGroupName"/> are not empty.
+/// </summary>
+internal sealed class RedisStreamsTransportOptionsValidator : IValidateOptions<RedisStreamsTransportOptions>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, RedisStreamsTransportOptions options)
+    {
+        var failures = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(options.StreamKey))
+        {
+            failures.Add($"{nameof(RedisStreamsTransportOptions.StreamKey)} must not be null or empty.");
+        }
+
+        if (string.IsNullOrWhiteSpace(options.ConsumerGroupName))
+        {
+            failures.Add($"{nameof(RedisStreamsTransportOptions.ConsumerGroupName)} must not be null or empty.");
+        }
+
+        return failures.Count == 0 ? ValidateOptionsResult.Success : ValidateOptionsResult.Fail(failures);
+    }
+}

--- a/src/NetEvolve.Pulse.Redis/RedisStreamsMediatorBuilderExtensions.cs
+++ b/src/NetEvolve.Pulse.Redis/RedisStreamsMediatorBuilderExtensions.cs
@@ -1,0 +1,92 @@
+namespace NetEvolve.Pulse;
+
+using System;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.Outbox;
+using NetEvolve.Pulse.Outbox;
+
+/// <summary>
+/// Extension methods for registering the Redis Streams message transport with the Pulse mediator.
+/// </summary>
+public static class RedisStreamsMediatorBuilderExtensions
+{
+    /// <summary>
+    /// Configures the outbox to publish messages via Redis Streams.
+    /// </summary>
+    /// <param name="configurator">The mediator configurator.</param>
+    /// <param name="configure">An optional action to configure <see cref="RedisStreamsTransportOptions"/>.</param>
+    /// <returns>The configurator for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configurator"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para><strong>Prerequisites:</strong></para>
+    /// <see cref="StackExchange.Redis.IConnectionMultiplexer"/> must be registered in the DI container
+    /// by the caller before the application starts.
+    /// <para><strong>Note:</strong></para>
+    /// Replaces any previously registered <see cref="IMessageTransport"/>.
+    /// Options are also bound from the <c>Pulse:Transports:RedisStreams</c> configuration section automatically.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// // Register IConnectionMultiplexer first
+    /// services.AddSingleton&lt;IConnectionMultiplexer&gt;(_ =>
+    ///     ConnectionMultiplexer.Connect("localhost:6379"));
+    ///
+    /// services.AddPulse(config => config
+    ///     .UseRedisStreamsTransport()
+    /// );
+    ///
+    /// // Or with custom options
+    /// services.AddPulse(config => config
+    ///     .UseRedisStreamsTransport(opts =>
+    ///     {
+    ///         opts.StreamKey = "my-app:outbox";
+    ///         opts.ConsumerGroupName = "my-app-processor";
+    ///     })
+    /// );
+    /// </code>
+    /// </example>
+    public static IMediatorBuilder UseRedisStreamsTransport(
+        this IMediatorBuilder configurator,
+        Action<RedisStreamsTransportOptions>? configure = null
+    )
+    {
+        ArgumentNullException.ThrowIfNull(configurator);
+
+        var services = configurator.Services;
+
+        _ = services.AddOptions<RedisStreamsTransportOptions>().ValidateOnStart();
+
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<
+                IConfigureOptions<RedisStreamsTransportOptions>,
+                RedisStreamsTransportOptionsConfiguration
+            >()
+        );
+
+        if (configure is not null)
+        {
+            _ = services.Configure(configure);
+        }
+
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<
+                IValidateOptions<RedisStreamsTransportOptions>,
+                RedisStreamsTransportOptionsValidator
+            >()
+        );
+
+        var existing = services.FirstOrDefault(d => d.ServiceType == typeof(IMessageTransport));
+        if (existing is not null)
+        {
+            _ = services.Remove(existing);
+        }
+
+        _ = services.AddSingleton<IMessageTransport, RedisStreamsMessageTransport>();
+
+        return configurator;
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/Redis/RedisStreamsMediatorBuilderExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Redis/RedisStreamsMediatorBuilderExtensionsTests.cs
@@ -1,0 +1,120 @@
+namespace NetEvolve.Pulse.Tests.Unit.Redis;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.Outbox;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
+
+[TestGroup("Redis")]
+public sealed class RedisStreamsMediatorBuilderExtensionsTests
+{
+    [Test]
+    public async Task UseRedisStreamsTransport_Registers_transport_service()
+    {
+        IServiceCollection services = new ServiceCollection();
+        _ = services.AddPulse(config => config.UseRedisStreamsTransport());
+
+        var descriptor = services.Single(d => d.ServiceType == typeof(IMessageTransport));
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor.ImplementationType).IsEqualTo(typeof(RedisStreamsMessageTransport));
+            _ = await Assert.That(descriptor.Lifetime).IsEqualTo(ServiceLifetime.Singleton);
+        }
+    }
+
+    [Test]
+    public async Task UseRedisStreamsTransport_Replaces_existing_transport()
+    {
+        IServiceCollection services = new ServiceCollection();
+        _ = services.AddSingleton<IMessageTransport>(new DummyTransport());
+        _ = services.AddPulse(config => config.UseRedisStreamsTransport());
+
+        var descriptors = services.Where(d => d.ServiceType == typeof(IMessageTransport)).ToList();
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptors.Count).IsEqualTo(1);
+            _ = await Assert.That(descriptors[0].ImplementationType).IsEqualTo(typeof(RedisStreamsMessageTransport));
+        }
+    }
+
+    [Test]
+    public async Task UseRedisStreamsTransport_Configures_options()
+    {
+        IServiceCollection services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        _ = services.AddPulse(config =>
+            config.UseRedisStreamsTransport(options => options.StreamKey = "custom:stream")
+        );
+
+        var provider = services.BuildServiceProvider();
+        await using (provider.ConfigureAwait(false))
+        {
+            var options = provider.GetRequiredService<IOptions<RedisStreamsTransportOptions>>();
+
+            _ = await Assert.That(options.Value.StreamKey).IsEqualTo("custom:stream");
+        }
+    }
+
+    [Test]
+    public async Task UseRedisStreamsTransport_Without_configureOptions_Default_options_are_valid()
+    {
+        IServiceCollection services = new ServiceCollection();
+        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        _ = services.AddPulse(config => config.UseRedisStreamsTransport());
+
+        var provider = services.BuildServiceProvider();
+        await using (provider.ConfigureAwait(false))
+        {
+            var options = provider.GetRequiredService<IOptions<RedisStreamsTransportOptions>>();
+
+            _ = await Assert.That(options.Value.StreamKey).IsEqualTo("pulse:outbox");
+        }
+    }
+
+    [Test]
+    public async Task UseRedisStreamsTransport_When_configurator_null_throws()
+    {
+        IMediatorBuilder configurator = null!;
+
+        var exception = Assert.Throws<ArgumentNullException>(() => configurator.UseRedisStreamsTransport());
+
+        _ = await Assert.That(exception).IsNotNull();
+        _ = await Assert.That(exception.ParamName).IsEqualTo("configurator");
+    }
+
+    [Test]
+    public async Task UseRedisStreamsTransport_Returns_configurator_for_chaining()
+    {
+        IServiceCollection services = new ServiceCollection();
+        IMediatorBuilder? returnedConfigurator = null;
+
+        _ = services.AddPulse(config => returnedConfigurator = config.UseRedisStreamsTransport());
+
+        _ = await Assert.That(returnedConfigurator).IsNotNull();
+    }
+
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes - instantiated via DI container
+    private sealed class DummyTransport : IMessageTransport
+#pragma warning restore CA1812
+    {
+        public Task<bool> IsHealthyAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+
+        public Task SendAsync(OutboxMessage message, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
+        public Task SendBatchAsync(
+            IEnumerable<OutboxMessage> messages,
+            CancellationToken cancellationToken = default
+        ) => Task.CompletedTask;
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/Redis/RedisStreamsMessageTransportTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Redis/RedisStreamsMessageTransportTests.cs
@@ -1,0 +1,298 @@
+namespace NetEvolve.Pulse.Tests.Unit.Redis;
+
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.Outbox;
+using NetEvolve.Pulse.Outbox;
+using StackExchange.Redis;
+using TUnit.Core;
+
+/// <summary>
+/// Behavioral invariants for <see cref="RedisStreamsMessageTransport"/>.
+/// IConnectionMultiplexer/IDatabase are very large interfaces; this file uses
+/// <see cref="DispatchProxy"/> to intercept the few methods the transport actually calls
+/// (<c>GetDatabase</c>, <c>StreamAddAsync</c>, <c>StreamCreateConsumerGroupAsync</c>) and capture
+/// their arguments. Every other call routes to <see cref="NotImplementedException"/> so accidental
+/// new dependencies on Redis methods surface immediately.
+/// </summary>
+[TestGroup("Redis")]
+public sealed class RedisStreamsMessageTransportTests
+{
+#pragma warning disable CA1034 // Test-only nested helper types; not part of any public API.
+#pragma warning disable CA1002 // List<T> as accumulator is fine for test fixtures.
+
+    internal sealed record StreamAddCall(RedisKey Key, NameValueEntry[] Fields);
+
+    internal sealed record StreamCreateConsumerGroupCall(RedisKey Key, RedisValue GroupName, RedisValue? Position);
+
+    internal class FakeDatabase : DispatchProxy
+    {
+        public List<StreamAddCall> StreamAddCalls { get; } = new();
+        public List<StreamCreateConsumerGroupCall> StreamCreateConsumerGroupCalls { get; } = new();
+        public bool ThrowBusyGroupOnCreateConsumerGroup { get; set; }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            if (targetMethod is null)
+            {
+                throw new InvalidOperationException("Null target method");
+            }
+
+            switch (targetMethod.Name)
+            {
+                case nameof(IDatabase.StreamAddAsync):
+                {
+                    // The transport calls the overload (RedisKey, NameValueEntry[], RedisValue?, int?, bool, CommandFlags)
+                    if (args is { Length: >= 2 } && args[0] is RedisKey key && args[1] is NameValueEntry[] fields)
+                    {
+                        StreamAddCalls.Add(new StreamAddCall(key, fields));
+                        return Task.FromResult(RedisValue.Null);
+                    }
+                    throw new NotSupportedException($"Unexpected StreamAddAsync overload: {targetMethod}");
+                }
+                case nameof(IDatabase.StreamCreateConsumerGroupAsync):
+                {
+                    if (args is { Length: >= 3 } && args[0] is RedisKey key && args[1] is RedisValue groupName)
+                    {
+                        var position = (RedisValue?)args[2];
+                        StreamCreateConsumerGroupCalls.Add(new StreamCreateConsumerGroupCall(key, groupName, position));
+
+                        if (ThrowBusyGroupOnCreateConsumerGroup)
+                        {
+                            throw new RedisServerException("BUSYGROUP Consumer Group name already exists");
+                        }
+
+                        return Task.FromResult(true);
+                    }
+                    throw new NotSupportedException(
+                        $"Unexpected StreamCreateConsumerGroupAsync overload: {targetMethod}"
+                    );
+                }
+                default:
+                    throw new NotImplementedException($"FakeDatabase has no behavior for {targetMethod}");
+            }
+        }
+    }
+
+    internal class FakeMultiplexer : DispatchProxy
+    {
+        public IDatabase? Database { get; set; }
+        public bool IsConnected { get; set; } = true;
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            if (targetMethod is null)
+            {
+                throw new InvalidOperationException("Null target method");
+            }
+
+            if (targetMethod.Name == nameof(IConnectionMultiplexer.GetDatabase))
+            {
+                return Database!;
+            }
+
+            if (targetMethod.Name == $"get_{nameof(IConnectionMultiplexer.IsConnected)}")
+            {
+                return IsConnected;
+            }
+
+            throw new NotImplementedException($"FakeMultiplexer has no behavior for {targetMethod}");
+        }
+    }
+
+    private static (IConnectionMultiplexer Mux, FakeMultiplexer MuxFake, FakeDatabase Capture) BuildFakes()
+    {
+        var dbProxy = DispatchProxy.Create<IDatabase, FakeDatabase>();
+        var muxProxy = DispatchProxy.Create<IConnectionMultiplexer, FakeMultiplexer>();
+        var muxFake = (FakeMultiplexer)(object)muxProxy;
+        muxFake.Database = dbProxy;
+        return (muxProxy, muxFake, (FakeDatabase)(object)dbProxy);
+    }
+
+    private static OutboxMessage CreateOutboxMessage() =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            EventType = typeof(TestRedisEvent),
+            Payload = """{"event":"sample"}""",
+            CorrelationId = "corr-123",
+            CausationId = "cause-456",
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            RetryCount = 2,
+        };
+
+    private sealed record TestRedisEvent : IEvent
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+        public string Id { get; init; } = Guid.NewGuid().ToString();
+        public DateTimeOffset? PublishedAt { get; set; }
+    }
+
+    [Test]
+    public async Task SendAsync_Publishes_one_entry_with_expected_fields(CancellationToken cancellationToken)
+    {
+        var (mux, _, capture) = BuildFakes();
+        var options = Options.Create(new RedisStreamsTransportOptions { StreamKey = "test-stream" });
+        using var transport = new RedisStreamsMessageTransport(mux, options);
+        var message = CreateOutboxMessage();
+
+        await transport.SendAsync(message, cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(capture.StreamAddCalls).HasCount(1);
+        var call = capture.StreamAddCalls[0];
+#pragma warning disable S8969 // RedisKey's implicit string conversion is annotated nullable; the value is never null here
+        _ = await Assert.That((string)call.Key!).IsEqualTo("test-stream");
+#pragma warning restore S8969
+
+#pragma warning disable S8969 // RedisValue's implicit string conversion is annotated nullable; the value is never null here
+        var byName = call.Fields.ToDictionary(f => ((string)f.Name)!, f => ((string)f.Value)!, StringComparer.Ordinal);
+#pragma warning restore S8969
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(byName["id"]).IsEqualTo(message.Id.ToString());
+            _ = await Assert.That(byName["eventType"]).IsEqualTo(message.EventType.ToOutboxEventTypeName());
+            _ = await Assert.That(byName["payload"]).IsEqualTo(message.Payload);
+            _ = await Assert.That(byName["correlationId"]).IsEqualTo(message.CorrelationId);
+            _ = await Assert.That(byName["causationId"]).IsEqualTo(message.CausationId);
+            _ = await Assert
+                .That(byName["retryCount"])
+                .IsEqualTo(message.RetryCount.ToString(CultureInfo.InvariantCulture));
+            _ = await Assert
+                .That(byName["createdAt"])
+                .IsEqualTo(message.CreatedAt.ToString("O", CultureInfo.InvariantCulture));
+        }
+    }
+
+    [Test]
+    public async Task SendAsync_Creates_consumer_group_once_on_first_use(CancellationToken cancellationToken)
+    {
+        var (mux, _, capture) = BuildFakes();
+        var options = Options.Create(
+            new RedisStreamsTransportOptions { CreateStreamIfNotExists = true, ConsumerGroupName = "group-1" }
+        );
+        using var transport = new RedisStreamsMessageTransport(mux, options);
+
+        await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false);
+        await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(capture.StreamCreateConsumerGroupCalls).HasCount(1);
+        _ = await Assert.That(capture.StreamAddCalls).HasCount(2);
+#pragma warning disable S8969 // RedisValue's implicit string conversion is annotated nullable; the value is never null here
+        _ = await Assert.That((string)capture.StreamCreateConsumerGroupCalls[0].GroupName!).IsEqualTo("group-1");
+#pragma warning restore S8969
+    }
+
+    [Test]
+    public async Task SendAsync_Tolerates_BUSYGROUP_error_and_still_adds_entry(CancellationToken cancellationToken)
+    {
+        var (mux, _, capture) = BuildFakes();
+        capture.ThrowBusyGroupOnCreateConsumerGroup = true;
+        var options = Options.Create(new RedisStreamsTransportOptions { CreateStreamIfNotExists = true });
+        using var transport = new RedisStreamsMessageTransport(mux, options);
+
+        await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(capture.StreamCreateConsumerGroupCalls).HasCount(1);
+        _ = await Assert.That(capture.StreamAddCalls).HasCount(1);
+    }
+
+    [Test]
+    public async Task SendAsync_When_CreateStreamIfNotExists_false_does_not_create_consumer_group(
+        CancellationToken cancellationToken
+    )
+    {
+        var (mux, _, capture) = BuildFakes();
+        var options = Options.Create(new RedisStreamsTransportOptions { CreateStreamIfNotExists = false });
+        using var transport = new RedisStreamsMessageTransport(mux, options);
+
+        await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(capture.StreamCreateConsumerGroupCalls).HasCount(0);
+        _ = await Assert.That(capture.StreamAddCalls).HasCount(1);
+    }
+
+    [Test]
+    public async Task SendBatchAsync_Sends_all_messages_in_order(CancellationToken cancellationToken)
+    {
+        var (mux, _, capture) = BuildFakes();
+        var options = Options.Create(new RedisStreamsTransportOptions());
+        using var transport = new RedisStreamsMessageTransport(mux, options);
+
+        var messages = Enumerable.Range(0, 3).Select(_ => CreateOutboxMessage()).ToArray();
+
+        await transport.SendBatchAsync(messages, cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(capture.StreamAddCalls).HasCount(3);
+
+        for (var i = 0; i < messages.Length; i++)
+        {
+            var byName = capture
+                .StreamAddCalls[i]
+#pragma warning disable S8969 // RedisValue's implicit string conversion is annotated nullable; the value is never null here
+                .Fields.ToDictionary(f => ((string)f.Name)!, f => ((string)f.Value)!, StringComparer.Ordinal);
+#pragma warning restore S8969
+            _ = await Assert.That(byName["id"]).IsEqualTo(messages[i].Id.ToString());
+        }
+    }
+
+    [Test]
+    public async Task IsHealthyAsync_When_multiplexer_connected_returns_true(CancellationToken cancellationToken)
+    {
+        var (mux, muxFake, _) = BuildFakes();
+        muxFake.IsConnected = true;
+        var options = Options.Create(new RedisStreamsTransportOptions());
+        using var transport = new RedisStreamsMessageTransport(mux, options);
+
+        var healthy = await transport.IsHealthyAsync(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(healthy).IsTrue();
+    }
+
+    [Test]
+    public async Task IsHealthyAsync_When_multiplexer_disconnected_returns_false(CancellationToken cancellationToken)
+    {
+        var (mux, muxFake, _) = BuildFakes();
+        muxFake.IsConnected = false;
+        var options = Options.Create(new RedisStreamsTransportOptions());
+        using var transport = new RedisStreamsMessageTransport(mux, options);
+
+        var healthy = await transport.IsHealthyAsync(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(healthy).IsFalse();
+    }
+
+    [Test]
+    public async Task Constructor_When_multiplexer_null_throws()
+    {
+        IConnectionMultiplexer multiplexer = null!;
+        var options = Options.Create(new RedisStreamsTransportOptions());
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            _ = new RedisStreamsMessageTransport(multiplexer, options)
+        );
+
+        _ = await Assert.That(exception).IsNotNull();
+        _ = await Assert.That(exception.ParamName).IsEqualTo("multiplexer");
+    }
+
+    [Test]
+    public async Task Constructor_When_options_null_throws()
+    {
+        var (mux, _, _) = BuildFakes();
+        IOptions<RedisStreamsTransportOptions> options = null!;
+
+        var exception = Assert.Throws<ArgumentNullException>(() => _ = new RedisStreamsMessageTransport(mux, options));
+
+        _ = await Assert.That(exception).IsNotNull();
+        _ = await Assert.That(exception.ParamName).IsEqualTo("options");
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/Redis/RedisStreamsTransportOptionsConfigurationTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Redis/RedisStreamsTransportOptionsConfigurationTests.cs
@@ -1,0 +1,66 @@
+namespace NetEvolve.Pulse.Tests.Unit.Redis;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("Redis")]
+public class RedisStreamsTransportOptionsConfigurationTests
+{
+    [Test]
+    public async Task Configure_WithPopulatedSection_BindsAllProperties()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["Pulse:Transports:RedisStreams:StreamKey"] = "custom:stream",
+                    ["Pulse:Transports:RedisStreams:ConsumerGroupName"] = "custom-group",
+                    ["Pulse:Transports:RedisStreams:ConsumerName"] = "custom-consumer",
+                    ["Pulse:Transports:RedisStreams:Database"] = "3",
+                    ["Pulse:Transports:RedisStreams:CreateStreamIfNotExists"] = "false",
+                }
+            )
+            .Build();
+
+        var configurator = new RedisStreamsTransportOptionsConfiguration(configuration);
+        var options = new RedisStreamsTransportOptions();
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.StreamKey).IsEqualTo("custom:stream");
+        _ = await Assert.That(options.ConsumerGroupName).IsEqualTo("custom-group");
+        _ = await Assert.That(options.ConsumerName).IsEqualTo("custom-consumer");
+        _ = await Assert.That(options.Database).IsEqualTo(3);
+        _ = await Assert.That(options.CreateStreamIfNotExists).IsFalse();
+    }
+
+    [Test]
+    public async Task Configure_WithoutSection_LeavesDefaultsUnchanged()
+    {
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection([]).Build();
+
+        var configurator = new RedisStreamsTransportOptionsConfiguration(configuration);
+        var options = new RedisStreamsTransportOptions();
+        var defaultStreamKey = options.StreamKey;
+        var defaultConsumerGroupName = options.ConsumerGroupName;
+        var defaultConsumerName = options.ConsumerName;
+        var defaultDatabase = options.Database;
+        var defaultCreateStreamIfNotExists = options.CreateStreamIfNotExists;
+
+        configurator.Configure(options);
+
+        _ = await Assert.That(options.StreamKey).IsEqualTo(defaultStreamKey);
+        _ = await Assert.That(options.ConsumerGroupName).IsEqualTo(defaultConsumerGroupName);
+        _ = await Assert.That(options.ConsumerName).IsEqualTo(defaultConsumerName);
+        _ = await Assert.That(options.Database).IsEqualTo(defaultDatabase);
+        _ = await Assert.That(options.CreateStreamIfNotExists).IsEqualTo(defaultCreateStreamIfNotExists);
+    }
+
+    [Test]
+    public void Constructor_WithNullConfiguration_ThrowsArgumentNullException() =>
+        _ = Assert.Throws<ArgumentNullException>(() => _ = new RedisStreamsTransportOptionsConfiguration(null!));
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/Redis/RedisStreamsTransportOptionsValidatorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Redis/RedisStreamsTransportOptionsValidatorTests.cs
@@ -1,0 +1,179 @@
+namespace NetEvolve.Pulse.Tests.Unit.Redis;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Outbox;
+using TUnit.Core;
+
+[TestGroup("Redis")]
+public class RedisStreamsTransportOptionsValidatorTests
+{
+    private static readonly RedisStreamsTransportOptionsValidator _validator = new();
+
+    [Test]
+    public async Task Validate_DefaultOptions_Succeeds()
+    {
+        var options = new RedisStreamsTransportOptions();
+
+        var result = _validator.Validate(null, options);
+
+        _ = await Assert.That(result.Succeeded).IsTrue();
+    }
+
+    [Test]
+    public async Task Validate_WithEmptyStreamKey_Fails()
+    {
+        var options = new RedisStreamsTransportOptions { StreamKey = string.Empty };
+
+        var result = _validator.Validate(null, options);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(result.Failed).IsTrue();
+            var failures = result.Failures!.ToArray();
+            _ = await Assert
+                .That(
+                    failures.Any(f =>
+                        f.Contains(nameof(RedisStreamsTransportOptions.StreamKey), StringComparison.Ordinal)
+                    )
+                )
+                .IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task Validate_WithNullStreamKey_Fails()
+    {
+        var options = new RedisStreamsTransportOptions { StreamKey = null! };
+
+        var result = _validator.Validate(null, options);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(result.Failed).IsTrue();
+            var failures = result.Failures!.ToArray();
+            _ = await Assert
+                .That(
+                    failures.Any(f =>
+                        f.Contains(nameof(RedisStreamsTransportOptions.StreamKey), StringComparison.Ordinal)
+                    )
+                )
+                .IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task Validate_WithWhitespaceStreamKey_Fails()
+    {
+        var options = new RedisStreamsTransportOptions { StreamKey = "   " };
+
+        var result = _validator.Validate(null, options);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(result.Failed).IsTrue();
+            var failures = result.Failures!.ToArray();
+            _ = await Assert
+                .That(
+                    failures.Any(f =>
+                        f.Contains(nameof(RedisStreamsTransportOptions.StreamKey), StringComparison.Ordinal)
+                    )
+                )
+                .IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task Validate_WithEmptyConsumerGroupName_Fails()
+    {
+        var options = new RedisStreamsTransportOptions { ConsumerGroupName = string.Empty };
+
+        var result = _validator.Validate(null, options);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(result.Failed).IsTrue();
+            var failures = result.Failures!.ToArray();
+            _ = await Assert
+                .That(
+                    failures.Any(f =>
+                        f.Contains(nameof(RedisStreamsTransportOptions.ConsumerGroupName), StringComparison.Ordinal)
+                    )
+                )
+                .IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task Validate_WithNullConsumerGroupName_Fails()
+    {
+        var options = new RedisStreamsTransportOptions { ConsumerGroupName = null! };
+
+        var result = _validator.Validate(null, options);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(result.Failed).IsTrue();
+            var failures = result.Failures!.ToArray();
+            _ = await Assert
+                .That(
+                    failures.Any(f =>
+                        f.Contains(nameof(RedisStreamsTransportOptions.ConsumerGroupName), StringComparison.Ordinal)
+                    )
+                )
+                .IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task Validate_WithWhitespaceConsumerGroupName_Fails()
+    {
+        var options = new RedisStreamsTransportOptions { ConsumerGroupName = "   " };
+
+        var result = _validator.Validate(null, options);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(result.Failed).IsTrue();
+            var failures = result.Failures!.ToArray();
+            _ = await Assert
+                .That(
+                    failures.Any(f =>
+                        f.Contains(nameof(RedisStreamsTransportOptions.ConsumerGroupName), StringComparison.Ordinal)
+                    )
+                )
+                .IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task Validate_WithBothStreamKeyAndConsumerGroupNameInvalid_FailsWithBothMessages()
+    {
+        var options = new RedisStreamsTransportOptions { StreamKey = string.Empty, ConsumerGroupName = string.Empty };
+
+        var result = _validator.Validate(null, options);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(result.Failed).IsTrue();
+            var failures = result.Failures!.ToArray();
+            _ = await Assert.That(failures.Length).IsEqualTo(2);
+            _ = await Assert
+                .That(
+                    failures.Any(f =>
+                        f.Contains(nameof(RedisStreamsTransportOptions.StreamKey), StringComparison.Ordinal)
+                    )
+                )
+                .IsTrue();
+            _ = await Assert
+                .That(
+                    failures.Any(f =>
+                        f.Contains(nameof(RedisStreamsTransportOptions.ConsumerGroupName), StringComparison.Ordinal)
+                    )
+                )
+                .IsTrue();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `RedisStreamsMessageTransport` (`IMessageTransport`), publishing outbox messages to a Redis stream via `XADD`, with lazy per-instance consumer-group bootstrapping (`XGROUP CREATE`) that tolerates a concurrent `BUSYGROUP` creation.
- Adds `RedisStreamsTransportOptions` (`StreamKey`, `ConsumerGroupName`, `ConsumerName`, `Database`, `CreateStreamIfNotExists`) with its `IValidateOptions`/`IConfigureOptions` pair, following this repo's established options-validation/configuration-binding pattern (`ValidateOnStart`, binds from `Pulse:Transports:RedisStreams`).
- Adds `UseRedisStreamsTransport(this IMediatorBuilder, ...)` registration extension, mirroring the RabbitMQ/Dapr transport registration shape.
- Adds unit tests for the transport (DispatchProxy-based fakes for `IConnectionMultiplexer`/`IDatabase`), the validator, the configuration binder, and the registration extension.

Closes #284
Closes #285

## Test plan
- [x] `dotnet build` clean on net8.0/net9.0/net10.0
- [x] `dotnet test` — full `NetEvolve.Pulse.Tests.Unit` suite passes (1657 tests)
- [x] `csharpier format .`