### PR TITLE
feat(caching): declarative cache invalidation for query caching

### DIFF
--- a/src/NetEvolve.Pulse.Extensibility/IInvalidatingCommand.cs
+++ b/src/NetEvolve.Pulse.Extensibility/IInvalidatingCommand.cs
@@ -1,0 +1,44 @@
+namespace NetEvolve.Pulse.Extensibility;
+
+using System;
+using System.Collections.Generic;
+
+/// <summary>
+/// Represents a command that, upon successful execution, invalidates the cached results of one or more
+/// query types.
+/// </summary>
+/// <typeparam name="TResponse">The type of response returned after executing the command.</typeparam>
+/// <remarks>
+/// <para><strong>Purpose:</strong></para>
+/// Commands implementing this interface declare which query types' cached results become stale when the
+/// command succeeds. This allows a cache invalidation interceptor to evict the corresponding cache entries
+/// after the command handler completes.
+/// <para><strong>Declared Types:</strong></para>
+/// Each <see cref="Type"/> listed in <see cref="InvalidatedQueryTypes"/> is expected to implement
+/// <see cref="IQuery{TResponse}"/> for the same <typeparamref name="TResponse"/> as this command. This
+/// interface does not enforce that relationship; the runtime check is performed by the consuming
+/// interceptor when it processes the invalidation.
+/// </remarks>
+/// <example>
+/// <code>
+/// public record UpdateCustomerCommand(string CustomerId, string Name)
+///     : IInvalidatingCommand&lt;CustomerUpdatedResult&gt;
+/// {
+///     public IEnumerable&lt;Type&gt; InvalidatedQueryTypes { get; } = [typeof(GetCustomerByIdQuery)];
+/// }
+///
+/// public record CustomerUpdatedResult(string CustomerId, DateTime UpdatedAt);
+/// </code>
+/// </example>
+/// <seealso cref="ICommand{TResponse}"/>
+public interface IInvalidatingCommand<TResponse> : ICommand<TResponse>
+{
+    /// <summary>
+    /// Gets the query types whose cached results should be invalidated after this command succeeds.
+    /// </summary>
+    /// <remarks>
+    /// Each listed type is expected to implement <see cref="IQuery{TResponse}"/> for the same
+    /// <typeparamref name="TResponse"/>, though this is not enforced by this interface.
+    /// </remarks>
+    IEnumerable<Type> InvalidatedQueryTypes { get; }
+}

--- a/src/NetEvolve.Pulse/CacheInvalidationMediatorBuilderExtensions.cs
+++ b/src/NetEvolve.Pulse/CacheInvalidationMediatorBuilderExtensions.cs
@@ -1,0 +1,46 @@
+namespace NetEvolve.Pulse;
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Interceptors;
+using NetEvolve.Pulse.Internals;
+
+/// <summary>
+/// Provides extension methods for registering the cache invalidation interceptor
+/// with the Pulse mediator.
+/// </summary>
+/// <seealso cref="IInvalidatingCommand{TResponse}"/>
+public static class CacheInvalidationMediatorBuilderExtensions
+{
+    /// <summary>
+    /// Registers the cache invalidation interceptor for commands.
+    /// Commands implementing <see cref="IInvalidatingCommand{TResponse}"/> evict the cached results of
+    /// their declared query types after the command handler completes successfully.
+    /// </summary>
+    /// <param name="builder">The mediator builder.</param>
+    /// <returns>The builder for method chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// This method must be called AFTER <c>AddQueryCaching()</c>, so that the cache key registry
+    /// already tracks the keys produced by the query caching interceptor when invalidation runs.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// services.AddPulse(c =&gt; c.AddQueryCaching().AddCacheInvalidation());
+    /// </code>
+    /// </example>
+    public static IMediatorBuilder AddCacheInvalidation(this IMediatorBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Services.TryAddSingleton<ICacheKeyRegistry, InMemoryCacheKeyRegistry>();
+
+        builder.Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton(typeof(IRequestInterceptor<,>), typeof(CacheInvalidationInterceptor<,>))
+        );
+
+        return builder;
+    }
+}

--- a/src/NetEvolve.Pulse/Interceptors/CacheInvalidationInterceptor.cs
+++ b/src/NetEvolve.Pulse/Interceptors/CacheInvalidationInterceptor.cs
@@ -1,0 +1,86 @@
+namespace NetEvolve.Pulse.Interceptors;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.DependencyInjection;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Internals;
+
+/// <summary>
+/// Request interceptor that evicts cached query results for commands implementing
+/// <see cref="IInvalidatingCommand{TResponse}"/> after the handler completes successfully.
+/// </summary>
+/// <typeparam name="TRequest">The type of request being intercepted.</typeparam>
+/// <typeparam name="TResponse">The type of response produced by the request.</typeparam>
+/// <remarks>
+/// <para><strong>Behavior:</strong></para>
+/// <list type="number">
+/// <item><description>If the request does not implement <see cref="IInvalidatingCommand{TResponse}"/>, the interceptor passes through without any cache interaction.</description></item>
+/// <item><description>The handler is always invoked first; if it throws, the exception propagates and no cache eviction is performed.</description></item>
+/// <item><description>If <see cref="IDistributedCache"/> is not registered in the DI container, the interceptor passes through without any cache interaction.</description></item>
+/// <item><description>Otherwise, after a successful handler call, for each type in <see cref="IInvalidatingCommand{TResponse}.InvalidatedQueryTypes"/> the cache keys tracked by <see cref="ICacheKeyRegistry"/> are removed from the cache and the registry entries for that type are cleared.</description></item>
+/// </list>
+/// <para><strong>Registration:</strong></para>
+/// Use <c>AddCacheInvalidation()</c> on the <see cref="IMediatorBuilder"/> to register this interceptor.
+/// </remarks>
+/// <seealso cref="IInvalidatingCommand{TResponse}"/>
+/// <seealso cref="ICacheKeyRegistry"/>
+internal sealed class CacheInvalidationInterceptor<TRequest, TResponse> : IRequestInterceptor<TRequest, TResponse>
+    where TRequest : IRequest<TResponse>
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ICacheKeyRegistry _cacheKeyRegistry;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CacheInvalidationInterceptor{TRequest, TResponse}"/> class.
+    /// </summary>
+    /// <param name="serviceProvider">The service provider used to resolve <see cref="IDistributedCache"/>.</param>
+    /// <param name="cacheKeyRegistry">The registry tracking cache keys produced per query type.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="serviceProvider"/> or <paramref name="cacheKeyRegistry"/> is <see langword="null"/>.</exception>
+    public CacheInvalidationInterceptor(IServiceProvider serviceProvider, ICacheKeyRegistry cacheKeyRegistry)
+    {
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+        ArgumentNullException.ThrowIfNull(cacheKeyRegistry);
+
+        _serviceProvider = serviceProvider;
+        _cacheKeyRegistry = cacheKeyRegistry;
+    }
+
+    /// <inheritdoc />
+    public async Task<TResponse> HandleAsync(
+        TRequest request,
+        Func<TRequest, CancellationToken, Task<TResponse>> handler,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+
+        if (request is not IInvalidatingCommand<TResponse> invalidatingCommand)
+        {
+            return await handler(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        var response = await handler(request, cancellationToken).ConfigureAwait(false);
+
+        var cache = _serviceProvider.GetService<IDistributedCache>();
+        if (cache is null)
+        {
+            return response;
+        }
+
+        foreach (var queryType in invalidatingCommand.InvalidatedQueryTypes)
+        {
+            var keys = _cacheKeyRegistry.GetKeysForType(queryType);
+            foreach (var key in keys)
+            {
+                await cache.RemoveAsync(key, cancellationToken).ConfigureAwait(false);
+            }
+
+            _cacheKeyRegistry.RemoveType(queryType);
+        }
+
+        return response;
+    }
+}

--- a/src/NetEvolve.Pulse/Interceptors/DistributedCacheQueryInterceptor.cs
+++ b/src/NetEvolve.Pulse/Interceptors/DistributedCacheQueryInterceptor.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using NetEvolve.Pulse.Extensibility;
 using NetEvolve.Pulse.Extensibility.Caching;
+using NetEvolve.Pulse.Internals;
 
 /// <summary>
 /// An interceptor that transparently caches query responses in <see cref="IDistributedCache"/>.
@@ -29,6 +30,10 @@ using NetEvolve.Pulse.Extensibility.Caching;
 /// <para><strong>No Cache Registered:</strong></para>
 /// When <see cref="IDistributedCache"/> is not registered in the DI container, the interceptor
 /// falls through to the handler without error.
+/// <para><strong>Cache Key Tracking:</strong></para>
+/// After a cache write, the query's cache key is registered with <see cref="ICacheKeyRegistry"/>, when
+/// registered in the DI container, so that related commands can later invalidate it. When the registry
+/// is not registered, this is a silent no-op.
 /// <para><strong>Expiry:</strong></para>
 /// The effective expiry is determined by first checking <see cref="ICacheableQuery{TResponse}.Expiry"/>;
 /// when it is <see langword="null"/>, <see cref="QueryCachingOptions.DefaultExpiry"/> is used as a fallback.
@@ -134,6 +139,10 @@ internal sealed class DistributedCacheQueryInterceptor<TQuery, TResponse> : IQue
                 var serialized = _payloadSerializer.SerializeToBytes(response);
                 var entryOptions = GetCacheEntryOptions(cacheableQuery);
                 await cache.SetAsync(cacheKey, serialized, entryOptions, cancellationToken).ConfigureAwait(false);
+
+                // Track the cache key for later invalidation, when a registry is registered
+                var registry = _serviceProvider.GetService<ICacheKeyRegistry>();
+                registry?.Register(typeof(TQuery), cacheKey);
             }
 
             return response;

--- a/src/NetEvolve.Pulse/Internals/ICacheKeyRegistry.cs
+++ b/src/NetEvolve.Pulse/Internals/ICacheKeyRegistry.cs
@@ -1,0 +1,70 @@
+namespace NetEvolve.Pulse.Internals;
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+/// <summary>
+/// Tracks the distributed cache keys produced for each query type, so that they can be looked up and
+/// removed when a related command invalidates that type's cached results.
+/// </summary>
+internal interface ICacheKeyRegistry
+{
+    /// <summary>
+    /// Registers a cache key as belonging to the specified query type.
+    /// </summary>
+    /// <param name="queryType">The query type the cache key was produced for.</param>
+    /// <param name="cacheKey">The cache key to register.</param>
+    void Register(Type queryType, string cacheKey);
+
+    /// <summary>
+    /// Gets a snapshot of all cache keys currently registered for the specified query type.
+    /// </summary>
+    /// <param name="queryType">The query type to look up.</param>
+    /// <returns>
+    /// A read-only list of the cache keys registered for <paramref name="queryType"/>, or an empty list
+    /// when no keys are registered for that type. Never <see langword="null"/>.
+    /// </returns>
+    IReadOnlyList<string> GetKeysForType(Type queryType);
+
+    /// <summary>
+    /// Removes all cache keys registered for the specified query type.
+    /// </summary>
+    /// <param name="queryType">The query type whose registered cache keys should be removed.</param>
+    void RemoveType(Type queryType);
+}
+
+/// <summary>
+/// Thread-safe, in-memory implementation of <see cref="ICacheKeyRegistry"/> backed by a
+/// <see cref="ConcurrentDictionary{TKey, TValue}"/> of <see cref="ConcurrentBag{T}"/> instances.
+/// </summary>
+internal sealed class InMemoryCacheKeyRegistry : ICacheKeyRegistry
+{
+    private readonly ConcurrentDictionary<Type, ConcurrentBag<string>> _keysByQueryType = new();
+
+    /// <inheritdoc />
+    public void Register(Type queryType, string cacheKey)
+    {
+        ArgumentNullException.ThrowIfNull(queryType);
+        ArgumentException.ThrowIfNullOrWhiteSpace(cacheKey);
+
+        var bag = _keysByQueryType.GetOrAdd(queryType, static _ => []);
+        bag.Add(cacheKey);
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> GetKeysForType(Type queryType)
+    {
+        ArgumentNullException.ThrowIfNull(queryType);
+
+        return _keysByQueryType.TryGetValue(queryType, out var bag) ? bag.ToArray() : [];
+    }
+
+    /// <inheritdoc />
+    public void RemoveType(Type queryType)
+    {
+        ArgumentNullException.ThrowIfNull(queryType);
+
+        _ = _keysByQueryType.TryRemove(queryType, out _);
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/CacheInvalidationMediatorBuilderExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/CacheInvalidationMediatorBuilderExtensionsTests.cs
@@ -1,0 +1,131 @@
+namespace NetEvolve.Pulse.Tests.Unit;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Interceptors;
+using NetEvolve.Pulse.Internals;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
+
+[TestGroup("Extensions")]
+public sealed class CacheInvalidationMediatorBuilderExtensionsTests
+{
+    [Test]
+    public async Task AddCacheInvalidation_NullBuilder_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() => CacheInvalidationMediatorBuilderExtensions.AddCacheInvalidation(null!))
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task AddCacheInvalidation_RegistersCacheKeyRegistryAsSingleton()
+    {
+        var services = new ServiceCollection();
+        var builder = new MediatorBuilder(services);
+
+        _ = builder.AddCacheInvalidation();
+
+        var descriptor = services.FirstOrDefault(d =>
+            d.ServiceType == typeof(ICacheKeyRegistry) && d.ImplementationType == typeof(InMemoryCacheKeyRegistry)
+        );
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor).IsNotNull();
+            _ = await Assert.That(descriptor!.Lifetime).IsEqualTo(ServiceLifetime.Singleton);
+        }
+    }
+
+    [Test]
+    public async Task AddCacheInvalidation_RegistersRequestInterceptorAsSingleton()
+    {
+        var services = new ServiceCollection();
+        var builder = new MediatorBuilder(services);
+
+        var result = builder.AddCacheInvalidation();
+
+        _ = await Assert.That(result).IsSameReferenceAs(builder);
+
+        var descriptor = services.FirstOrDefault(d =>
+            d.ServiceType == typeof(IRequestInterceptor<,>)
+            && d.ImplementationType == typeof(CacheInvalidationInterceptor<,>)
+        );
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor).IsNotNull();
+            _ = await Assert.That(descriptor!.Lifetime).IsEqualTo(ServiceLifetime.Singleton);
+        }
+    }
+
+    [Test]
+    public async Task AddCacheInvalidation_CalledMultipleTimes_DoesNotDuplicateRegistrations()
+    {
+        var services = new ServiceCollection();
+        var builder = new MediatorBuilder(services);
+
+        _ = builder.AddCacheInvalidation();
+        _ = builder.AddCacheInvalidation();
+
+        var registryDescriptors = services
+            .Where(d =>
+                d.ServiceType == typeof(ICacheKeyRegistry) && d.ImplementationType == typeof(InMemoryCacheKeyRegistry)
+            )
+            .ToList();
+
+        var interceptorDescriptors = services
+            .Where(d =>
+                d.ServiceType == typeof(IRequestInterceptor<,>)
+                && d.ImplementationType == typeof(CacheInvalidationInterceptor<,>)
+            )
+            .ToList();
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(registryDescriptors).HasSingleItem();
+            _ = await Assert.That(interceptorDescriptors).HasSingleItem();
+        }
+    }
+
+    [Test]
+    public async Task AddCacheInvalidation_ReturnsSameBuilder()
+    {
+        var services = new ServiceCollection();
+        var builder = new MediatorBuilder(services);
+
+        var result = builder.AddCacheInvalidation();
+
+        _ = await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    [Test]
+    public async Task AddCacheInvalidation_WithoutPriorAddQueryCaching_RegistersSuccessfully()
+    {
+        var services = new ServiceCollection();
+        var builder = new MediatorBuilder(services);
+
+        // Registration does not require AddQueryCaching() to have run first; the ordering only matters
+        // for invalidation to have an effect at runtime, not for the registration itself.
+        var result = builder.AddCacheInvalidation();
+
+        var registryDescriptor = services.FirstOrDefault(d =>
+            d.ServiceType == typeof(ICacheKeyRegistry) && d.ImplementationType == typeof(InMemoryCacheKeyRegistry)
+        );
+
+        var interceptorDescriptor = services.FirstOrDefault(d =>
+            d.ServiceType == typeof(IRequestInterceptor<,>)
+            && d.ImplementationType == typeof(CacheInvalidationInterceptor<,>)
+        );
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(result).IsSameReferenceAs(builder);
+            _ = await Assert.That(registryDescriptor).IsNotNull();
+            _ = await Assert.That(interceptorDescriptor).IsNotNull();
+        }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/CacheInvalidationInterceptorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/CacheInvalidationInterceptorTests.cs
@@ -1,0 +1,242 @@
+namespace NetEvolve.Pulse.Tests.Unit.Interceptors;
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.DependencyInjection;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Interceptors;
+using NetEvolve.Pulse.Internals;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
+
+[TestGroup("Interceptors")]
+public sealed class CacheInvalidationInterceptorTests
+{
+    [Test]
+    public async Task Constructor_NullServiceProvider_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() => new CacheInvalidationInterceptor<TestCommand, string>(null!, new InMemoryCacheKeyRegistry()))
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Constructor_NullCacheKeyRegistry_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() =>
+                new CacheInvalidationInterceptor<TestCommand, string>(
+                    new ServiceCollection().BuildServiceProvider(),
+                    null!
+                )
+            )
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task HandleAsync_NonInvalidatingCommand_PassesThroughWithoutCacheInteraction(
+        CancellationToken cancellationToken
+    )
+    {
+        var provider = new ServiceCollection().BuildServiceProvider();
+        await using (provider.ConfigureAwait(false))
+        {
+            var interceptor = new CacheInvalidationInterceptor<NonInvalidatingCommand, string>(
+                provider,
+                new InMemoryCacheKeyRegistry()
+            );
+            var command = new NonInvalidatingCommand();
+            var handlerCallCount = 0;
+
+            var result = await interceptor
+                .HandleAsync(
+                    command,
+                    (_, _) =>
+                    {
+                        handlerCallCount++;
+                        return Task.FromResult("handler-result");
+                    },
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+
+            using (Assert.Multiple())
+            {
+                _ = await Assert.That(result).IsEqualTo("handler-result");
+                _ = await Assert.That(handlerCallCount).IsEqualTo(1);
+            }
+        }
+    }
+
+    [Test]
+    public async Task HandleAsync_SuccessfulInvalidatingCommand_EvictsRegisteredKeysAndClearsRegistry(
+        CancellationToken cancellationToken
+    )
+    {
+        var services = new ServiceCollection();
+        _ = services.AddDistributedMemoryCache();
+        var provider = services.BuildServiceProvider();
+        await using (provider.ConfigureAwait(false))
+        {
+            var cache = provider.GetRequiredService<IDistributedCache>();
+            await cache.SetAsync("query-key", [1, 2, 3], cancellationToken).ConfigureAwait(false);
+
+            var registry = new InMemoryCacheKeyRegistry();
+            registry.Register(typeof(TestQuery), "query-key");
+
+            var interceptor = new CacheInvalidationInterceptor<TestCommand, string>(provider, registry);
+            var command = new TestCommand([typeof(TestQuery)]);
+
+            var result = await interceptor
+                .HandleAsync(command, (_, _) => Task.FromResult("handler-result"), cancellationToken)
+                .ConfigureAwait(false);
+
+            using (Assert.Multiple())
+            {
+                _ = await Assert.That(result).IsEqualTo("handler-result");
+
+                var bytes = await cache.GetAsync("query-key", cancellationToken).ConfigureAwait(false);
+                _ = await Assert.That(bytes).IsNull();
+
+                _ = await Assert.That(registry.GetKeysForType(typeof(TestQuery))).IsEmpty();
+            }
+        }
+    }
+
+    [Test]
+    public async Task HandleAsync_HandlerThrows_DoesNotEvictCache(CancellationToken cancellationToken)
+    {
+        var services = new ServiceCollection();
+        _ = services.AddDistributedMemoryCache();
+        var provider = services.BuildServiceProvider();
+        await using (provider.ConfigureAwait(false))
+        {
+            var cache = provider.GetRequiredService<IDistributedCache>();
+            await cache.SetAsync("query-key", [1, 2, 3], cancellationToken).ConfigureAwait(false);
+
+            var registry = new InMemoryCacheKeyRegistry();
+            registry.Register(typeof(TestQuery), "query-key");
+
+            var interceptor = new CacheInvalidationInterceptor<TestCommand, string>(provider, registry);
+            var command = new TestCommand([typeof(TestQuery)]);
+
+            _ = await Assert
+                .That(async () =>
+                    await interceptor
+                        .HandleAsync(
+                            command,
+                            (_, _) => Task.FromException<string>(new InvalidOperationException("handler error")),
+                            cancellationToken
+                        )
+                        .ConfigureAwait(false)
+                )
+                .Throws<InvalidOperationException>();
+
+            var bytes = await cache.GetAsync("query-key", cancellationToken).ConfigureAwait(false);
+            _ = await Assert.That(bytes).IsNotNull();
+        }
+    }
+
+    [Test]
+    public async Task HandleAsync_MultipleInvalidatedQueryTypes_EvictsKeysForAllTypes(
+        CancellationToken cancellationToken
+    )
+    {
+        var services = new ServiceCollection();
+        _ = services.AddDistributedMemoryCache();
+        var provider = services.BuildServiceProvider();
+        await using (provider.ConfigureAwait(false))
+        {
+            var cache = provider.GetRequiredService<IDistributedCache>();
+            await cache.SetAsync("query-key-1", [1], cancellationToken).ConfigureAwait(false);
+            await cache.SetAsync("query-key-2", [2], cancellationToken).ConfigureAwait(false);
+
+            var registry = new InMemoryCacheKeyRegistry();
+            registry.Register(typeof(TestQuery), "query-key-1");
+            registry.Register(typeof(AnotherTestQuery), "query-key-2");
+
+            var interceptor = new CacheInvalidationInterceptor<TestCommand, string>(provider, registry);
+            var command = new TestCommand([typeof(TestQuery), typeof(AnotherTestQuery)]);
+
+            var result = await interceptor
+                .HandleAsync(command, (_, _) => Task.FromResult("handler-result"), cancellationToken)
+                .ConfigureAwait(false);
+
+            using (Assert.Multiple())
+            {
+                _ = await Assert.That(result).IsEqualTo("handler-result");
+
+                var bytes1 = await cache.GetAsync("query-key-1", cancellationToken).ConfigureAwait(false);
+                _ = await Assert.That(bytes1).IsNull();
+
+                var bytes2 = await cache.GetAsync("query-key-2", cancellationToken).ConfigureAwait(false);
+                _ = await Assert.That(bytes2).IsNull();
+
+                _ = await Assert.That(registry.GetKeysForType(typeof(TestQuery))).IsEmpty();
+                _ = await Assert.That(registry.GetKeysForType(typeof(AnotherTestQuery))).IsEmpty();
+            }
+        }
+    }
+
+    [Test]
+    public async Task HandleAsync_NoCacheRegistered_CompletesSuccessfullyWithoutEviction(
+        CancellationToken cancellationToken
+    )
+    {
+        var provider = new ServiceCollection().BuildServiceProvider();
+        // Do NOT register IDistributedCache
+        await using (provider.ConfigureAwait(false))
+        {
+            var registry = new InMemoryCacheKeyRegistry();
+            registry.Register(typeof(TestQuery), "query-key");
+
+            var interceptor = new CacheInvalidationInterceptor<TestCommand, string>(provider, registry);
+            var command = new TestCommand([typeof(TestQuery)]);
+            var handlerCallCount = 0;
+
+            var result = await interceptor
+                .HandleAsync(
+                    command,
+                    (_, _) =>
+                    {
+                        handlerCallCount++;
+                        return Task.FromResult("handler-result");
+                    },
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+
+            using (Assert.Multiple())
+            {
+                _ = await Assert.That(result).IsEqualTo("handler-result");
+                _ = await Assert.That(handlerCallCount).IsEqualTo(1);
+            }
+        }
+    }
+
+    // ── Private test types ───────────────────────────────────────────────────
+
+    private sealed class TestQuery : IQuery<string>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed class AnotherTestQuery : IQuery<string>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed record NonInvalidatingCommand : ICommand<string>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed record TestCommand(IEnumerable<Type> InvalidatedQueryTypes) : IInvalidatingCommand<string>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/DistributedCacheQueryInterceptorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/DistributedCacheQueryInterceptorTests.cs
@@ -8,6 +8,7 @@ using NetEvolve.Extensions.TUnit;
 using NetEvolve.Pulse.Extensibility;
 using NetEvolve.Pulse.Extensibility.Caching;
 using NetEvolve.Pulse.Interceptors;
+using NetEvolve.Pulse.Internals;
 using NetEvolve.Pulse.Serialization;
 using TUnit.Core;
 
@@ -515,12 +516,87 @@ public class DistributedCacheQueryInterceptorTests
         }
     }
 
+    [Test]
+    public async Task HandleAsync_CacheMiss_RegistersCacheKeyWithRegistry(CancellationToken cancellationToken)
+    {
+        var services = new ServiceCollection();
+        _ = services.AddDistributedMemoryCache();
+        var registry = new FakeCacheKeyRegistry();
+        _ = services.AddSingleton<ICacheKeyRegistry>(registry);
+        var provider = services.BuildServiceProvider();
+        await using (provider.ConfigureAwait(false))
+        {
+            var interceptor = new DistributedCacheQueryInterceptor<CacheableQuery, string>(
+                provider,
+                DefaultOptions,
+                DefaultSerializer
+            );
+            var query = new CacheableQuery("registry-key");
+
+            var result = await interceptor
+                .HandleAsync(query, (_, _) => Task.FromResult("registry-value"), cancellationToken)
+                .ConfigureAwait(false);
+
+            _ = await Assert.That(result).IsEqualTo("registry-value");
+
+            using (Assert.Multiple())
+            {
+                _ = await Assert.That(registry.RegisteredCalls.Count).IsEqualTo(1);
+                _ = await Assert.That(registry.RegisteredCalls[0].QueryType).IsEqualTo(typeof(CacheableQuery));
+                _ = await Assert.That(registry.RegisteredCalls[0].CacheKey).IsEqualTo("registry-key");
+            }
+        }
+    }
+
+    [Test]
+    public async Task HandleAsync_NoCacheKeyRegistryRegistered_StillCachesAndReturnsResult(
+        CancellationToken cancellationToken
+    )
+    {
+        var services = new ServiceCollection();
+        _ = services.AddDistributedMemoryCache();
+        // Do NOT register ICacheKeyRegistry
+        var provider = services.BuildServiceProvider();
+        await using (provider.ConfigureAwait(false))
+        {
+            var interceptor = new DistributedCacheQueryInterceptor<CacheableQuery, string>(
+                provider,
+                DefaultOptions,
+                DefaultSerializer
+            );
+            var query = new CacheableQuery("no-registry-key");
+
+            var result = await interceptor
+                .HandleAsync(query, (_, _) => Task.FromResult("no-registry-value"), cancellationToken)
+                .ConfigureAwait(false);
+
+            _ = await Assert.That(result).IsEqualTo("no-registry-value");
+
+            var cache = provider.GetRequiredService<IDistributedCache>();
+            var bytes = await cache.GetAsync("no-registry-key", cancellationToken).ConfigureAwait(false);
+            _ = await Assert.That(bytes).IsNotNull();
+            var deserialised = DefaultSerializer.Deserialize<string>(bytes!);
+            _ = await Assert.That(deserialised).IsEqualTo("no-registry-value");
+        }
+    }
+
     // ── Private test types ───────────────────────────────────────────────────
 
     private sealed class NonCacheableQuery : IQuery<string>
     {
         public string? CausationId { get; set; }
         public string? CorrelationId { get; set; }
+    }
+
+    private sealed class FakeCacheKeyRegistry : ICacheKeyRegistry
+    {
+        public List<(Type QueryType, string CacheKey)> RegisteredCalls { get; } = [];
+
+        public void Register(Type queryType, string cacheKey) => RegisteredCalls.Add((queryType, cacheKey));
+
+        public IReadOnlyList<string> GetKeysForType(Type queryType) => [];
+
+        public void RemoveType(Type queryType) { }
     }
 
     [Test]

--- a/tests/NetEvolve.Pulse.Tests.Unit/Internals/InMemoryCacheKeyRegistryTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Internals/InMemoryCacheKeyRegistryTests.cs
@@ -1,0 +1,176 @@
+namespace NetEvolve.Pulse.Tests.Unit.Internals;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Internals;
+using TUnit.Core;
+
+[TestGroup("Internals")]
+public class InMemoryCacheKeyRegistryTests
+{
+    private static readonly string[] ExpectedKeys = ["key-1", "key-2", "key-3"];
+
+    [Test]
+    public async Task Register_Then_GetKeysForType_ReturnsRegisteredKey()
+    {
+        var registry = new InMemoryCacheKeyRegistry();
+
+        registry.Register(typeof(SampleQueryA), "key-1");
+
+        var keys = registry.GetKeysForType(typeof(SampleQueryA));
+
+        _ = await Assert.That(keys).IsEquivalentTo(["key-1"]);
+    }
+
+    [Test]
+    public async Task Register_MultipleCallsForSameType_AccumulatesAllKeys()
+    {
+        var registry = new InMemoryCacheKeyRegistry();
+
+        registry.Register(typeof(SampleQueryA), "key-1");
+        registry.Register(typeof(SampleQueryA), "key-2");
+        registry.Register(typeof(SampleQueryA), "key-3");
+
+        var keys = registry.GetKeysForType(typeof(SampleQueryA));
+
+        _ = await Assert
+            .That(keys.OrderBy(x => x, StringComparer.Ordinal))
+            .IsEquivalentTo(ExpectedKeys.OrderBy(x => x, StringComparer.Ordinal));
+    }
+
+    [Test]
+    public async Task GetKeysForType_WithNoRegistrations_ReturnsEmptyReadOnlyList()
+    {
+        var registry = new InMemoryCacheKeyRegistry();
+
+        var keys = registry.GetKeysForType(typeof(SampleQueryA));
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(keys).IsNotNull();
+            _ = await Assert.That(keys).IsEmpty();
+            _ = await Assert.That(keys).IsAssignableTo<IReadOnlyList<string>>();
+        }
+    }
+
+    [Test]
+    public async Task RemoveType_ClearsKeysForType_WhileLeavingOtherTypesUntouched()
+    {
+        var registry = new InMemoryCacheKeyRegistry();
+        registry.Register(typeof(SampleQueryA), "key-1");
+        registry.Register(typeof(SampleQueryA), "key-2");
+        registry.Register(typeof(SampleQueryB), "other-key");
+
+        registry.RemoveType(typeof(SampleQueryA));
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(registry.GetKeysForType(typeof(SampleQueryA))).IsEmpty();
+            _ = await Assert.That(registry.GetKeysForType(typeof(SampleQueryB))).IsEquivalentTo(["other-key"]);
+        }
+    }
+
+    [Test]
+    public async Task RemoveType_WithNoRegistrations_DoesNotThrow()
+    {
+        var registry = new InMemoryCacheKeyRegistry();
+
+        _ = await Assert.That(() => registry.RemoveType(typeof(SampleQueryA))).ThrowsNothing();
+    }
+
+    [Test]
+    public async Task Register_ConcurrentCallsAcrossMultipleTypes_AllKeysRetrievableWithNoLostWrites()
+    {
+        var registry = new InMemoryCacheKeyRegistry();
+        var types = new[] { typeof(SampleQueryA), typeof(SampleQueryB), typeof(SampleQueryC) };
+        const int keysPerType = 200;
+
+        var tasks = new List<Task>();
+        foreach (var type in types)
+        {
+            for (var i = 0; i < keysPerType; i++)
+            {
+                var capturedType = type;
+                var capturedKey = $"{type.Name}-{i}";
+                tasks.Add(Task.Run(() => registry.Register(capturedType, capturedKey)));
+            }
+        }
+
+        await Task.WhenAll(tasks).ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            foreach (var type in types)
+            {
+                var expected = Enumerable
+                    .Range(0, keysPerType)
+                    .Select(i => $"{type.Name}-{i}")
+                    .OrderBy(x => x, StringComparer.Ordinal);
+                var actual = registry.GetKeysForType(type).OrderBy(x => x, StringComparer.Ordinal);
+
+                _ = await Assert.That(actual).IsEquivalentTo(expected);
+            }
+        }
+    }
+
+    [Test]
+    public async Task Register_When_queryType_is_null_throws_ArgumentNullException()
+    {
+        var registry = new InMemoryCacheKeyRegistry();
+
+        _ = await Assert.That(() => registry.Register(null!, "key")).Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Register_When_cacheKey_is_null_throws_ArgumentException()
+    {
+        var registry = new InMemoryCacheKeyRegistry();
+
+        _ = await Assert.That(() => registry.Register(typeof(SampleQueryA), null!)).Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task Register_When_cacheKey_is_empty_throws_ArgumentException()
+    {
+        var registry = new InMemoryCacheKeyRegistry();
+
+        _ = await Assert.That(() => registry.Register(typeof(SampleQueryA), string.Empty)).Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task Register_When_cacheKey_is_whitespace_throws_ArgumentException()
+    {
+        var registry = new InMemoryCacheKeyRegistry();
+
+        _ = await Assert.That(() => registry.Register(typeof(SampleQueryA), "   ")).Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task GetKeysForType_When_queryType_is_null_throws_ArgumentNullException()
+    {
+        var registry = new InMemoryCacheKeyRegistry();
+
+        _ = await Assert.That(() => registry.GetKeysForType(null!)).Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task RemoveType_When_queryType_is_null_throws_ArgumentNullException()
+    {
+        var registry = new InMemoryCacheKeyRegistry();
+
+        _ = await Assert.That(() => registry.RemoveType(null!)).Throws<ArgumentNullException>();
+    }
+
+    // ── Private test types ───────────────────────────────────────────────────
+
+#pragma warning disable S2094 // Classes intentionally empty; used only as distinct Type markers via typeof()
+    private sealed class SampleQueryA;
+
+    private sealed class SampleQueryB;
+
+    private sealed class SampleQueryC;
+#pragma warning restore S2094
+}


### PR DESCRIPTION
## Summary
- Adds `IInvalidatingCommand<TResponse>` (`NetEvolve.Pulse.Extensibility`): a command declares which query types' cached results it invalidates via `InvalidatedQueryTypes`.
- Adds `ICacheKeyRegistry` / `InMemoryCacheKeyRegistry` (internal, `ConcurrentDictionary<Type, ConcurrentBag<string>>`-backed) tracking which cache keys were written per query type.
- Updates `DistributedCacheQueryInterceptor` to register each cache key it writes into the registry (silent no-op when the registry isn't in DI).
- Adds `CacheInvalidationInterceptor` + `AddCacheInvalidation()`: on a successful invalidating command, evicts every registered key for each declared query type from `IDistributedCache` and clears the registry for those types. Pass-through for non-invalidating commands, and cache is never evicted when the handler throws.
- Adds unit tests for the registry (including a concurrency stress test), the interceptor (all four scenarios from the issue), the registration extension, and the updated `DistributedCacheQueryInterceptor`.

Note: the underlying issues reference a "QueryCachingInterceptor" and an "ICache abstraction" that don't exist in this codebase — the actual types are `DistributedCacheQueryInterceptor` and `Microsoft.Extensions.Caching.Distributed.IDistributedCache`, used directly throughout instead of inventing a new abstraction.

Closes #257
Closes #258
Closes #259
Closes #260

## Test plan
- [x] `dotnet build` clean on net8.0/net9.0/net10.0
- [x] `dotnet test` — full `NetEvolve.Pulse.Tests.Unit` suite passes (1684 tests)
- [x] `csharpier format .`