### PR TITLE
feat(dead-letter): Command Dead Letter store (EF Core + 4 ADO.NET providers)

### DIFF
--- a/src/NetEvolve.Pulse.EntityFramework/Configurations/CommandDeadLetterEntryConfigurationBase.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Configurations/CommandDeadLetterEntryConfigurationBase.cs
@@ -1,0 +1,103 @@
+﻿namespace NetEvolve.Pulse.Configurations;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.DeadLetter;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+using NetEvolve.Pulse.Extensibility.Outbox;
+
+/// <summary>
+/// Abstract base class for Entity Framework Core configuration of <see cref="CommandDeadLetterEntry"/>.
+/// Encapsulates all provider-agnostic column and key mappings, leaving column type overrides
+/// as optional members to be implemented per database provider.
+/// </summary>
+/// <remarks>
+/// <para><strong>Provider-specific column types:</strong></para>
+/// Derived classes may override <see cref="ApplyColumnTypes"/> to add explicit
+/// <c>HasColumnType</c> calls. Without overrides, EF Core convention-based defaults apply.
+/// <para><strong>Customization:</strong></para>
+/// Override schema and table names via <see cref="CommandDeadLetterOptions"/> before applying this configuration.
+/// </remarks>
+internal abstract class CommandDeadLetterEntryConfigurationBase : IEntityTypeConfiguration<CommandDeadLetterEntry>
+{
+    private readonly CommandDeadLetterOptions _options;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="CommandDeadLetterEntryConfigurationBase"/>.
+    /// </summary>
+    /// <param name="options">The command dead letter options containing schema and table configuration.</param>
+    protected CommandDeadLetterEntryConfigurationBase(IOptions<CommandDeadLetterOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        _options = options.Value;
+    }
+
+    /// <summary>
+    /// Applies provider-specific column type overrides to the entity mapping.
+    /// Called from <see cref="Configure"/> after all shared column mappings are applied.
+    /// </summary>
+    /// <remarks>
+    /// Override this method to call <c>HasColumnType</c> for columns whose native type
+    /// differs between providers.
+    /// The default implementation is a no-op.
+    /// </remarks>
+    /// <param name="builder">The entity type builder for <see cref="CommandDeadLetterEntry"/>.</param>
+    protected virtual void ApplyColumnTypes(EntityTypeBuilder<CommandDeadLetterEntry> builder) { }
+
+    /// <inheritdoc />
+    public void Configure(EntityTypeBuilder<CommandDeadLetterEntry> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        // Table configuration
+        var schema = string.IsNullOrWhiteSpace(_options.Schema)
+            ? CommandDeadLetterSchema.DefaultSchema
+            : _options.Schema.Trim();
+        var tableName = _options.TableName;
+        SqlIdentifier.Validate(schema, nameof(_options.Schema));
+        SqlIdentifier.Validate(tableName, nameof(_options.TableName));
+
+        _ = builder.ToTable(tableName, schema);
+
+        // Primary key
+        _ = builder.HasKey(e => e.Id).HasName($"PK_{schema}_{tableName}");
+
+        // Id column
+        _ = builder.Property(e => e.Id).HasColumnName(CommandDeadLetterSchema.Columns.Id).IsRequired();
+
+        // CommandType column
+        _ = builder
+            .Property(e => e.CommandType)
+            .HasColumnName(CommandDeadLetterSchema.Columns.CommandType)
+            .HasMaxLength(CommandDeadLetterSchema.MaxLengths.CommandType)
+            .IsRequired();
+
+        // Payload column
+        _ = builder.Property(e => e.Payload).HasColumnName(CommandDeadLetterSchema.Columns.Payload).IsRequired();
+
+        // ExceptionType column
+        _ = builder
+            .Property(e => e.ExceptionType)
+            .HasColumnName(CommandDeadLetterSchema.Columns.ExceptionType)
+            .HasMaxLength(CommandDeadLetterSchema.MaxLengths.ExceptionType);
+
+        // ExceptionMessage column
+        _ = builder.Property(e => e.ExceptionMessage).HasColumnName(CommandDeadLetterSchema.Columns.ExceptionMessage);
+
+        // OccurredAt column
+        _ = builder.Property(e => e.OccurredAt).HasColumnName(CommandDeadLetterSchema.Columns.OccurredAt).IsRequired();
+
+        // AttemptCount column
+        _ = builder
+            .Property(e => e.AttemptCount)
+            .HasColumnName(CommandDeadLetterSchema.Columns.AttemptCount)
+            .IsRequired();
+
+        // Status column
+        _ = builder.Property(e => e.Status).HasColumnName(CommandDeadLetterSchema.Columns.Status).IsRequired();
+
+        // Provider-specific column type overrides
+        ApplyColumnTypes(builder);
+    }
+}

--- a/src/NetEvolve.Pulse.EntityFramework/Configurations/InMemoryCommandDeadLetterEntryConfiguration.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Configurations/InMemoryCommandDeadLetterEntryConfiguration.cs
@@ -1,0 +1,26 @@
+﻿namespace NetEvolve.Pulse.Configurations;
+
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.DeadLetter;
+
+/// <summary>
+/// Entity Framework Core configuration for <see cref="Extensibility.DeadLetter.CommandDeadLetterEntry"/> targeting the
+/// <c>Microsoft.EntityFrameworkCore.InMemory</c> provider.
+/// Intended for testing only.
+/// </summary>
+internal sealed class InMemoryCommandDeadLetterEntryConfiguration : CommandDeadLetterEntryConfigurationBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InMemoryCommandDeadLetterEntryConfiguration"/> class
+    /// with default options.
+    /// </summary>
+    public InMemoryCommandDeadLetterEntryConfiguration()
+        : this(Options.Create(new CommandDeadLetterOptions())) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InMemoryCommandDeadLetterEntryConfiguration"/> class.
+    /// </summary>
+    /// <param name="options">The command dead letter options containing schema and table configuration.</param>
+    public InMemoryCommandDeadLetterEntryConfiguration(IOptions<CommandDeadLetterOptions> options)
+        : base(options) { }
+}

--- a/src/NetEvolve.Pulse.EntityFramework/Configurations/MySqlCommandDeadLetterEntryConfiguration.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Configurations/MySqlCommandDeadLetterEntryConfiguration.cs
@@ -1,0 +1,60 @@
+﻿namespace NetEvolve.Pulse.Configurations;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.DeadLetter;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+
+/// <summary>
+/// Entity Framework Core configuration for <see cref="CommandDeadLetterEntry"/> targeting MySQL
+/// via the Oracle provider (<c>MySql.EntityFrameworkCore</c>).
+/// </summary>
+/// <remarks>
+/// <para><strong>Column Types:</strong></para>
+/// <list type="bullet">
+/// <item><description><c>varchar(500)</c> for the command and exception type columns</description></item>
+/// <item><description><c>longtext</c> for the payload and exception message columns</description></item>
+/// <item><description><c>bigint</c> for <see cref="DateTimeOffset"/> — stored as UTC ticks via a <see langword="long"/> value converter</description></item>
+/// </list>
+/// <para><strong>Why bigint for DateTimeOffset:</strong></para>
+/// The Oracle MySQL provider (<c>MySql.EntityFrameworkCore</c>) lacks a proper
+/// <c>datetimeoffset</c> type mapping. Converting to <see langword="long"/> (UTC ticks)
+/// eliminates the broken provider-specific type resolution and ensures correct ordering
+/// and comparison semantics.
+/// </remarks>
+internal sealed class MySqlCommandDeadLetterEntryConfiguration : CommandDeadLetterEntryConfigurationBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MySqlCommandDeadLetterEntryConfiguration"/> class with default options.
+    /// </summary>
+    public MySqlCommandDeadLetterEntryConfiguration()
+        : this(Options.Create(new CommandDeadLetterOptions())) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MySqlCommandDeadLetterEntryConfiguration"/> class.
+    /// </summary>
+    /// <param name="options">The command dead letter options containing schema and table configuration.</param>
+    public MySqlCommandDeadLetterEntryConfiguration(IOptions<CommandDeadLetterOptions> options)
+        : base(options) { }
+
+    /// <inheritdoc />
+    protected override void ApplyColumnTypes(EntityTypeBuilder<CommandDeadLetterEntry> builder)
+    {
+        _ = builder.Property(e => e.CommandType).HasColumnType("varchar(500)");
+        _ = builder.Property(e => e.Payload).HasColumnType("longtext");
+        _ = builder.Property(e => e.ExceptionType).HasColumnType("varchar(500)");
+        _ = builder.Property(e => e.ExceptionMessage).HasColumnType("longtext");
+
+        // DateTimeOffset is stored as BIGINT (UTC ticks).
+        // The Oracle MySQL provider lacks a proper DateTimeOffset type mapping for
+        // parameterised operations. Converting to long eliminates the broken provider-specific
+        // type resolution and ensures correct ordering and comparison semantics.
+        // The read-back uses TimeSpan.Zero because the value is always persisted as UTC ticks
+        // (v.UtcTicks), so the reconstructed DateTimeOffset correctly represents UTC.
+        _ = builder
+            .Property(e => e.OccurredAt)
+            .HasColumnType("bigint")
+            .HasConversion(v => v.UtcTicks, v => new DateTimeOffset(v, TimeSpan.Zero));
+    }
+}

--- a/src/NetEvolve.Pulse.EntityFramework/Configurations/PostgreSqlCommandDeadLetterEntryConfiguration.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Configurations/PostgreSqlCommandDeadLetterEntryConfiguration.cs
@@ -1,0 +1,38 @@
+﻿namespace NetEvolve.Pulse.Configurations;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.DeadLetter;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+
+/// <summary>
+/// Entity Framework Core configuration for <see cref="CommandDeadLetterEntry"/> targeting PostgreSQL.
+/// Uses native PostgreSQL column types for optimal compatibility.
+/// </summary>
+internal sealed class PostgreSqlCommandDeadLetterEntryConfiguration : CommandDeadLetterEntryConfigurationBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PostgreSqlCommandDeadLetterEntryConfiguration"/> class with default options.
+    /// </summary>
+    public PostgreSqlCommandDeadLetterEntryConfiguration()
+        : this(Options.Create(new CommandDeadLetterOptions())) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PostgreSqlCommandDeadLetterEntryConfiguration"/> class.
+    /// </summary>
+    /// <param name="options">The command dead letter options containing schema and table configuration.</param>
+    public PostgreSqlCommandDeadLetterEntryConfiguration(IOptions<CommandDeadLetterOptions> options)
+        : base(options) { }
+
+    /// <inheritdoc />
+    protected override void ApplyColumnTypes(EntityTypeBuilder<CommandDeadLetterEntry> builder)
+    {
+        _ = builder.Property(e => e.CommandType).HasColumnType("character varying(500)");
+        _ = builder.Property(e => e.Payload).HasColumnType("text");
+        _ = builder.Property(e => e.ExceptionType).HasColumnType("character varying(500)");
+        _ = builder.Property(e => e.ExceptionMessage).HasColumnType("text");
+        // "timestamp with time zone" (timestamptz) preserves UTC correctly.
+        _ = builder.Property(e => e.OccurredAt).HasColumnType("timestamp with time zone");
+    }
+}

--- a/src/NetEvolve.Pulse.EntityFramework/Configurations/SqlServerCommandDeadLetterEntryConfiguration.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Configurations/SqlServerCommandDeadLetterEntryConfiguration.cs
@@ -1,0 +1,37 @@
+﻿namespace NetEvolve.Pulse.Configurations;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.DeadLetter;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+
+/// <summary>
+/// Entity Framework Core configuration for <see cref="CommandDeadLetterEntry"/> targeting SQL Server.
+/// Applies the canonical schema to ensure interchangeability with other persistence providers.
+/// </summary>
+internal sealed class SqlServerCommandDeadLetterEntryConfiguration : CommandDeadLetterEntryConfigurationBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SqlServerCommandDeadLetterEntryConfiguration"/> class with default options.
+    /// </summary>
+    public SqlServerCommandDeadLetterEntryConfiguration()
+        : this(Options.Create(new CommandDeadLetterOptions())) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SqlServerCommandDeadLetterEntryConfiguration"/> class.
+    /// </summary>
+    /// <param name="options">The command dead letter options containing schema and table configuration.</param>
+    public SqlServerCommandDeadLetterEntryConfiguration(IOptions<CommandDeadLetterOptions> options)
+        : base(options) { }
+
+    /// <inheritdoc />
+    protected override void ApplyColumnTypes(EntityTypeBuilder<CommandDeadLetterEntry> builder)
+    {
+        _ = builder.Property(e => e.CommandType).HasColumnType("nvarchar(500)");
+        _ = builder.Property(e => e.Payload).HasColumnType("nvarchar(max)");
+        _ = builder.Property(e => e.ExceptionType).HasColumnType("nvarchar(500)");
+        _ = builder.Property(e => e.ExceptionMessage).HasColumnType("nvarchar(max)");
+        _ = builder.Property(e => e.OccurredAt).HasColumnType("datetimeoffset");
+    }
+}

--- a/src/NetEvolve.Pulse.EntityFramework/Configurations/SqliteCommandDeadLetterEntryConfiguration.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Configurations/SqliteCommandDeadLetterEntryConfiguration.cs
@@ -1,0 +1,46 @@
+﻿namespace NetEvolve.Pulse.Configurations;
+
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.DeadLetter;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+
+/// <summary>
+/// Entity Framework Core configuration for <see cref="CommandDeadLetterEntry"/> targeting SQLite.
+/// Uses native SQLite storage classes for optimal compatibility.
+/// </summary>
+/// <remarks>
+/// SQLite does not support named schemas. If <see cref="CommandDeadLetterOptions.Schema"/> is set,
+/// it will be passed to EF Core which silently ignores it for SQLite.
+/// </remarks>
+internal sealed class SqliteCommandDeadLetterEntryConfiguration : CommandDeadLetterEntryConfigurationBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SqliteCommandDeadLetterEntryConfiguration"/> class with default options.
+    /// </summary>
+    public SqliteCommandDeadLetterEntryConfiguration()
+        : this(Options.Create(new CommandDeadLetterOptions())) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SqliteCommandDeadLetterEntryConfiguration"/> class.
+    /// </summary>
+    /// <param name="options">The command dead letter options containing schema and table configuration.</param>
+    public SqliteCommandDeadLetterEntryConfiguration(IOptions<CommandDeadLetterOptions> options)
+        : base(options) { }
+
+    /// <inheritdoc />
+    protected override void ApplyColumnTypes(EntityTypeBuilder<CommandDeadLetterEntry> builder)
+    {
+        _ = builder.Property(e => e.CommandType).HasColumnType("TEXT");
+        _ = builder.Property(e => e.Payload).HasColumnType("TEXT");
+        _ = builder.Property(e => e.ExceptionType).HasColumnType("TEXT");
+        _ = builder.Property(e => e.ExceptionMessage).HasColumnType("TEXT");
+        // DateTimeOffset stored as INTEGER (UTC ticks) for correct ordering in SQLite.
+        _ = builder
+            .Property(e => e.OccurredAt)
+            .HasColumnType("INTEGER")
+            .HasConversion(v => v.UtcTicks, v => new DateTimeOffset(v, TimeSpan.Zero));
+    }
+}

--- a/src/NetEvolve.Pulse.EntityFramework/DeadLetter/EntityFrameworkCommandDeadLetterManagement.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/DeadLetter/EntityFrameworkCommandDeadLetterManagement.cs
@@ -1,0 +1,119 @@
+﻿namespace NetEvolve.Pulse.DeadLetter;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+
+/// <summary>
+/// Entity Framework Core implementation of <see cref="ICommandDeadLetterManagement"/>.
+/// Provides pending-entry inspection, replay, dismissal, and statistics queries using any EF Core database provider.
+/// </summary>
+/// <remarks>
+/// All read and write operations run directly against <see cref="ICommandDeadLetterDbContext.CommandDeadLetterEntries"/>
+/// using plain LINQ queries and <c>SaveChangesAsync</c>, and are therefore provider-agnostic. Replay dispatch
+/// is delegated to the shared <see cref="CommandDeadLetterReplayDispatcher"/>.
+/// </remarks>
+/// <typeparam name="TContext">The DbContext type that implements <see cref="ICommandDeadLetterDbContext"/>.</typeparam>
+internal sealed class EntityFrameworkCommandDeadLetterManagement<TContext> : ICommandDeadLetterManagement
+    where TContext : DbContext, ICommandDeadLetterDbContext
+{
+    private readonly TContext _context;
+    private readonly IMediatorSendOnly _mediator;
+    private readonly IPayloadSerializer _payloadSerializer;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EntityFrameworkCommandDeadLetterManagement{TContext}"/> class.
+    /// </summary>
+    /// <param name="context">The DbContext for database operations.</param>
+    /// <param name="mediator">The mediator used to dispatch replayed commands.</param>
+    /// <param name="payloadSerializer">The serializer used to deserialize stored payloads.</param>
+    public EntityFrameworkCommandDeadLetterManagement(
+        TContext context,
+        IMediatorSendOnly mediator,
+        IPayloadSerializer payloadSerializer
+    )
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(mediator);
+        ArgumentNullException.ThrowIfNull(payloadSerializer);
+
+        _context = context;
+        _mediator = mediator;
+        _payloadSerializer = payloadSerializer;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<CommandDeadLetterEntry>> GetPendingAsync(
+        int count = 50,
+        CancellationToken cancellationToken = default
+    ) =>
+        await _context
+            .CommandDeadLetterEntries.Where(e => e.Status == CommandDeadLetterStatus.New)
+            .OrderBy(e => e.OccurredAt)
+            .Take(count)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+    /// <inheritdoc />
+    public async Task ReplayAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entry = await GetEntryAsync(id, cancellationToken).ConfigureAwait(false);
+
+        entry.Status = CommandDeadLetterStatus.Replaying;
+        _ = await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        await CommandDeadLetterReplayDispatcher
+            .ReplayAsync(_mediator, _payloadSerializer, entry.CommandType, entry.Payload, cancellationToken)
+            .ConfigureAwait(false);
+
+        entry.Status = CommandDeadLetterStatus.Resolved;
+        _ = await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task DismissAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entry = await GetEntryAsync(id, cancellationToken).ConfigureAwait(false);
+
+        entry.Status = CommandDeadLetterStatus.Dismissed;
+        _ = await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<CommandDeadLetterStatistics> GetStatisticsAsync(CancellationToken cancellationToken = default)
+    {
+        var counts = await _context
+            .CommandDeadLetterEntries.GroupBy(e => e.Status)
+            .Select(g => new { Status = g.Key, Count = g.Count() })
+            .ToDictionaryAsync(g => g.Status, g => g.Count, cancellationToken)
+            .ConfigureAwait(false);
+
+        return new CommandDeadLetterStatistics(
+            NewCount: counts.GetValueOrDefault(CommandDeadLetterStatus.New),
+            ReplayingCount: counts.GetValueOrDefault(CommandDeadLetterStatus.Replaying),
+            ResolvedCount: counts.GetValueOrDefault(CommandDeadLetterStatus.Resolved),
+            DismissedCount: counts.GetValueOrDefault(CommandDeadLetterStatus.Dismissed)
+        );
+    }
+
+    /// <summary>
+    /// Loads the command dead letter entry identified by <paramref name="id"/>.
+    /// </summary>
+    /// <param name="id">The identifier of the dead letter entry to load.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>The loaded <see cref="CommandDeadLetterEntry"/>.</returns>
+    /// <exception cref="KeyNotFoundException">No entry with the given <paramref name="id"/> exists.</exception>
+    private async Task<CommandDeadLetterEntry> GetEntryAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var entry = await _context
+            .CommandDeadLetterEntries.FirstOrDefaultAsync(e => e.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return entry ?? throw new KeyNotFoundException($"No command dead letter entry with id '{id}' was found.");
+    }
+}

--- a/src/NetEvolve.Pulse.EntityFramework/DeadLetter/EntityFrameworkCommandDeadLetterStore.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/DeadLetter/EntityFrameworkCommandDeadLetterStore.cs
@@ -1,0 +1,145 @@
+﻿namespace NetEvolve.Pulse.DeadLetter;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+
+/// <summary>
+/// Entity Framework Core implementation of <see cref="ICommandDeadLetterStore"/>.
+/// Provides command dead letter persistence using any EF Core database provider.
+/// </summary>
+/// <remarks>
+/// <para><strong>Provider Agnostic:</strong></para>
+/// Works with any EF Core database provider (SQL Server, PostgreSQL, SQLite, etc.).
+/// <para><strong>Duplicate Key Handling:</strong></para>
+/// Each call generates a fresh <see cref="Guid"/> for <see cref="CommandDeadLetterEntry.Id"/>, so a
+/// database unique constraint violation is only expected in the astronomically rare case of a
+/// <see cref="Guid"/> collision. A violation is nonetheless caught and treated as a successful
+/// (idempotent) store operation, mirroring the defensive handling used by the Entity Framework
+/// idempotency key repository.
+/// </remarks>
+/// <typeparam name="TContext">The DbContext type that implements <see cref="ICommandDeadLetterDbContext"/>.</typeparam>
+internal sealed class EntityFrameworkCommandDeadLetterStore<TContext> : ICommandDeadLetterStore
+    where TContext : DbContext, ICommandDeadLetterDbContext
+{
+    private readonly TContext _context;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EntityFrameworkCommandDeadLetterStore{TContext}"/> class.
+    /// </summary>
+    /// <param name="context">The DbContext for database operations.</param>
+    public EntityFrameworkCommandDeadLetterStore(TContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        _context = context;
+    }
+
+    /// <inheritdoc />
+    public async Task StoreAsync(
+        string commandType,
+        string payload,
+        Exception exception,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(commandType);
+        ArgumentException.ThrowIfNullOrWhiteSpace(payload);
+        ArgumentNullException.ThrowIfNull(exception);
+
+        var entry = new CommandDeadLetterEntry
+        {
+            Id = Guid.NewGuid(),
+            CommandType = commandType,
+            Payload = payload,
+            ExceptionType = exception.GetType().AssemblyQualifiedName,
+            ExceptionMessage = exception.Message,
+            OccurredAt = DateTimeOffset.UtcNow,
+            AttemptCount = 1,
+            Status = CommandDeadLetterStatus.New,
+        };
+
+        _ = await _context.CommandDeadLetterEntries.AddAsync(entry, cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            _ = await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (IsDuplicateKeyException(ex))
+        {
+            // An entry with the same (freshly generated) Guid already exists — this is the
+            // astronomically rare Guid collision case. Treat it as idempotent and safe to
+            // ignore, detaching the conflicting entry so the context remains in a clean state.
+            _context.Entry(entry).State = EntityState.Detached;
+        }
+    }
+
+    /// <summary>
+    /// Determines whether the given exception was caused by a unique-constraint or
+    /// primary-key violation (i.e., a duplicate key insert).
+    /// </summary>
+    /// <remarks>
+    /// Handles exceptions from all supported EF Core providers:
+    /// <list type="bullet">
+    /// <item><description>
+    /// <strong>Relational providers</strong> (SQL Server, PostgreSQL, SQLite, MySQL) —
+    /// raise <see cref="DbUpdateException"/> wrapping a provider-specific database exception
+    /// whose message contains a duplicate-key indicator. The full exception chain is walked
+    /// because some providers wrap the root cause multiple levels deep.
+    /// </description></item>
+    /// <item><description>
+    /// <strong>EF Core InMemory provider</strong> — raises <see cref="ArgumentException"/>
+    /// with the message "An item with the same key has already been added."
+    /// </description></item>
+    /// </list>
+    /// </remarks>
+    internal static bool IsDuplicateKeyException(Exception ex)
+    {
+        // Walk the full exception chain so that providers that nest the root cause
+        // more than one level deep (e.g. AggregateException wrappers) are handled correctly.
+        var current = ex;
+        while (current is not null)
+        {
+            // EF Core InMemory provider raises ArgumentException (not DbUpdateException) for
+            // duplicate primary-key inserts across different DbContext instances.
+            if (
+                current is ArgumentException
+                && current.Message.Contains(
+                    "An item with the same key has already been added",
+                    StringComparison.OrdinalIgnoreCase
+                )
+            )
+            {
+                return true;
+            }
+
+            var message = current.Message;
+
+            // SQL Server / Azure SQL:
+            //   Error 2627 (PK violation):    "Violation of PRIMARY KEY constraint '...'. Cannot insert duplicate key ..."
+            //   Error 2601 (unique-ix violation): "Cannot insert duplicate key row in object '...' with unique index '...'"
+            // PostgreSQL (Npgsql):
+            //   SQLSTATE 23505: "23505: duplicate key value violates unique constraint ..."
+            // SQLite:
+            //   Error 19: "SQLite Error 19: 'UNIQUE constraint failed: ...'"
+            // MySQL / MariaDB:
+            //   Error 1062: "Duplicate entry '...' for key '...'"
+            if (
+                message.Contains("Cannot insert duplicate key", StringComparison.OrdinalIgnoreCase)
+                || message.Contains("Violation of PRIMARY KEY constraint", StringComparison.OrdinalIgnoreCase)
+                || message.Contains("23505", StringComparison.Ordinal)
+                || message.Contains("UNIQUE constraint failed", StringComparison.OrdinalIgnoreCase)
+                || message.Contains("Duplicate entry", StringComparison.OrdinalIgnoreCase)
+                || message.Contains("unique constraint", StringComparison.OrdinalIgnoreCase)
+            )
+            {
+                return true;
+            }
+
+            current = current.InnerException;
+        }
+
+        return false;
+    }
+}

--- a/src/NetEvolve.Pulse.EntityFramework/DeadLetter/ICommandDeadLetterDbContext.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/DeadLetter/ICommandDeadLetterDbContext.cs
@@ -1,0 +1,42 @@
+﻿namespace NetEvolve.Pulse.DeadLetter;
+
+using Microsoft.EntityFrameworkCore;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+
+/// <summary>
+/// Defines the contract for a DbContext that supports command dead letter persistence.
+/// Implement this interface in your application's DbContext to enable Entity Framework command dead letter store support.
+/// </summary>
+/// <remarks>
+/// <para><strong>Implementation:</strong></para>
+/// Your DbContext must expose a <see cref="DbSet{TEntity}"/> for <see cref="CommandDeadLetterEntry"/>
+/// and apply the appropriate <c>CommandDeadLetterEntryConfiguration</c> in <c>OnModelCreating</c>.
+/// <para><strong>Migration Workflow:</strong></para>
+/// <list type="number">
+/// <item><description>Implement <see cref="ICommandDeadLetterDbContext"/> in your DbContext</description></item>
+/// <item><description>Apply the command dead letter configuration via <c>modelBuilder.ApplyPulseConfiguration(this)</c> in OnModelCreating</description></item>
+/// <item><description>Run <c>dotnet ef migrations add AddCommandDeadLetter</c> with your chosen provider</description></item>
+/// <item><description>Apply migration with <c>dotnet ef database update</c></description></item>
+/// </list>
+/// </remarks>
+/// <example>
+/// <code>
+/// public class ApplicationDbContext : DbContext, ICommandDeadLetterDbContext
+/// {
+///     public DbSet&lt;CommandDeadLetterEntry&gt; CommandDeadLetterEntries =&gt; Set&lt;CommandDeadLetterEntry&gt;();
+///
+///     protected override void OnModelCreating(ModelBuilder modelBuilder)
+///     {
+///         base.OnModelCreating(modelBuilder);
+///         modelBuilder.ApplyPulseConfiguration(this);
+///     }
+/// }
+/// </code>
+/// </example>
+public interface ICommandDeadLetterDbContext
+{
+    /// <summary>
+    /// Gets the <see cref="DbSet{TEntity}"/> for command dead letter entries.
+    /// </summary>
+    DbSet<CommandDeadLetterEntry> CommandDeadLetterEntries { get; }
+}

--- a/src/NetEvolve.Pulse.EntityFramework/EntityFrameworkCommandDeadLetterExtensions.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/EntityFrameworkCommandDeadLetterExtensions.cs
@@ -1,0 +1,74 @@
+﻿namespace NetEvolve.Pulse;
+
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using NetEvolve.Pulse.DeadLetter;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+
+/// <summary>
+/// Extension methods for configuring the Entity Framework Core command dead letter store on <see cref="IMediatorBuilder"/>.
+/// </summary>
+public static class EntityFrameworkCommandDeadLetterExtensions
+{
+    /// <summary>
+    /// Adds Entity Framework Core-backed command dead letter persistence with the specified DbContext.
+    /// </summary>
+    /// <typeparam name="TContext">The DbContext type that implements <see cref="ICommandDeadLetterDbContext"/>.</typeparam>
+    /// <param name="configurator">The mediator configurator.</param>
+    /// <param name="configureOptions">Optional action to configure <see cref="CommandDeadLetterOptions"/>.</param>
+    /// <returns>The configurator for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configurator"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para><strong>Prerequisites:</strong></para>
+    /// <list type="number">
+    /// <item><description>Your DbContext must implement <see cref="ICommandDeadLetterDbContext"/></description></item>
+    /// <item><description>Apply <see cref="ModelBuilderExtensions.ApplyPulseConfiguration{TContext}(ModelBuilder, TContext)"/> in OnModelCreating</description></item>
+    /// <item><description>Generate and apply migrations with your chosen provider</description></item>
+    /// </list>
+    /// <para><strong>Registered Services:</strong></para>
+    /// <list type="bullet">
+    /// <item><description><see cref="ICommandDeadLetterStore"/> as <see cref="EntityFrameworkCommandDeadLetterStore{TContext}"/> (Scoped)</description></item>
+    /// <item><description><see cref="ICommandDeadLetterManagement"/> as <see cref="EntityFrameworkCommandDeadLetterManagement{TContext}"/> (Scoped)</description></item>
+    /// </list>
+    /// <para><strong>Note:</strong></para>
+    /// The DbContext must already be registered in the service collection.
+    /// This method does not register the DbContext itself.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// // Register DbContext with your chosen provider
+    /// services.AddDbContext&lt;MyDbContext&gt;(options =&gt;
+    ///     options.UseSqlServer(connectionString));
+    ///
+    /// // Add command dead letter support
+    /// services.AddPulse(config =&gt; config
+    ///     .AddEntityFrameworkCommandDeadLetterStore&lt;MyDbContext&gt;()
+    /// );
+    /// </code>
+    /// </example>
+    public static IMediatorBuilder AddEntityFrameworkCommandDeadLetterStore<TContext>(
+        this IMediatorBuilder configurator,
+        Action<CommandDeadLetterOptions>? configureOptions = null
+    )
+        where TContext : DbContext, ICommandDeadLetterDbContext
+    {
+        ArgumentNullException.ThrowIfNull(configurator);
+
+        var services = configurator.Services;
+
+        _ = services.Configure(configureOptions ?? (_ => { }));
+
+        _ = services
+            .RemoveAll<ICommandDeadLetterStore>()
+            .AddScoped<ICommandDeadLetterStore, EntityFrameworkCommandDeadLetterStore<TContext>>();
+
+        _ = services
+            .RemoveAll<ICommandDeadLetterManagement>()
+            .AddScoped<ICommandDeadLetterManagement, EntityFrameworkCommandDeadLetterManagement<TContext>>();
+
+        return configurator;
+    }
+}

--- a/src/NetEvolve.Pulse.EntityFramework/ModelBuilderExtensions.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/ModelBuilderExtensions.cs
@@ -4,6 +4,8 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.Options;
 using NetEvolve.Pulse.Configurations;
+using NetEvolve.Pulse.DeadLetter;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
 using NetEvolve.Pulse.Extensibility.Outbox;
 using NetEvolve.Pulse.Idempotency;
 using NetEvolve.Pulse.Outbox;
@@ -16,7 +18,7 @@ public static class ModelBuilderExtensions
     /// <summary>
     /// Applies all Pulse-related entity configurations to the model builder.
     /// </summary>
-    /// <typeparam name="TContext">The DbContext type. When it implements <see cref="IOutboxDbContext"/>, the outbox message configuration is applied automatically. When it implements <see cref="IIdempotencyStoreDbContext"/>, the idempotency key configuration is applied automatically.</typeparam>
+    /// <typeparam name="TContext">The DbContext type. When it implements <see cref="IOutboxDbContext"/>, the outbox message configuration is applied automatically. When it implements <see cref="IIdempotencyStoreDbContext"/>, the idempotency key configuration is applied automatically. When it implements <see cref="ICommandDeadLetterDbContext"/>, the command dead letter entry configuration is applied automatically.</typeparam>
     /// <param name="modelBuilder">The model builder to apply the configuration to.</param>
     /// <param name="context">The DbContext instance used to resolve provider-specific configuration.</param>
     /// <returns>The <paramref name="modelBuilder"/> for chaining.</returns>
@@ -38,6 +40,13 @@ public static class ModelBuilderExtensions
         if (context is IIdempotencyStoreDbContext)
         {
             var configuration = GetIdempotencyKeyConfiguration(context, providerName);
+
+            _ = modelBuilder.ApplyConfiguration(configuration);
+        }
+
+        if (context is ICommandDeadLetterDbContext)
+        {
+            var configuration = GetCommandDeadLetterConfiguration(context, providerName);
 
             _ = modelBuilder.ApplyConfiguration(configuration);
         }
@@ -123,6 +132,47 @@ public static class ModelBuilderExtensions
                 resolvedOptions
             ),
             ProviderName.InMemory => new InMemoryIdempotencyKeyConfiguration(resolvedOptions),
+            _ => throw new NotSupportedException($"Unsupported EF Core provider: {providerName}"),
+        };
+    }
+
+    /// <summary>
+    /// Selects and instantiates the provider-appropriate <see cref="IEntityTypeConfiguration{TEntity}"/>
+    /// for <see cref="CommandDeadLetterEntry"/> based on the active EF Core provider.
+    /// </summary>
+    /// <typeparam name="TContext">The DbContext type, used to resolve registered <see cref="CommandDeadLetterOptions"/>.</typeparam>
+    /// <param name="context">The DbContext instance used to resolve <see cref="IOptions{TOptions}"/> of <see cref="CommandDeadLetterOptions"/>.</param>
+    /// <param name="providerName">The EF Core provider name read from <see cref="DatabaseFacade.ProviderName"/>.</param>
+    /// <returns>A provider-specific <see cref="IEntityTypeConfiguration{TEntity}"/> for <see cref="CommandDeadLetterEntry"/>.</returns>
+    /// <exception cref="NotSupportedException">Thrown when <paramref name="providerName"/> is not a supported EF Core provider.</exception>
+    private static IEntityTypeConfiguration<CommandDeadLetterEntry> GetCommandDeadLetterConfiguration<TContext>(
+        TContext context,
+        string? providerName
+    )
+        where TContext : DbContext
+    {
+        IOptions<CommandDeadLetterOptions>? resolvedOptions = null;
+        try
+        {
+            // EF Core's GetService throws InvalidOperationException when the service is not
+            // registered (instead of returning null), so we catch and fall back to defaults.
+            resolvedOptions = context.GetService<IOptions<CommandDeadLetterOptions>>();
+        }
+        catch (InvalidOperationException)
+        {
+            // IOptions<CommandDeadLetterOptions> not registered; use default options.
+        }
+
+        resolvedOptions ??= Options.Create(new CommandDeadLetterOptions());
+        return providerName switch
+        {
+            ProviderName.Npgsql => new PostgreSqlCommandDeadLetterEntryConfiguration(resolvedOptions),
+            ProviderName.Sqlite => new SqliteCommandDeadLetterEntryConfiguration(resolvedOptions),
+            ProviderName.SqlServer => new SqlServerCommandDeadLetterEntryConfiguration(resolvedOptions),
+            ProviderName.PomeloMySql or ProviderName.OracleMySql => new MySqlCommandDeadLetterEntryConfiguration(
+                resolvedOptions
+            ),
+            ProviderName.InMemory => new InMemoryCommandDeadLetterEntryConfiguration(resolvedOptions),
             _ => throw new NotSupportedException($"Unsupported EF Core provider: {providerName}"),
         };
     }

--- a/src/NetEvolve.Pulse.Extensibility/DeadLetter/CommandDeadLetterEntry.cs
+++ b/src/NetEvolve.Pulse.Extensibility/DeadLetter/CommandDeadLetterEntry.cs
@@ -1,0 +1,71 @@
+namespace NetEvolve.Pulse.Extensibility.DeadLetter;
+
+/// <summary>
+/// Represents a command that failed processing and was moved to the dead letter store.
+/// This entity serves as the canonical schema contract shared across all persistence providers.
+/// </summary>
+/// <remarks>
+/// <para><strong>Schema Contract:</strong></para>
+/// All persistence implementations (SQL Server, Entity Framework, etc.) MUST use
+/// identical column names and types to ensure interchangeability.
+/// <para><strong>Column Specifications:</strong></para>
+/// <list type="bullet">
+/// <item><description><see cref="Id"/>: UNIQUEIDENTIFIER / GUID, Primary Key</description></item>
+/// <item><description><see cref="CommandType"/>: NVARCHAR(500), NOT NULL - Runtime type; persisted as assembly-qualified name</description></item>
+/// <item><description><see cref="Payload"/>: NVARCHAR(MAX) / TEXT, NOT NULL - JSON serialized command</description></item>
+/// <item><description><see cref="ExceptionType"/>: NVARCHAR(500), NULL - Assembly-qualified name of the exception type that caused the failure</description></item>
+/// <item><description><see cref="ExceptionMessage"/>: NVARCHAR(MAX) / TEXT, NULL - Message of the exception that caused the failure</description></item>
+/// <item><description><see cref="OccurredAt"/>: DATETIMEOFFSET, NOT NULL - Timestamp the failure was recorded</description></item>
+/// <item><description><see cref="AttemptCount"/>: INT, NOT NULL, DEFAULT 1 - Number of processing attempts</description></item>
+/// <item><description><see cref="Status"/>: INT, NOT NULL, DEFAULT 0 - Dead letter status enum value</description></item>
+/// </list>
+/// </remarks>
+public sealed class CommandDeadLetterEntry
+{
+    /// <summary>
+    /// Gets or sets the unique identifier for this dead letter entry.
+    /// </summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the assembly-qualified type name of the command that failed processing.
+    /// </summary>
+    /// <remarks>
+    /// Stored in the database as a string (maximum 500 characters).
+    /// Used to resolve the runtime <see cref="Type"/> when replaying the command.
+    /// </remarks>
+    public string CommandType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the JSON serialized command payload.
+    /// </summary>
+    public string Payload { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the assembly-qualified type name of the exception that caused the failure.
+    /// </summary>
+    /// <remarks>
+    /// Maximum length: 500 characters.
+    /// </remarks>
+    public string? ExceptionType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the message of the exception that caused the failure.
+    /// </summary>
+    public string? ExceptionMessage { get; set; }
+
+    /// <summary>
+    /// Gets or sets the timestamp when this entry was recorded.
+    /// </summary>
+    public DateTimeOffset OccurredAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of times processing of this command has been attempted.
+    /// </summary>
+    public int AttemptCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the current dead letter status.
+    /// </summary>
+    public CommandDeadLetterStatus Status { get; set; } = CommandDeadLetterStatus.New;
+}

--- a/src/NetEvolve.Pulse.Extensibility/DeadLetter/CommandDeadLetterReplayDispatcher.cs
+++ b/src/NetEvolve.Pulse.Extensibility/DeadLetter/CommandDeadLetterReplayDispatcher.cs
@@ -1,0 +1,137 @@
+namespace NetEvolve.Pulse.Extensibility.DeadLetter;
+
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+
+/// <summary>
+/// Provides the shared reflection-based logic to replay a command persisted in the dead letter store.
+/// </summary>
+/// <remarks>
+/// <para><strong>Purpose:</strong></para>
+/// <see cref="ICommandDeadLetterManagement.ReplayAsync"/> only has a <see cref="Guid"/> identifier at
+/// compile time and must resolve the concrete command and response types from persisted string metadata
+/// (<see cref="CommandDeadLetterEntry.CommandType"/> and <see cref="CommandDeadLetterEntry.Payload"/>) at
+/// runtime. Because every dead letter store implementation (Entity Framework Core, SQL Server, PostgreSQL,
+/// SQLite, MySQL, etc.) needs to perform this exact same reflection dance, the logic is implemented once
+/// here and shared by all of them.
+/// </remarks>
+public static class CommandDeadLetterReplayDispatcher
+{
+    /// <summary>
+    /// Caches resolved command types by their assembly-qualified name, mirroring the resolution pattern
+    /// used elsewhere in this codebase for persisted type names. Repeated string-based type resolution
+    /// via <see cref="Type.GetType(string, bool)"/> parses the name and probes loaded assemblies on every
+    /// call, which is unnecessary overhead when the same command type is replayed repeatedly.
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, Type> _commandTypeCache = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Resolves the command and response types from the persisted metadata, deserializes the payload,
+    /// and dispatches the resulting command instance via <paramref name="mediator"/>.
+    /// </summary>
+    /// <param name="mediator">The mediator used to dispatch the replayed command.</param>
+    /// <param name="payloadSerializer">The serializer used to deserialize the stored payload.</param>
+    /// <param name="commandType">The assembly-qualified type name of the command to replay.</param>
+    /// <param name="payload">The JSON serialized command payload.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A task representing the asynchronous dispatch operation.</returns>
+    /// <exception cref="ArgumentException"><paramref name="commandType"/> or <paramref name="payload"/> is <see langword="null"/>, empty, or consists only of white-space characters.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// <paramref name="commandType"/> cannot be resolved to a runtime <see cref="Type"/>, the resolved type
+    /// does not implement <see cref="ICommand{TResponse}"/>, or the payload fails to deserialize.
+    /// </exception>
+    public static async Task ReplayAsync(
+        IMediatorSendOnly mediator,
+        IPayloadSerializer payloadSerializer,
+        string commandType,
+        string payload,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(mediator);
+        ArgumentNullException.ThrowIfNull(payloadSerializer);
+        ArgumentException.ThrowIfNullOrWhiteSpace(commandType);
+        ArgumentException.ThrowIfNullOrWhiteSpace(payload);
+
+        var resolvedType = ResolveCommandType(commandType);
+        var responseType = ResolveResponseType(resolvedType, commandType);
+        var command = DeserializeCommand(payloadSerializer, resolvedType, commandType, payload);
+
+        var sendAsyncMethod = ResolveSendAsyncMethod().MakeGenericMethod(resolvedType, responseType);
+
+        try
+        {
+            var result = sendAsyncMethod.Invoke(mediator, [command, cancellationToken]);
+            await ((Task)result!).ConfigureAwait(false);
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException is not null)
+        {
+            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+        }
+    }
+
+    private static Type ResolveCommandType(string commandType)
+    {
+        if (_commandTypeCache.TryGetValue(commandType, out var cached))
+        {
+            return cached;
+        }
+
+        var resolved =
+            Type.GetType(commandType, throwOnError: false)
+            ?? throw new InvalidOperationException($"Cannot resolve command type '{commandType}'.");
+
+        return _commandTypeCache.GetOrAdd(commandType, resolved);
+    }
+
+    private static Type ResolveResponseType(Type resolvedType, string commandType)
+    {
+        foreach (var interfaceType in resolvedType.GetInterfaces())
+        {
+            if (interfaceType.IsGenericType && interfaceType.GetGenericTypeDefinition() == typeof(ICommand<>))
+            {
+                return interfaceType.GetGenericArguments()[0];
+            }
+        }
+
+        throw new InvalidOperationException($"'{commandType}' does not implement ICommand<TResponse>.");
+    }
+
+    private static object DeserializeCommand(
+        IPayloadSerializer payloadSerializer,
+        Type resolvedType,
+        string commandType,
+        string payload
+    )
+    {
+        var deserializeMethod = typeof(IPayloadSerializer)
+            .GetMethod(nameof(IPayloadSerializer.Deserialize), [typeof(string)])!
+            .MakeGenericMethod(resolvedType);
+
+        var command = deserializeMethod.Invoke(payloadSerializer, [payload]);
+
+        return command
+            ?? throw new InvalidOperationException($"Failed to deserialize payload for command type '{commandType}'.");
+    }
+
+    private static MethodInfo ResolveSendAsyncMethod()
+    {
+        foreach (var method in typeof(IMediatorSendOnly).GetMethods())
+        {
+            if (
+                method.Name == nameof(IMediatorSendOnly.SendAsync)
+                && method.IsGenericMethodDefinition
+                && method.GetGenericArguments().Length == 2
+                && method.GetParameters().Length == 2
+            )
+            {
+                return method;
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Cannot resolve the two-generic-argument overload of '{nameof(IMediatorSendOnly.SendAsync)}'."
+        );
+    }
+}

--- a/src/NetEvolve.Pulse.Extensibility/DeadLetter/CommandDeadLetterSchema.cs
+++ b/src/NetEvolve.Pulse.Extensibility/DeadLetter/CommandDeadLetterSchema.cs
@@ -1,0 +1,118 @@
+namespace NetEvolve.Pulse.Extensibility.DeadLetter;
+
+using System.Diagnostics.CodeAnalysis;
+
+/// <summary>
+/// Defines the canonical database schema for command dead letter entries.
+/// All persistence providers MUST use these constants to ensure interchangeability.
+/// </summary>
+public static class CommandDeadLetterSchema
+{
+    /// <summary>
+    /// Default schema name for the command dead letter table.
+    /// </summary>
+    public const string DefaultSchema = "pulse";
+
+    /// <summary>
+    /// Default table name for the command dead letter entries.
+    /// </summary>
+    public const string DefaultTableName = "CommandDeadLetter";
+
+    /// <summary>
+    /// Column name constants matching <see cref="CommandDeadLetterEntry"/> properties.
+    /// </summary>
+    [SuppressMessage(
+        "Design",
+        "CA1034:Nested types should not be visible",
+        Justification = "Intentionally nested for organizational clarity - constants grouped by purpose."
+    )]
+    public static class Columns
+    {
+        /// <summary>
+        /// The Id column name.
+        /// </summary>
+        public const string Id = "Id";
+
+        /// <summary>
+        /// The CommandType column name.
+        /// </summary>
+        public const string CommandType = "CommandType";
+
+        /// <summary>
+        /// The Payload column name.
+        /// </summary>
+        public const string Payload = "Payload";
+
+        /// <summary>
+        /// The ExceptionType column name.
+        /// </summary>
+        public const string ExceptionType = "ExceptionType";
+
+        /// <summary>
+        /// The ExceptionMessage column name.
+        /// </summary>
+        public const string ExceptionMessage = "ExceptionMessage";
+
+        /// <summary>
+        /// The OccurredAt column name.
+        /// </summary>
+        public const string OccurredAt = "OccurredAt";
+
+        /// <summary>
+        /// The AttemptCount column name.
+        /// </summary>
+        public const string AttemptCount = "AttemptCount";
+
+        /// <summary>
+        /// The Status column name.
+        /// </summary>
+        public const string Status = "Status";
+    }
+
+    /// <summary>
+    /// Recommended maximum lengths for string columns.
+    /// </summary>
+    [SuppressMessage(
+        "Design",
+        "CA1034:Nested types should not be visible",
+        Justification = "Intentionally nested for organizational clarity - constants grouped by purpose."
+    )]
+    public static class MaxLengths
+    {
+        /// <summary>
+        /// Maximum length for CommandType column (500 characters).
+        /// </summary>
+        public const int CommandType = 500;
+
+        /// <summary>
+        /// Maximum length for ExceptionType column (500 characters).
+        /// </summary>
+        public const int ExceptionType = 500;
+    }
+}
+
+/// <summary>
+/// Represents the processing status of a command dead letter entry.
+/// </summary>
+public enum CommandDeadLetterStatus
+{
+    /// <summary>
+    /// The entry is newly stored and awaiting operator action.
+    /// </summary>
+    New = 0,
+
+    /// <summary>
+    /// The entry's command is currently being replayed.
+    /// </summary>
+    Replaying = 1,
+
+    /// <summary>
+    /// The entry's command was successfully replayed and resolved.
+    /// </summary>
+    Resolved = 2,
+
+    /// <summary>
+    /// The entry was manually dismissed and will not be replayed.
+    /// </summary>
+    Dismissed = 3,
+}

--- a/src/NetEvolve.Pulse.Extensibility/DeadLetter/CommandDeadLetterStatistics.cs
+++ b/src/NetEvolve.Pulse.Extensibility/DeadLetter/CommandDeadLetterStatistics.cs
@@ -1,0 +1,22 @@
+namespace NetEvolve.Pulse.Extensibility.DeadLetter;
+
+/// <summary>
+/// Represents the aggregate counts of command dead letter entries per <see cref="CommandDeadLetterStatus"/>.
+/// This is the value returned by <see cref="ICommandDeadLetterManagement.GetStatisticsAsync"/>.
+/// </summary>
+/// <param name="NewCount">The number of entries with <see cref="CommandDeadLetterStatus.New"/> status.</param>
+/// <param name="ReplayingCount">The number of entries with <see cref="CommandDeadLetterStatus.Replaying"/> status.</param>
+/// <param name="ResolvedCount">The number of entries with <see cref="CommandDeadLetterStatus.Resolved"/> status.</param>
+/// <param name="DismissedCount">The number of entries with <see cref="CommandDeadLetterStatus.Dismissed"/> status.</param>
+public sealed record CommandDeadLetterStatistics(
+    int NewCount,
+    int ReplayingCount,
+    int ResolvedCount,
+    int DismissedCount
+)
+{
+    /// <summary>
+    /// Gets the total number of dead letter entries across all statuses.
+    /// </summary>
+    public int TotalCount => NewCount + ReplayingCount + ResolvedCount + DismissedCount;
+}

--- a/src/NetEvolve.Pulse.Extensibility/DeadLetter/ICommandDeadLetterManagement.cs
+++ b/src/NetEvolve.Pulse.Extensibility/DeadLetter/ICommandDeadLetterManagement.cs
@@ -1,0 +1,54 @@
+namespace NetEvolve.Pulse.Extensibility.DeadLetter;
+
+/// <summary>
+/// Defines the contract for managing commands stored in the dead letter store.
+/// </summary>
+public interface ICommandDeadLetterManagement
+{
+    /// <summary>
+    /// Retrieves the pending dead letter entries, i.e. entries with <see cref="CommandDeadLetterStatus.New"/> status.
+    /// </summary>
+    /// <param name="count">The maximum number of entries to return. Default: <c>50</c>.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>
+    /// A read-only list of at most <paramref name="count"/> entries with <see cref="CommandDeadLetterStatus.New"/> status,
+    /// ordered by <see cref="CommandDeadLetterEntry.OccurredAt"/> ascending (oldest first).
+    /// </returns>
+    Task<IReadOnlyList<CommandDeadLetterEntry>> GetPendingAsync(
+        int count = 50,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
+    /// Replays the command stored in the dead letter entry identified by <paramref name="id"/>.
+    /// </summary>
+    /// <param name="id">The identifier of the dead letter entry to replay.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    /// <remarks>
+    /// Implementations set <see cref="CommandDeadLetterEntry.Status"/> to <see cref="CommandDeadLetterStatus.Replaying"/>,
+    /// deserialize the stored payload, dispatch it via <see cref="IMediatorSendOnly"/>, and set
+    /// <see cref="CommandDeadLetterEntry.Status"/> to <see cref="CommandDeadLetterStatus.Resolved"/> on success.
+    /// Implementations should use the shared <see cref="CommandDeadLetterReplayDispatcher"/> to perform the
+    /// type resolution and dispatch, rather than reimplementing the reflection dispatch.
+    /// </remarks>
+    Task ReplayAsync(Guid id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Dismisses the dead letter entry identified by <paramref name="id"/>, preventing further replay attempts.
+    /// </summary>
+    /// <param name="id">The identifier of the dead letter entry to dismiss.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    /// <remarks>
+    /// Implementations set <see cref="CommandDeadLetterEntry.Status"/> to <see cref="CommandDeadLetterStatus.Dismissed"/>.
+    /// </remarks>
+    Task DismissAsync(Guid id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves aggregate counts of dead letter entries per <see cref="CommandDeadLetterStatus"/>.
+    /// </summary>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A <see cref="CommandDeadLetterStatistics"/> instance describing the current aggregate counts.</returns>
+    Task<CommandDeadLetterStatistics> GetStatisticsAsync(CancellationToken cancellationToken = default);
+}

--- a/src/NetEvolve.Pulse.Extensibility/DeadLetter/ICommandDeadLetterStore.cs
+++ b/src/NetEvolve.Pulse.Extensibility/DeadLetter/ICommandDeadLetterStore.cs
@@ -1,0 +1,34 @@
+namespace NetEvolve.Pulse.Extensibility.DeadLetter;
+
+/// <summary>
+/// Defines the contract for persisting commands that failed processing to the dead letter store.
+/// </summary>
+/// <remarks>
+/// <para><strong>Implementation Guidelines:</strong></para>
+/// Implementations MUST persist a new <see cref="CommandDeadLetterEntry"/> with the following values:
+/// <list type="bullet">
+/// <item><description><see cref="CommandDeadLetterEntry.Id"/>: a freshly generated <see cref="Guid"/>.</description></item>
+/// <item><description><see cref="CommandDeadLetterEntry.Status"/>: <see cref="CommandDeadLetterStatus.New"/>.</description></item>
+/// <item><description><see cref="CommandDeadLetterEntry.OccurredAt"/>: the current timestamp.</description></item>
+/// <item><description><see cref="CommandDeadLetterEntry.AttemptCount"/>: <c>1</c>.</description></item>
+/// <item><description><see cref="CommandDeadLetterEntry.ExceptionType"/>: <c>exception.GetType().AssemblyQualifiedName</c>.</description></item>
+/// <item><description><see cref="CommandDeadLetterEntry.ExceptionMessage"/>: <c>exception.Message</c>.</description></item>
+/// </list>
+/// </remarks>
+public interface ICommandDeadLetterStore
+{
+    /// <summary>
+    /// Stores a command that failed processing as a new dead letter entry.
+    /// </summary>
+    /// <param name="commandType">The assembly-qualified type name of the command that failed processing.</param>
+    /// <param name="payload">The JSON serialized command payload.</param>
+    /// <param name="exception">The exception that caused the failure.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task StoreAsync(
+        string commandType,
+        string payload,
+        Exception exception,
+        CancellationToken cancellationToken = default
+    );
+}

--- a/src/NetEvolve.Pulse.MySql/DeadLetter/MySqlCommandDeadLetterManagement.cs
+++ b/src/NetEvolve.Pulse.MySql/DeadLetter/MySqlCommandDeadLetterManagement.cs
@@ -1,0 +1,343 @@
+namespace NetEvolve.Pulse.DeadLetter;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using MySql.Data.MySqlClient;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+using NetEvolve.Pulse.Extensibility.Outbox;
+
+/// <summary>
+/// MySQL implementation of <see cref="ICommandDeadLetterManagement"/> using ADO.NET.
+/// Provides pending inspection, replay, dismissal, and statistics queries for the command dead letter store.
+/// </summary>
+/// <remarks>
+/// <para><strong>Prerequisites:</strong></para>
+/// Execute the schema script from <c>Scripts/CommandDeadLetter.sql</c> to create the required
+/// database objects before using this provider.
+/// <para><strong>Schema:</strong></para>
+/// MySQL does not use schema namespaces in the same way as SQL Server or PostgreSQL.
+/// All tables reside in the active database specified by the connection string.
+/// The <see cref="CommandDeadLetterOptions.Schema"/> property is ignored for MySQL.
+/// <para><strong>Timestamps:</strong></para>
+/// Stores <see cref="DateTimeOffset"/> values as <c>BIGINT</c> (UTC ticks), matching the
+/// interoperability contract with the Entity Framework MySQL provider.
+/// </remarks>
+[SuppressMessage(
+    "Reliability",
+    "CA2007:Consider calling ConfigureAwait on the awaited task",
+    Justification = "await using statements in library code; ConfigureAwait applied to all Task-returning awaits."
+)]
+[SuppressMessage(
+    "Security",
+    "CA2100:Review SQL queries for security vulnerabilities",
+    Justification = "SQL is constructed from validated CommandDeadLetterOptions.TableName property, not user input."
+)]
+internal sealed class MySqlCommandDeadLetterManagement : ICommandDeadLetterManagement
+{
+    private readonly string _connectionString;
+    private readonly IMediatorSendOnly _mediator;
+    private readonly IPayloadSerializer _payloadSerializer;
+
+    // Cached SQL statements
+    private readonly string _getPendingSql;
+    private readonly string _getByIdSql;
+    private readonly string _markReplayingSql;
+    private readonly string _markResolvedSql;
+    private readonly string _markDismissedSql;
+    private readonly string _getStatisticsSql;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MySqlCommandDeadLetterManagement"/> class.
+    /// </summary>
+    /// <param name="options">The command dead letter configuration options.</param>
+    /// <param name="mediator">The mediator used to dispatch replayed commands.</param>
+    /// <param name="payloadSerializer">The serializer used to deserialize stored payloads.</param>
+    public MySqlCommandDeadLetterManagement(
+        IOptions<CommandDeadLetterOptions> options,
+        IMediatorSendOnly mediator,
+        IPayloadSerializer payloadSerializer
+    )
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrWhiteSpace(options.Value.ConnectionString);
+        ArgumentNullException.ThrowIfNull(mediator);
+        ArgumentNullException.ThrowIfNull(payloadSerializer);
+
+        var opts = options.Value;
+        _connectionString = opts.ConnectionString;
+        _mediator = mediator;
+        _payloadSerializer = payloadSerializer;
+
+        SqlIdentifier.Validate(opts.TableName, nameof(opts.TableName));
+        var table = $"`{opts.TableName}`";
+
+        _getPendingSql = $"""
+            SELECT
+                `{CommandDeadLetterSchema.Columns.Id}`,
+                `{CommandDeadLetterSchema.Columns.CommandType}`,
+                `{CommandDeadLetterSchema.Columns.Payload}`,
+                `{CommandDeadLetterSchema.Columns.ExceptionType}`,
+                `{CommandDeadLetterSchema.Columns.ExceptionMessage}`,
+                `{CommandDeadLetterSchema.Columns.OccurredAt}`,
+                `{CommandDeadLetterSchema.Columns.AttemptCount}`,
+                `{CommandDeadLetterSchema.Columns.Status}`
+            FROM {table}
+            WHERE `{CommandDeadLetterSchema.Columns.Status}` = 0
+            ORDER BY `{CommandDeadLetterSchema.Columns.OccurredAt}` ASC
+            LIMIT @count
+            """;
+
+        _getByIdSql = $"""
+            SELECT
+                `{CommandDeadLetterSchema.Columns.Id}`,
+                `{CommandDeadLetterSchema.Columns.CommandType}`,
+                `{CommandDeadLetterSchema.Columns.Payload}`,
+                `{CommandDeadLetterSchema.Columns.ExceptionType}`,
+                `{CommandDeadLetterSchema.Columns.ExceptionMessage}`,
+                `{CommandDeadLetterSchema.Columns.OccurredAt}`,
+                `{CommandDeadLetterSchema.Columns.AttemptCount}`,
+                `{CommandDeadLetterSchema.Columns.Status}`
+            FROM {table}
+            WHERE `{CommandDeadLetterSchema.Columns.Id}` = @id
+            """;
+
+        _markReplayingSql = $"""
+            UPDATE {table}
+            SET `{CommandDeadLetterSchema.Columns.Status}` = 1
+            WHERE `{CommandDeadLetterSchema.Columns.Id}` = @id
+            """;
+
+        _markResolvedSql = $"""
+            UPDATE {table}
+            SET `{CommandDeadLetterSchema.Columns.Status}` = 2
+            WHERE `{CommandDeadLetterSchema.Columns.Id}` = @id
+            """;
+
+        _markDismissedSql = $"""
+            UPDATE {table}
+            SET `{CommandDeadLetterSchema.Columns.Status}` = 3
+            WHERE `{CommandDeadLetterSchema.Columns.Id}` = @id
+            """;
+
+        _getStatisticsSql = $"""
+            SELECT `{CommandDeadLetterSchema.Columns.Status}`, COUNT(*)
+            FROM {table}
+            GROUP BY `{CommandDeadLetterSchema.Columns.Status}`
+            """;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<CommandDeadLetterEntry>> GetPendingAsync(
+        int count = 50,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var command = new MySqlCommand(_getPendingSql, connection);
+            await using (command.ConfigureAwait(false))
+            {
+                _ = command.Parameters.AddWithValue("@count", count);
+
+                return await ReadEntriesAsync(command, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task ReplayAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entry = await GetByIdAsync(id, cancellationToken).ConfigureAwait(false) ?? throw NotFound(id);
+
+        await SetStatusAsync(_markReplayingSql, id, cancellationToken).ConfigureAwait(false);
+
+        await CommandDeadLetterReplayDispatcher
+            .ReplayAsync(_mediator, _payloadSerializer, entry.CommandType, entry.Payload, cancellationToken)
+            .ConfigureAwait(false);
+
+        await SetStatusAsync(_markResolvedSql, id, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task DismissAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var command = new MySqlCommand(_markDismissedSql, connection);
+            await using (command.ConfigureAwait(false))
+            {
+                _ = command.Parameters.AddWithValue("@id", id.ToByteArray());
+
+                var affected = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+                if (affected == 0)
+                {
+                    throw NotFound(id);
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<CommandDeadLetterStatistics> GetStatisticsAsync(CancellationToken cancellationToken = default)
+    {
+        var newCount = 0;
+        var replayingCount = 0;
+        var resolvedCount = 0;
+        var dismissedCount = 0;
+
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var command = new MySqlCommand(_getStatisticsSql, connection);
+            await using (command.ConfigureAwait(false))
+            {
+                var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                await using (reader.ConfigureAwait(false))
+                {
+                    while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                    {
+                        var status = (CommandDeadLetterStatus)reader.GetInt32(0);
+                        var count = Convert.ToInt32(
+                            reader.GetValue(1),
+                            System.Globalization.CultureInfo.InvariantCulture
+                        );
+
+                        switch (status)
+                        {
+                            case CommandDeadLetterStatus.New:
+                                newCount = count;
+                                break;
+                            case CommandDeadLetterStatus.Replaying:
+                                replayingCount = count;
+                                break;
+                            case CommandDeadLetterStatus.Resolved:
+                                resolvedCount = count;
+                                break;
+                            case CommandDeadLetterStatus.Dismissed:
+                                dismissedCount = count;
+                                break;
+                        }
+                    }
+                }
+            }
+        }
+
+        return new CommandDeadLetterStatistics(newCount, replayingCount, resolvedCount, dismissedCount);
+    }
+
+    /// <summary>
+    /// Retrieves the dead letter entry identified by <paramref name="id"/>, or <see langword="null"/> when not found.
+    /// </summary>
+    private async Task<CommandDeadLetterEntry?> GetByIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var command = new MySqlCommand(_getByIdSql, connection);
+            await using (command.ConfigureAwait(false))
+            {
+                _ = command.Parameters.AddWithValue("@id", id.ToByteArray());
+
+                var entries = await ReadEntriesAsync(command, cancellationToken).ConfigureAwait(false);
+                return entries.Count > 0 ? entries[0] : null;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Executes a status-update statement parameterized on <c>@id</c> against the dead letter entry
+    /// identified by <paramref name="id"/>.
+    /// </summary>
+    private async Task SetStatusAsync(string sql, Guid id, CancellationToken cancellationToken)
+    {
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var command = new MySqlCommand(sql, connection);
+            await using (command.ConfigureAwait(false))
+            {
+                _ = command.Parameters.AddWithValue("@id", id.ToByteArray());
+
+                _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Opens and returns a new <see cref="MySqlConnection"/> using the stored connection string.
+    /// The caller is responsible for disposing the connection.
+    /// </summary>
+    private async Task<MySqlConnection> CreateConnectionAsync(CancellationToken cancellationToken)
+    {
+        var connection = new MySqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        return connection;
+    }
+
+    /// <summary>
+    /// Executes <paramref name="command"/> and reads all rows into a list of <see cref="CommandDeadLetterEntry"/> instances.
+    /// </summary>
+    private static async Task<IReadOnlyList<CommandDeadLetterEntry>> ReadEntriesAsync(
+        MySqlCommand command,
+        CancellationToken cancellationToken
+    )
+    {
+        var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        await using (reader.ConfigureAwait(false))
+        {
+            if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                return [];
+            }
+
+            var ordId = reader.GetOrdinal(CommandDeadLetterSchema.Columns.Id);
+            var ordCommandType = reader.GetOrdinal(CommandDeadLetterSchema.Columns.CommandType);
+            var ordPayload = reader.GetOrdinal(CommandDeadLetterSchema.Columns.Payload);
+            var ordExceptionType = reader.GetOrdinal(CommandDeadLetterSchema.Columns.ExceptionType);
+            var ordExceptionMessage = reader.GetOrdinal(CommandDeadLetterSchema.Columns.ExceptionMessage);
+            var ordOccurredAt = reader.GetOrdinal(CommandDeadLetterSchema.Columns.OccurredAt);
+            var ordAttemptCount = reader.GetOrdinal(CommandDeadLetterSchema.Columns.AttemptCount);
+            var ordStatus = reader.GetOrdinal(CommandDeadLetterSchema.Columns.Status);
+
+            var entries = new List<CommandDeadLetterEntry>();
+            do
+            {
+                var idBytes = await reader.GetFieldValueAsync<byte[]>(ordId, cancellationToken).ConfigureAwait(false);
+                var exceptionTypeNull = await reader
+                    .IsDBNullAsync(ordExceptionType, cancellationToken)
+                    .ConfigureAwait(false);
+                var exceptionMessageNull = await reader
+                    .IsDBNullAsync(ordExceptionMessage, cancellationToken)
+                    .ConfigureAwait(false);
+
+                entries.Add(
+                    new CommandDeadLetterEntry
+                    {
+                        Id = new Guid(idBytes),
+                        CommandType = reader.GetString(ordCommandType),
+                        Payload = reader.GetString(ordPayload),
+                        ExceptionType = exceptionTypeNull ? null : reader.GetString(ordExceptionType),
+                        ExceptionMessage = exceptionMessageNull ? null : reader.GetString(ordExceptionMessage),
+                        OccurredAt = new DateTimeOffset(reader.GetInt64(ordOccurredAt), TimeSpan.Zero),
+                        AttemptCount = reader.GetInt32(ordAttemptCount),
+                        Status = (CommandDeadLetterStatus)reader.GetInt32(ordStatus),
+                    }
+                );
+            } while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false));
+
+            return entries;
+        }
+    }
+
+    /// <summary>
+    /// Creates the exception thrown when a dead letter entry cannot be found by its identifier.
+    /// </summary>
+    private static KeyNotFoundException NotFound(Guid id) => new($"CommandDeadLetterEntry '{id}' was not found.");
+}

--- a/src/NetEvolve.Pulse.MySql/DeadLetter/MySqlCommandDeadLetterStore.cs
+++ b/src/NetEvolve.Pulse.MySql/DeadLetter/MySqlCommandDeadLetterStore.cs
@@ -1,0 +1,123 @@
+namespace NetEvolve.Pulse.DeadLetter;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using MySql.Data.MySqlClient;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+using NetEvolve.Pulse.Extensibility.Outbox;
+
+/// <summary>
+/// MySQL implementation of <see cref="ICommandDeadLetterStore"/> using ADO.NET.
+/// Provides command dead letter persistence optimized for MySQL.
+/// </summary>
+/// <remarks>
+/// <para><strong>Prerequisites:</strong></para>
+/// Execute the schema script from <c>Scripts/CommandDeadLetter.sql</c> to create the required
+/// database objects before using this provider.
+/// <para><strong>Schema:</strong></para>
+/// MySQL does not use schema namespaces in the same way as SQL Server or PostgreSQL.
+/// All tables reside in the active database specified by the connection string.
+/// The <see cref="CommandDeadLetterOptions.Schema"/> property is ignored for MySQL.
+/// <para><strong>Timestamps:</strong></para>
+/// Stores <see cref="DateTimeOffset"/> values as <c>BIGINT</c> (UTC ticks), matching the
+/// interoperability contract with the Entity Framework MySQL provider.
+/// <para><strong>Duplicate Key Handling:</strong></para>
+/// Uses <c>INSERT IGNORE</c> so a duplicate <see cref="CommandDeadLetterEntry.Id"/> (an extremely
+/// unlikely freshly-generated <see cref="Guid"/> collision) is silently ignored rather than throwing.
+/// </remarks>
+[SuppressMessage(
+    "Reliability",
+    "CA2007:Consider calling ConfigureAwait on the awaited task",
+    Justification = "await using statements in library code; ConfigureAwait applied to all Task-returning awaits."
+)]
+[SuppressMessage(
+    "Security",
+    "CA2100:Review SQL queries for security vulnerabilities",
+    Justification = "SQL is constructed from validated CommandDeadLetterOptions.TableName property, not user input."
+)]
+internal sealed class MySqlCommandDeadLetterStore : ICommandDeadLetterStore
+{
+    /// <summary>The MySQL connection string used to open new connections for each store operation.</summary>
+    private readonly string _connectionString;
+
+    /// <summary>Cached SQL statement for inserting a command dead letter entry.</summary>
+    private readonly string _insertSql;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MySqlCommandDeadLetterStore"/> class.
+    /// </summary>
+    /// <param name="options">The command dead letter configuration options.</param>
+    public MySqlCommandDeadLetterStore(IOptions<CommandDeadLetterOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrWhiteSpace(options.Value.ConnectionString);
+
+        var opts = options.Value;
+        _connectionString = opts.ConnectionString;
+
+        SqlIdentifier.Validate(opts.TableName, nameof(opts.TableName));
+        var table = $"`{opts.TableName}`";
+
+        _insertSql = $"""
+            INSERT IGNORE INTO {table}
+                (`{CommandDeadLetterSchema.Columns.Id}`,
+                 `{CommandDeadLetterSchema.Columns.CommandType}`,
+                 `{CommandDeadLetterSchema.Columns.Payload}`,
+                 `{CommandDeadLetterSchema.Columns.ExceptionType}`,
+                 `{CommandDeadLetterSchema.Columns.ExceptionMessage}`,
+                 `{CommandDeadLetterSchema.Columns.OccurredAt}`,
+                 `{CommandDeadLetterSchema.Columns.AttemptCount}`,
+                 `{CommandDeadLetterSchema.Columns.Status}`)
+            VALUES
+                (@id, @commandType, @payload, @exceptionType, @exceptionMessage, @occurredAtTicks, @attemptCount, @status)
+            """;
+    }
+
+    /// <inheritdoc />
+    public async Task StoreAsync(
+        string commandType,
+        string payload,
+        Exception exception,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(commandType);
+        ArgumentException.ThrowIfNullOrWhiteSpace(payload);
+        ArgumentNullException.ThrowIfNull(exception);
+
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var command = new MySqlCommand(_insertSql, connection);
+            await using (command.ConfigureAwait(false))
+            {
+                _ = command.Parameters.AddWithValue("@id", Guid.NewGuid().ToByteArray());
+                _ = command.Parameters.AddWithValue("@commandType", commandType);
+                _ = command.Parameters.AddWithValue("@payload", payload);
+                _ = command.Parameters.AddWithValue("@exceptionType", exception.GetType().AssemblyQualifiedName);
+                _ = command.Parameters.AddWithValue("@exceptionMessage", exception.Message);
+                _ = command.Parameters.AddWithValue("@occurredAtTicks", DateTimeOffset.UtcNow.UtcTicks);
+                _ = command.Parameters.AddWithValue("@attemptCount", 1);
+                _ = command.Parameters.AddWithValue("@status", (int)CommandDeadLetterStatus.New);
+
+                _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Opens and returns a new <see cref="MySqlConnection"/> using the stored connection string.
+    /// The caller is responsible for disposing the connection.
+    /// </summary>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>An open <see cref="MySqlConnection"/>.</returns>
+    private async Task<MySqlConnection> CreateConnectionAsync(CancellationToken cancellationToken)
+    {
+        var connection = new MySqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        return connection;
+    }
+}

--- a/src/NetEvolve.Pulse.MySql/MySqlCommandDeadLetterMediatorBuilderExtensions.cs
+++ b/src/NetEvolve.Pulse.MySql/MySqlCommandDeadLetterMediatorBuilderExtensions.cs
@@ -1,0 +1,71 @@
+namespace NetEvolve.Pulse;
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using NetEvolve.Pulse.DeadLetter;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+
+/// <summary>
+/// Extension methods for configuring the MySQL command dead letter store on <see cref="IMediatorBuilder"/>.
+/// </summary>
+public static class MySqlCommandDeadLetterMediatorBuilderExtensions
+{
+    /// <summary>
+    /// Adds MySQL command dead letter persistence using ADO.NET.
+    /// </summary>
+    /// <param name="configurator">The mediator configurator.</param>
+    /// <param name="configureOptions">Action to configure <see cref="CommandDeadLetterOptions"/>.</param>
+    /// <returns>The configurator for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configurator"/> or <paramref name="configureOptions"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para><strong>Prerequisites:</strong></para>
+    /// Execute the schema script from <c>Scripts/CommandDeadLetter.sql</c> against the target MySQL
+    /// database to create the required table before using this provider.
+    /// <para><strong>Schema:</strong></para>
+    /// MySQL does not use schema namespaces. The <see cref="CommandDeadLetterOptions.Schema"/> property is
+    /// ignored; tables are always created in the active database from the connection string.
+    /// <para><strong>Interoperability:</strong></para>
+    /// Stores <see cref="DateTimeOffset"/> values as <c>BIGINT</c> (UTC ticks), matching
+    /// the Entity Framework MySQL provider schema.
+    /// <para><strong>Registered Services:</strong></para>
+    /// <list type="bullet">
+    /// <item><description><see cref="ICommandDeadLetterStore"/> as <see cref="MySqlCommandDeadLetterStore"/> (Scoped)</description></item>
+    /// <item><description><see cref="ICommandDeadLetterManagement"/> as <see cref="MySqlCommandDeadLetterManagement"/> (Scoped)</description></item>
+    /// </list>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// services.AddPulse(config => config
+    ///     .AddMySqlCommandDeadLetterStore(opts =>
+    ///     {
+    ///         opts.ConnectionString = "Server=localhost;Database=mydb;User Id=root;Password=secret;";
+    ///     })
+    /// );
+    /// </code>
+    /// </example>
+    public static IMediatorBuilder AddMySqlCommandDeadLetterStore(
+        this IMediatorBuilder configurator,
+        Action<CommandDeadLetterOptions> configureOptions
+    )
+    {
+        ArgumentNullException.ThrowIfNull(configurator);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+
+        _ = configurator.Services.Configure(configureOptions);
+
+        return configurator.RegisterMySqlCommandDeadLetterServices();
+    }
+
+    private static IMediatorBuilder RegisterMySqlCommandDeadLetterServices(this IMediatorBuilder configurator)
+    {
+        _ = configurator
+            .Services.RemoveAll<ICommandDeadLetterStore>()
+            .AddScoped<ICommandDeadLetterStore, MySqlCommandDeadLetterStore>()
+            .RemoveAll<ICommandDeadLetterManagement>()
+            .AddScoped<ICommandDeadLetterManagement, MySqlCommandDeadLetterManagement>();
+
+        return configurator;
+    }
+}

--- a/src/NetEvolve.Pulse.MySql/Scripts/CommandDeadLetter.sql
+++ b/src/NetEvolve.Pulse.MySql/Scripts/CommandDeadLetter.sql
@@ -1,0 +1,54 @@
+-- ============================================================================
+-- CommandDeadLetter Table Schema (MySQL)
+-- ============================================================================
+--
+-- Purpose:   Stores commands that failed processing so operators can inspect,
+--            replay, or dismiss them later.
+-- Provider:  NetEvolve.Pulse.MySql (ADO.NET)
+--            NetEvolve.Pulse.EntityFramework with MySql.EntityFrameworkCore
+--
+-- Prerequisites:
+--   MySQL 8.0 or later
+--
+-- Column types:
+--   Id               BINARY(16)    -- Guid.ToByteArray(), primary key
+--   CommandType      VARCHAR(500)  -- assembly-qualified type name of the failed command
+--   Payload          LONGTEXT      -- JSON serialized command payload
+--   ExceptionType    VARCHAR(500)  -- assembly-qualified type name of the exception (nullable)
+--   ExceptionMessage LONGTEXT      -- message of the exception (nullable)
+--   OccurredAt       BIGINT        -- UTC ticks (use dto.UtcTicks / new DateTimeOffset(ticks, TimeSpan.Zero))
+--   AttemptCount     INT           -- number of processing attempts, default 1
+--   Status           TINYINT       -- CommandDeadLetterStatus enum value, default 0 (New)
+--
+-- Usage:
+--   Run this script in the target MySQL database once before deploying the application:
+--     mysql -u <user> -p <database> < CommandDeadLetter.sql
+--
+--   If you need a custom table name, replace all occurrences of `CommandDeadLetter`
+--   and update CommandDeadLetterOptions.TableName in your application configuration accordingly.
+--
+-- Note on schema:
+--   MySQL does not use schema namespaces in the same way as SQL Server or PostgreSQL.
+--   Tables are created in whichever database is active when this script runs.
+--   Pass the desired database in the connection string (Database=<dbname>).
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS `CommandDeadLetter` (
+    `Id`               BINARY(16)   NOT NULL,
+    `CommandType`      VARCHAR(500) NOT NULL,
+    `Payload`          LONGTEXT     NOT NULL,
+    `ExceptionType`    VARCHAR(500)     NULL,
+    `ExceptionMessage` LONGTEXT         NULL,
+    `OccurredAt`       BIGINT       NOT NULL,
+    `AttemptCount`     INT          NOT NULL DEFAULT 1,
+    `Status`           TINYINT      NOT NULL DEFAULT 0,
+    CONSTRAINT `PK_CommandDeadLetter` PRIMARY KEY (`Id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Index to efficiently filter entries by status (for GetPendingAsync filtering)
+CREATE INDEX `IX_CommandDeadLetter_Status`
+    ON `CommandDeadLetter` (`Status`);
+
+-- Index to efficiently order entries by occurrence time
+CREATE INDEX `IX_CommandDeadLetter_OccurredAt`
+    ON `CommandDeadLetter` (`OccurredAt`);

--- a/src/NetEvolve.Pulse.PostgreSql/DeadLetter/PostgreSqlCommandDeadLetterManagement.cs
+++ b/src/NetEvolve.Pulse.PostgreSql/DeadLetter/PostgreSqlCommandDeadLetterManagement.cs
@@ -1,0 +1,330 @@
+namespace NetEvolve.Pulse.DeadLetter;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+using NetEvolve.Pulse.Extensibility.Outbox;
+using Npgsql;
+
+/// <summary>
+/// PostgreSQL implementation of <see cref="ICommandDeadLetterManagement"/> using ADO.NET.
+/// Provides dead-letter inspection, replay, dismissal, and statistics queries for PostgreSQL.
+/// </summary>
+/// <remarks>
+/// <para><strong>Prerequisites:</strong></para>
+/// Execute the schema script from <c>Scripts/CommandDeadLetter.sql</c> to create the required
+/// database objects before using this provider.
+/// </remarks>
+[SuppressMessage(
+    "Reliability",
+    "CA2007:Consider calling ConfigureAwait on the awaited task",
+    Justification = "await using statements in library code; ConfigureAwait applied to all Task-returning awaits."
+)]
+[SuppressMessage(
+    "Security",
+    "CA2100:Review SQL queries for security vulnerabilities",
+    Justification = "The table name is constructed from validated CommandDeadLetterOptions.Schema/TableName properties, not user input."
+)]
+internal sealed class PostgreSqlCommandDeadLetterManagement : ICommandDeadLetterManagement
+{
+    /// <summary>The PostgreSQL connection string used to open new connections for each operation.</summary>
+    private readonly string _connectionString;
+
+    /// <summary>The mediator used to dispatch replayed commands.</summary>
+    private readonly IMediatorSendOnly _mediator;
+
+    /// <summary>The serializer used to deserialize stored payloads for replay.</summary>
+    private readonly IPayloadSerializer _payloadSerializer;
+
+    /// <summary>Cached SQL for selecting pending dead letter entries.</summary>
+    private readonly string _getPendingSql;
+
+    /// <summary>Cached SQL for selecting a single dead letter entry by identifier.</summary>
+    private readonly string _getByIdSql;
+
+    /// <summary>Cached SQL for updating the status of a dead letter entry.</summary>
+    private readonly string _updateStatusSql;
+
+    /// <summary>Cached SQL for aggregating entry counts per status.</summary>
+    private readonly string _getStatisticsSql;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PostgreSqlCommandDeadLetterManagement"/> class.
+    /// </summary>
+    /// <param name="options">The command dead letter configuration options.</param>
+    /// <param name="mediator">The mediator used to dispatch replayed commands.</param>
+    /// <param name="payloadSerializer">The serializer used to deserialize stored payloads for replay.</param>
+    public PostgreSqlCommandDeadLetterManagement(
+        IOptions<CommandDeadLetterOptions> options,
+        IMediatorSendOnly mediator,
+        IPayloadSerializer payloadSerializer
+    )
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrWhiteSpace(options.Value.ConnectionString);
+        ArgumentNullException.ThrowIfNull(mediator);
+        ArgumentNullException.ThrowIfNull(payloadSerializer);
+
+        _connectionString = options.Value.ConnectionString;
+        _mediator = mediator;
+        _payloadSerializer = payloadSerializer;
+
+        var schema = string.IsNullOrWhiteSpace(options.Value.Schema)
+            ? CommandDeadLetterSchema.DefaultSchema
+            : options.Value.Schema;
+        SqlIdentifier.Validate(schema, nameof(options.Value.Schema));
+
+        var tableName = string.IsNullOrWhiteSpace(options.Value.TableName)
+            ? CommandDeadLetterSchema.DefaultTableName
+            : options.Value.TableName;
+        SqlIdentifier.Validate(tableName, nameof(options.Value.TableName));
+
+        var qualifiedTableName = $"\"{schema}\".\"{tableName}\"";
+
+        var columns =
+            $"\"{CommandDeadLetterSchema.Columns.Id}\", \"{CommandDeadLetterSchema.Columns.CommandType}\", "
+            + $"\"{CommandDeadLetterSchema.Columns.Payload}\", \"{CommandDeadLetterSchema.Columns.ExceptionType}\", "
+            + $"\"{CommandDeadLetterSchema.Columns.ExceptionMessage}\", \"{CommandDeadLetterSchema.Columns.OccurredAt}\", "
+            + $"\"{CommandDeadLetterSchema.Columns.AttemptCount}\", \"{CommandDeadLetterSchema.Columns.Status}\"";
+
+        _getPendingSql = $"""
+            SELECT {columns}
+            FROM {qualifiedTableName}
+            WHERE "{CommandDeadLetterSchema.Columns.Status}" = @status
+            ORDER BY "{CommandDeadLetterSchema.Columns.OccurredAt}" ASC
+            LIMIT @count
+            """;
+
+        _getByIdSql = $"""
+            SELECT {columns}
+            FROM {qualifiedTableName}
+            WHERE "{CommandDeadLetterSchema.Columns.Id}" = @id
+            """;
+
+        _updateStatusSql = $"""
+            UPDATE {qualifiedTableName}
+            SET "{CommandDeadLetterSchema.Columns.Status}" = @status
+            WHERE "{CommandDeadLetterSchema.Columns.Id}" = @id
+            """;
+
+        _getStatisticsSql = $"""
+            SELECT "{CommandDeadLetterSchema.Columns.Status}", COUNT(*)
+            FROM {qualifiedTableName}
+            GROUP BY "{CommandDeadLetterSchema.Columns.Status}"
+            """;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<CommandDeadLetterEntry>> GetPendingAsync(
+        int count = 50,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var command = new NpgsqlCommand(_getPendingSql, connection);
+            await using (command.ConfigureAwait(false))
+            {
+                _ = command.Parameters.AddWithValue("status", (short)CommandDeadLetterStatus.New);
+                _ = command.Parameters.AddWithValue("count", count);
+
+                var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                await using (reader.ConfigureAwait(false))
+                {
+                    var entries = new List<CommandDeadLetterEntry>();
+                    while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                    {
+                        entries.Add(MapToEntry(reader));
+                    }
+
+                    return entries;
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task ReplayAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var entry =
+                await GetByIdAsync(connection, id, cancellationToken).ConfigureAwait(false)
+                ?? throw new KeyNotFoundException($"CommandDeadLetterEntry '{id}' was not found.");
+
+            await UpdateStatusAsync(connection, id, CommandDeadLetterStatus.Replaying, cancellationToken)
+                .ConfigureAwait(false);
+
+            await CommandDeadLetterReplayDispatcher
+                .ReplayAsync(_mediator, _payloadSerializer, entry.CommandType, entry.Payload, cancellationToken)
+                .ConfigureAwait(false);
+
+            await UpdateStatusAsync(connection, id, CommandDeadLetterStatus.Resolved, cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task DismissAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var command = new NpgsqlCommand(_updateStatusSql, connection);
+            await using (command.ConfigureAwait(false))
+            {
+                _ = command.Parameters.AddWithValue("status", (short)CommandDeadLetterStatus.Dismissed);
+                _ = command.Parameters.AddWithValue("id", id);
+
+                var affected = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+                if (affected == 0)
+                {
+                    throw new KeyNotFoundException($"CommandDeadLetterEntry '{id}' was not found.");
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<CommandDeadLetterStatistics> GetStatisticsAsync(CancellationToken cancellationToken = default)
+    {
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var command = new NpgsqlCommand(_getStatisticsSql, connection);
+            await using (command.ConfigureAwait(false))
+            {
+                var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                await using (reader.ConfigureAwait(false))
+                {
+                    var newCount = 0;
+                    var replayingCount = 0;
+                    var resolvedCount = 0;
+                    var dismissedCount = 0;
+
+                    while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                    {
+                        var status = (CommandDeadLetterStatus)reader.GetInt16(0);
+                        var groupCount = Convert.ToInt32(
+                            reader.GetInt64(1),
+                            System.Globalization.CultureInfo.InvariantCulture
+                        );
+
+                        switch (status)
+                        {
+                            case CommandDeadLetterStatus.New:
+                                newCount = groupCount;
+                                break;
+                            case CommandDeadLetterStatus.Replaying:
+                                replayingCount = groupCount;
+                                break;
+                            case CommandDeadLetterStatus.Resolved:
+                                resolvedCount = groupCount;
+                                break;
+                            case CommandDeadLetterStatus.Dismissed:
+                                dismissedCount = groupCount;
+                                break;
+                        }
+                    }
+
+                    return new CommandDeadLetterStatistics(newCount, replayingCount, resolvedCount, dismissedCount);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Opens and returns a new <see cref="NpgsqlConnection"/> using the stored connection string.
+    /// The caller is responsible for disposing the connection.
+    /// </summary>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>An open <see cref="NpgsqlConnection"/>.</returns>
+    private async Task<NpgsqlConnection> CreateConnectionAsync(CancellationToken cancellationToken)
+    {
+        var connection = new NpgsqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        return connection;
+    }
+
+    /// <summary>
+    /// Retrieves the dead letter entry identified by <paramref name="id"/>, or <see langword="null"/>
+    /// when no such entry exists.
+    /// </summary>
+    private async Task<CommandDeadLetterEntry?> GetByIdAsync(
+        NpgsqlConnection connection,
+        Guid id,
+        CancellationToken cancellationToken
+    )
+    {
+        var command = new NpgsqlCommand(_getByIdSql, connection);
+        await using (command.ConfigureAwait(false))
+        {
+            _ = command.Parameters.AddWithValue("id", id);
+
+            var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            await using (reader.ConfigureAwait(false))
+            {
+                if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    return null;
+                }
+
+                return MapToEntry(reader);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Updates the status of the dead letter entry identified by <paramref name="id"/>.
+    /// </summary>
+    private async Task UpdateStatusAsync(
+        NpgsqlConnection connection,
+        Guid id,
+        CommandDeadLetterStatus status,
+        CancellationToken cancellationToken
+    )
+    {
+        var command = new NpgsqlCommand(_updateStatusSql, connection);
+        await using (command.ConfigureAwait(false))
+        {
+            _ = command.Parameters.AddWithValue("status", (short)status);
+            _ = command.Parameters.AddWithValue("id", id);
+
+            _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Maps the current row of a <see cref="NpgsqlDataReader"/> to a new <see cref="CommandDeadLetterEntry"/> instance.
+    /// </summary>
+    private static CommandDeadLetterEntry MapToEntry(NpgsqlDataReader reader)
+    {
+        var ordId = reader.GetOrdinal(CommandDeadLetterSchema.Columns.Id);
+        var ordCommandType = reader.GetOrdinal(CommandDeadLetterSchema.Columns.CommandType);
+        var ordPayload = reader.GetOrdinal(CommandDeadLetterSchema.Columns.Payload);
+        var ordExceptionType = reader.GetOrdinal(CommandDeadLetterSchema.Columns.ExceptionType);
+        var ordExceptionMessage = reader.GetOrdinal(CommandDeadLetterSchema.Columns.ExceptionMessage);
+        var ordOccurredAt = reader.GetOrdinal(CommandDeadLetterSchema.Columns.OccurredAt);
+        var ordAttemptCount = reader.GetOrdinal(CommandDeadLetterSchema.Columns.AttemptCount);
+        var ordStatus = reader.GetOrdinal(CommandDeadLetterSchema.Columns.Status);
+
+        return new CommandDeadLetterEntry
+        {
+            Id = reader.GetGuid(ordId),
+            CommandType = reader.GetString(ordCommandType),
+            Payload = reader.GetString(ordPayload),
+            ExceptionType = reader.IsDBNull(ordExceptionType) ? null : reader.GetString(ordExceptionType),
+            ExceptionMessage = reader.IsDBNull(ordExceptionMessage) ? null : reader.GetString(ordExceptionMessage),
+            OccurredAt = reader.GetFieldValue<DateTimeOffset>(ordOccurredAt),
+            AttemptCount = reader.GetInt32(ordAttemptCount),
+            Status = (CommandDeadLetterStatus)reader.GetInt16(ordStatus),
+        };
+    }
+}

--- a/src/NetEvolve.Pulse.PostgreSql/DeadLetter/PostgreSqlCommandDeadLetterStore.cs
+++ b/src/NetEvolve.Pulse.PostgreSql/DeadLetter/PostgreSqlCommandDeadLetterStore.cs
@@ -1,0 +1,138 @@
+namespace NetEvolve.Pulse.DeadLetter;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+using NetEvolve.Pulse.Extensibility.Outbox;
+using Npgsql;
+
+/// <summary>
+/// PostgreSQL implementation of <see cref="ICommandDeadLetterStore"/> using ADO.NET.
+/// Provides command dead letter persistence optimized for PostgreSQL.
+/// </summary>
+/// <remarks>
+/// <para><strong>Prerequisites:</strong></para>
+/// Execute the schema script from <c>Scripts/CommandDeadLetter.sql</c> to create the required
+/// database objects before using this provider.
+/// <para><strong>Duplicate Key Handling:</strong></para>
+/// Catches unique-constraint violations on the primary key insert and silently ignores them,
+/// matching the idempotent-store semantics used elsewhere in this provider.
+/// </remarks>
+[SuppressMessage(
+    "Reliability",
+    "CA2007:Consider calling ConfigureAwait on the awaited task",
+    Justification = "await using statements in library code; ConfigureAwait applied to all Task-returning awaits."
+)]
+[SuppressMessage(
+    "Security",
+    "CA2100:Review SQL queries for security vulnerabilities",
+    Justification = "The table name is constructed from validated CommandDeadLetterOptions.Schema/TableName properties, not user input."
+)]
+internal sealed class PostgreSqlCommandDeadLetterStore : ICommandDeadLetterStore
+{
+    /// <summary>The PostgreSQL connection string used to open new connections for each operation.</summary>
+    private readonly string _connectionString;
+
+    /// <summary>Cached SQL for inserting a command dead letter entry.</summary>
+    private readonly string _insertSql;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PostgreSqlCommandDeadLetterStore"/> class.
+    /// </summary>
+    /// <param name="options">The command dead letter configuration options.</param>
+    public PostgreSqlCommandDeadLetterStore(IOptions<CommandDeadLetterOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrWhiteSpace(options.Value.ConnectionString);
+
+        _connectionString = options.Value.ConnectionString;
+
+        var schema = string.IsNullOrWhiteSpace(options.Value.Schema)
+            ? CommandDeadLetterSchema.DefaultSchema
+            : options.Value.Schema;
+        SqlIdentifier.Validate(schema, nameof(options.Value.Schema));
+
+        var tableName = string.IsNullOrWhiteSpace(options.Value.TableName)
+            ? CommandDeadLetterSchema.DefaultTableName
+            : options.Value.TableName;
+        SqlIdentifier.Validate(tableName, nameof(options.Value.TableName));
+
+        var qualifiedTableName = $"\"{schema}\".\"{tableName}\"";
+
+        _insertSql = $"""
+            INSERT INTO {qualifiedTableName}
+                ("{CommandDeadLetterSchema.Columns.Id}", "{CommandDeadLetterSchema.Columns.CommandType}", "{CommandDeadLetterSchema.Columns.Payload}", "{CommandDeadLetterSchema.Columns.ExceptionType}", "{CommandDeadLetterSchema.Columns.ExceptionMessage}", "{CommandDeadLetterSchema.Columns.OccurredAt}", "{CommandDeadLetterSchema.Columns.AttemptCount}", "{CommandDeadLetterSchema.Columns.Status}")
+            VALUES
+                (@id, @command_type, @payload, @exception_type, @exception_message, @occurred_at, @attempt_count, @status)
+            """;
+    }
+
+    /// <inheritdoc />
+    public async Task StoreAsync(
+        string commandType,
+        string payload,
+        Exception exception,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(commandType);
+        ArgumentException.ThrowIfNullOrWhiteSpace(payload);
+        ArgumentNullException.ThrowIfNull(exception);
+
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var command = new NpgsqlCommand(_insertSql, connection);
+            await using (command.ConfigureAwait(false))
+            {
+                _ = command.Parameters.AddWithValue("id", Guid.NewGuid());
+                _ = command.Parameters.AddWithValue("command_type", commandType);
+                _ = command.Parameters.AddWithValue("payload", payload);
+                _ = command.Parameters.AddWithValue(
+                    "exception_type",
+                    (object?)exception.GetType().AssemblyQualifiedName ?? DBNull.Value
+                );
+                _ = command.Parameters.AddWithValue("exception_message", (object?)exception.Message ?? DBNull.Value);
+                _ = command.Parameters.AddWithValue("occurred_at", DateTimeOffset.UtcNow);
+                _ = command.Parameters.AddWithValue("attempt_count", 1);
+                _ = command.Parameters.AddWithValue("status", (short)CommandDeadLetterStatus.New);
+
+                try
+                {
+                    _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+                }
+                catch (PostgresException ex) when (IsDuplicateKeyException(ex))
+                {
+                    // A concurrent request already stored an entry with the same identifier — this is
+                    // extremely unlikely given a freshly generated Guid, but is handled defensively.
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Opens and returns a new <see cref="NpgsqlConnection"/> using the stored connection string.
+    /// The caller is responsible for disposing the connection.
+    /// </summary>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>An open <see cref="NpgsqlConnection"/>.</returns>
+    private async Task<NpgsqlConnection> CreateConnectionAsync(CancellationToken cancellationToken)
+    {
+        var connection = new NpgsqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        return connection;
+    }
+
+    /// <summary>
+    /// Determines whether the given exception was caused by a unique-constraint violation
+    /// (i.e., a duplicate key insert).
+    /// </summary>
+    /// <remarks>
+    /// PostgreSQL SQLSTATE <c>23505</c> indicates a unique-constraint violation.
+    /// </remarks>
+    private static bool IsDuplicateKeyException(PostgresException ex) =>
+        ex.SqlState == PostgresErrorCodes.UniqueViolation;
+}

--- a/src/NetEvolve.Pulse.PostgreSql/PostgreSqlCommandDeadLetterMediatorBuilderExtensions.cs
+++ b/src/NetEvolve.Pulse.PostgreSql/PostgreSqlCommandDeadLetterMediatorBuilderExtensions.cs
@@ -1,0 +1,70 @@
+namespace NetEvolve.Pulse;
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using NetEvolve.Pulse.DeadLetter;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+
+/// <summary>
+/// Extension methods for configuring PostgreSQL command dead letter persistence on <see cref="IMediatorBuilder"/>.
+/// </summary>
+public static class PostgreSqlCommandDeadLetterMediatorBuilderExtensions
+{
+    /// <summary>
+    /// Adds PostgreSQL command dead letter persistence using ADO.NET.
+    /// </summary>
+    /// <param name="configurator">The mediator configurator.</param>
+    /// <param name="configureOptions">Action to configure <see cref="CommandDeadLetterOptions"/>.</param>
+    /// <returns>The configurator for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configurator"/> or <paramref name="configureOptions"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para><strong>Prerequisites:</strong></para>
+    /// Execute the schema script from <c>Scripts/CommandDeadLetter.sql</c> to create the required
+    /// database objects before using this provider.
+    /// <para><strong>Registered Services:</strong></para>
+    /// <list type="bullet">
+    /// <item><description><see cref="ICommandDeadLetterStore"/> as <see cref="PostgreSqlCommandDeadLetterStore"/> (Scoped)</description></item>
+    /// <item><description><see cref="ICommandDeadLetterManagement"/> as <see cref="PostgreSqlCommandDeadLetterManagement"/> (Scoped)</description></item>
+    /// </list>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// services.AddPulse(config => config
+    ///     .AddPostgreSqlCommandDeadLetterStore(opts =>
+    ///     {
+    ///         opts.ConnectionString = "Host=localhost;Database=MyDb;Username=postgres;Password=secret;";
+    ///         opts.Schema = "myschema";
+    ///     })
+    /// );
+    /// </code>
+    /// </example>
+    public static IMediatorBuilder AddPostgreSqlCommandDeadLetterStore(
+        this IMediatorBuilder configurator,
+        Action<CommandDeadLetterOptions> configureOptions
+    )
+    {
+        ArgumentNullException.ThrowIfNull(configurator);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+
+        _ = configurator.Services.Configure(configureOptions);
+
+        return configurator.RegisterPostgreSqlCommandDeadLetterStore();
+    }
+
+    private static IMediatorBuilder RegisterPostgreSqlCommandDeadLetterStore(this IMediatorBuilder configurator)
+    {
+        var services = configurator.Services;
+
+        _ = services
+            .RemoveAll<ICommandDeadLetterStore>()
+            .AddScoped<ICommandDeadLetterStore, PostgreSqlCommandDeadLetterStore>();
+
+        _ = services
+            .RemoveAll<ICommandDeadLetterManagement>()
+            .AddScoped<ICommandDeadLetterManagement, PostgreSqlCommandDeadLetterManagement>();
+
+        return configurator;
+    }
+}

--- a/src/NetEvolve.Pulse.PostgreSql/Scripts/CommandDeadLetter.sql
+++ b/src/NetEvolve.Pulse.PostgreSql/Scripts/CommandDeadLetter.sql
@@ -1,0 +1,44 @@
+-- ============================================================================
+-- CommandDeadLetter Table Schema (PostgreSQL)
+-- ============================================================================
+-- Purpose: Stores commands that failed processing for later inspection, replay,
+--          or dismissal.
+-- Compatible with: NetEvolve.Pulse.PostgreSql (ADO.NET)
+--
+-- Configuration:
+--   Adjust schema_name and table_name variables below before executing.
+--   Run this script using psql or any PostgreSQL-compatible client.
+--
+-- Usage:
+--   psql -h your-host -d your-database -f CommandDeadLetter.sql
+-- ============================================================================
+
+-- ============================================================================
+-- Configuration
+-- ============================================================================
+\set schema_name 'pulse'
+\set table_name 'CommandDeadLetter'
+
+-- Create schema if it doesn't exist
+CREATE SCHEMA IF NOT EXISTS :schema_name;
+
+-- Create table if it doesn't exist
+CREATE TABLE IF NOT EXISTS ":schema_name".":table_name" (
+    "Id"               UUID                      NOT NULL,
+    "CommandType"      VARCHAR(500)              NOT NULL,
+    "Payload"          TEXT                      NOT NULL,
+    "ExceptionType"    VARCHAR(500)              NULL,
+    "ExceptionMessage" TEXT                      NULL,
+    "OccurredAt"       TIMESTAMP WITH TIME ZONE  NOT NULL,
+    "AttemptCount"     INTEGER                   NOT NULL DEFAULT 1,
+    "Status"           SMALLINT                  NOT NULL DEFAULT 0,
+    CONSTRAINT "PK_:schema_name_:table_name" PRIMARY KEY ("Id")
+);
+
+-- Index for efficient filtering of pending (Status = 0) entries
+CREATE INDEX IF NOT EXISTS "IX_:schema_name_:table_name_Status"
+ON ":schema_name".":table_name" ("Status");
+
+-- Index for ordering entries by occurrence time
+CREATE INDEX IF NOT EXISTS "IX_:schema_name_:table_name_OccurredAt"
+ON ":schema_name".":table_name" ("OccurredAt");

--- a/src/NetEvolve.Pulse.SQLite/DeadLetter/SQLiteCommandDeadLetterManagement.cs
+++ b/src/NetEvolve.Pulse.SQLite/DeadLetter/SQLiteCommandDeadLetterManagement.cs
@@ -1,0 +1,367 @@
+namespace NetEvolve.Pulse.DeadLetter;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+using NetEvolve.Pulse.Extensibility.Outbox;
+
+/// <summary>
+/// SQLite implementation of <see cref="ICommandDeadLetterManagement"/> using ADO.NET.
+/// Provides dead letter inspection, replay, dismissal, and statistics queries.
+/// </summary>
+/// <remarks>
+/// <para><strong>Prerequisites:</strong></para>
+/// Execute the schema script from <c>Scripts/003_CreateCommandDeadLetterTable.sql</c> to create the
+/// required database objects before using this provider.
+/// <para><strong>Replay:</strong></para>
+/// Uses the shared <see cref="CommandDeadLetterReplayDispatcher"/> to resolve the command type and
+/// dispatch it via <see cref="IMediatorSendOnly"/>.
+/// </remarks>
+[SuppressMessage(
+    "Reliability",
+    "CA2007:Consider calling ConfigureAwait on the awaited task",
+    Justification = "await using statements in library code; ConfigureAwait applied to all Task-returning awaits."
+)]
+[SuppressMessage(
+    "Security",
+    "CA2100:Review SQL queries for security vulnerabilities",
+    Justification = "SQL is constructed from validated CommandDeadLetterOptions.TableName property, not user input."
+)]
+internal sealed class SQLiteCommandDeadLetterManagement : ICommandDeadLetterManagement
+{
+    /// <summary>The SQLite connection string resolved from <see cref="CommandDeadLetterOptions"/>.</summary>
+    private readonly string _connectionString;
+
+    /// <summary>Whether to apply WAL journal mode to the database.</summary>
+    private readonly bool _enableWalMode;
+
+    /// <summary>Tracks whether the persistent WAL journal mode has already been applied to the database.</summary>
+    private int _walModeApplied;
+
+    /// <summary>The mediator used to dispatch replayed commands.</summary>
+    private readonly IMediatorSendOnly _mediator;
+
+    /// <summary>The serializer used to deserialize stored payloads for replay.</summary>
+    private readonly IPayloadSerializer _payloadSerializer;
+
+    // Cached SQL statements
+    private readonly string _getPendingSql;
+    private readonly string _getByIdSql;
+    private readonly string _setReplayingSql;
+    private readonly string _setResolvedSql;
+    private readonly string _dismissSql;
+    private readonly string _getStatisticsSql;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SQLiteCommandDeadLetterManagement"/> class.
+    /// </summary>
+    /// <param name="options">The command dead letter configuration options.</param>
+    /// <param name="mediator">The mediator used to dispatch replayed commands.</param>
+    /// <param name="payloadSerializer">The serializer used to deserialize stored payloads for replay.</param>
+    public SQLiteCommandDeadLetterManagement(
+        IOptions<CommandDeadLetterOptions> options,
+        IMediatorSendOnly mediator,
+        IPayloadSerializer payloadSerializer
+    )
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(mediator);
+        ArgumentNullException.ThrowIfNull(payloadSerializer);
+        ArgumentException.ThrowIfNullOrWhiteSpace(options.Value.ConnectionString);
+
+        var opts = options.Value;
+        _connectionString = opts.ConnectionString;
+        _enableWalMode = opts.EnableWalMode;
+        _mediator = mediator;
+        _payloadSerializer = payloadSerializer;
+
+        SqlIdentifier.Validate(opts.TableName, nameof(opts.TableName));
+        var table = $"\"{opts.TableName}\"";
+
+        _getPendingSql = $"""
+            SELECT
+                "{CommandDeadLetterSchema.Columns.Id}",
+                "{CommandDeadLetterSchema.Columns.CommandType}",
+                "{CommandDeadLetterSchema.Columns.Payload}",
+                "{CommandDeadLetterSchema.Columns.ExceptionType}",
+                "{CommandDeadLetterSchema.Columns.ExceptionMessage}",
+                "{CommandDeadLetterSchema.Columns.OccurredAt}",
+                "{CommandDeadLetterSchema.Columns.AttemptCount}",
+                "{CommandDeadLetterSchema.Columns.Status}"
+            FROM {table}
+            WHERE "{CommandDeadLetterSchema.Columns.Status}" = 0
+            ORDER BY "{CommandDeadLetterSchema.Columns.OccurredAt}" ASC
+            LIMIT @count;
+            """;
+
+        _getByIdSql = $"""
+            SELECT
+                "{CommandDeadLetterSchema.Columns.Id}",
+                "{CommandDeadLetterSchema.Columns.CommandType}",
+                "{CommandDeadLetterSchema.Columns.Payload}",
+                "{CommandDeadLetterSchema.Columns.ExceptionType}",
+                "{CommandDeadLetterSchema.Columns.ExceptionMessage}",
+                "{CommandDeadLetterSchema.Columns.OccurredAt}",
+                "{CommandDeadLetterSchema.Columns.AttemptCount}",
+                "{CommandDeadLetterSchema.Columns.Status}"
+            FROM {table}
+            WHERE "{CommandDeadLetterSchema.Columns.Id}" = @id;
+            """;
+
+        _setReplayingSql = $"""
+            UPDATE {table}
+            SET "{CommandDeadLetterSchema.Columns.Status}" = 1
+            WHERE "{CommandDeadLetterSchema.Columns.Id}" = @id;
+            """;
+
+        _setResolvedSql = $"""
+            UPDATE {table}
+            SET "{CommandDeadLetterSchema.Columns.Status}" = 2
+            WHERE "{CommandDeadLetterSchema.Columns.Id}" = @id;
+            """;
+
+        _dismissSql = $"""
+            UPDATE {table}
+            SET "{CommandDeadLetterSchema.Columns.Status}" = 3
+            WHERE "{CommandDeadLetterSchema.Columns.Id}" = @id;
+            """;
+
+        _getStatisticsSql = $"""
+            SELECT "{CommandDeadLetterSchema.Columns.Status}", COUNT(*)
+            FROM {table}
+            GROUP BY "{CommandDeadLetterSchema.Columns.Status}";
+            """;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<CommandDeadLetterEntry>> GetPendingAsync(
+        int count = 50,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var command = new SqliteCommand(_getPendingSql, connection);
+            await using (command.ConfigureAwait(false))
+            {
+                _ = command.Parameters.AddWithValue("@count", count);
+
+                return await ReadEntriesAsync(command, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task ReplayAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var entry =
+                await GetByIdAsync(connection, id, cancellationToken).ConfigureAwait(false)
+                ?? throw new KeyNotFoundException($"CommandDeadLetterEntry '{id}' was not found.");
+
+            var replayingCommand = new SqliteCommand(_setReplayingSql, connection);
+            await using (replayingCommand.ConfigureAwait(false))
+            {
+                _ = replayingCommand.Parameters.AddWithValue("@id", id.ToString());
+                _ = await replayingCommand.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            await CommandDeadLetterReplayDispatcher
+                .ReplayAsync(_mediator, _payloadSerializer, entry.CommandType, entry.Payload, cancellationToken)
+                .ConfigureAwait(false);
+
+            var resolvedCommand = new SqliteCommand(_setResolvedSql, connection);
+            await using (resolvedCommand.ConfigureAwait(false))
+            {
+                _ = resolvedCommand.Parameters.AddWithValue("@id", id.ToString());
+                _ = await resolvedCommand.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task DismissAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var command = new SqliteCommand(_dismissSql, connection);
+            await using (command.ConfigureAwait(false))
+            {
+                _ = command.Parameters.AddWithValue("@id", id.ToString());
+
+                var updated = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+                if (updated == 0)
+                {
+                    throw new KeyNotFoundException($"CommandDeadLetterEntry '{id}' was not found.");
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<CommandDeadLetterStatistics> GetStatisticsAsync(CancellationToken cancellationToken = default)
+    {
+        var newCount = 0;
+        var replayingCount = 0;
+        var resolvedCount = 0;
+        var dismissedCount = 0;
+
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var command = new SqliteCommand(_getStatisticsSql, connection);
+            await using (command.ConfigureAwait(false))
+            {
+                var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                await using (reader.ConfigureAwait(false))
+                {
+                    while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                    {
+                        var status = (CommandDeadLetterStatus)reader.GetInt64(0);
+                        var count = (int)reader.GetInt64(1);
+
+                        switch (status)
+                        {
+                            case CommandDeadLetterStatus.New:
+                                newCount = count;
+                                break;
+                            case CommandDeadLetterStatus.Replaying:
+                                replayingCount = count;
+                                break;
+                            case CommandDeadLetterStatus.Resolved:
+                                resolvedCount = count;
+                                break;
+                            case CommandDeadLetterStatus.Dismissed:
+                                dismissedCount = count;
+                                break;
+                        }
+                    }
+                }
+            }
+        }
+
+        return new CommandDeadLetterStatistics(newCount, replayingCount, resolvedCount, dismissedCount);
+    }
+
+    /// <summary>
+    /// Retrieves a single <see cref="CommandDeadLetterEntry"/> by its identifier on the given connection.
+    /// </summary>
+    /// <param name="connection">The open <see cref="SqliteConnection"/> to use.</param>
+    /// <param name="id">The identifier of the entry to retrieve.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>The matching <see cref="CommandDeadLetterEntry"/>, or <see langword="null"/> if not found.</returns>
+    private async Task<CommandDeadLetterEntry?> GetByIdAsync(
+        SqliteConnection connection,
+        Guid id,
+        CancellationToken cancellationToken
+    )
+    {
+        var command = new SqliteCommand(_getByIdSql, connection);
+        await using (command.ConfigureAwait(false))
+        {
+            _ = command.Parameters.AddWithValue("@id", id.ToString());
+
+            var entries = await ReadEntriesAsync(command, cancellationToken).ConfigureAwait(false);
+            return entries.Count > 0 ? entries[0] : null;
+        }
+    }
+
+    /// <summary>
+    /// Opens and returns a new <see cref="SqliteConnection"/> using the stored connection string.
+    /// Applies WAL mode once per instance when <see cref="CommandDeadLetterOptions.EnableWalMode"/> is
+    /// <see langword="true"/>; the journal mode is a persistent database property and does not need
+    /// to be re-applied on subsequent connections.
+    /// The caller is responsible for disposing the connection.
+    /// </summary>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>An open <see cref="SqliteConnection"/>.</returns>
+    private async Task<SqliteConnection> CreateConnectionAsync(CancellationToken cancellationToken)
+    {
+        var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        if (_enableWalMode && Volatile.Read(ref _walModeApplied) == 0)
+        {
+            var walCmd = new SqliteCommand("PRAGMA journal_mode=WAL;", connection);
+            await using (walCmd.ConfigureAwait(false))
+            {
+                _ = await walCmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            Volatile.Write(ref _walModeApplied, 1);
+        }
+
+        return connection;
+    }
+
+    /// <summary>
+    /// Executes <paramref name="command"/> and reads all rows into a list of <see cref="CommandDeadLetterEntry"/> instances.
+    /// </summary>
+    /// <param name="command">The <see cref="SqliteCommand"/> to execute.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A read-only list of <see cref="CommandDeadLetterEntry"/> records.</returns>
+    private static async Task<IReadOnlyList<CommandDeadLetterEntry>> ReadEntriesAsync(
+        SqliteCommand command,
+        CancellationToken cancellationToken
+    )
+    {
+        var entries = new List<CommandDeadLetterEntry>();
+
+        var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        await using (reader.ConfigureAwait(false))
+        {
+            if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                return entries;
+            }
+
+            var ordId = reader.GetOrdinal(CommandDeadLetterSchema.Columns.Id);
+            var ordCommandType = reader.GetOrdinal(CommandDeadLetterSchema.Columns.CommandType);
+            var ordPayload = reader.GetOrdinal(CommandDeadLetterSchema.Columns.Payload);
+            var ordExceptionType = reader.GetOrdinal(CommandDeadLetterSchema.Columns.ExceptionType);
+            var ordExceptionMessage = reader.GetOrdinal(CommandDeadLetterSchema.Columns.ExceptionMessage);
+            var ordOccurredAt = reader.GetOrdinal(CommandDeadLetterSchema.Columns.OccurredAt);
+            var ordAttemptCount = reader.GetOrdinal(CommandDeadLetterSchema.Columns.AttemptCount);
+            var ordStatus = reader.GetOrdinal(CommandDeadLetterSchema.Columns.Status);
+
+            do
+            {
+                var exceptionTypeNull = await reader
+                    .IsDBNullAsync(ordExceptionType, cancellationToken)
+                    .ConfigureAwait(false);
+                var exceptionMessageNull = await reader
+                    .IsDBNullAsync(ordExceptionMessage, cancellationToken)
+                    .ConfigureAwait(false);
+                var occurredAt = await reader
+                    .GetFieldValueAsync<DateTimeOffset>(ordOccurredAt, cancellationToken)
+                    .ConfigureAwait(false);
+
+                entries.Add(
+                    new CommandDeadLetterEntry
+                    {
+                        Id = Guid.Parse(reader.GetString(ordId)),
+                        CommandType = reader.GetString(ordCommandType),
+                        Payload = reader.GetString(ordPayload),
+                        ExceptionType = exceptionTypeNull ? null : reader.GetString(ordExceptionType),
+                        ExceptionMessage = exceptionMessageNull ? null : reader.GetString(ordExceptionMessage),
+                        OccurredAt = occurredAt,
+                        AttemptCount = (int)reader.GetInt64(ordAttemptCount),
+                        Status = (CommandDeadLetterStatus)reader.GetInt64(ordStatus),
+                    }
+                );
+            } while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false));
+
+            return entries;
+        }
+    }
+}

--- a/src/NetEvolve.Pulse.SQLite/DeadLetter/SQLiteCommandDeadLetterStore.cs
+++ b/src/NetEvolve.Pulse.SQLite/DeadLetter/SQLiteCommandDeadLetterStore.cs
@@ -1,0 +1,134 @@
+namespace NetEvolve.Pulse.DeadLetter;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+using NetEvolve.Pulse.Extensibility.Outbox;
+
+/// <summary>
+/// SQLite implementation of <see cref="ICommandDeadLetterStore"/> using ADO.NET.
+/// Provides command dead letter persistence optimized for SQLite.
+/// </summary>
+/// <remarks>
+/// <para><strong>Prerequisites:</strong></para>
+/// Execute the schema script from <c>Scripts/003_CreateCommandDeadLetterTable.sql</c> to create the
+/// required database objects before using this provider.
+/// </remarks>
+[SuppressMessage(
+    "Reliability",
+    "CA2007:Consider calling ConfigureAwait on the awaited task",
+    Justification = "await using statements in library code; ConfigureAwait applied to all Task-returning awaits."
+)]
+[SuppressMessage(
+    "Security",
+    "CA2100:Review SQL queries for security vulnerabilities",
+    Justification = "SQL is constructed from validated CommandDeadLetterOptions.TableName property, not user input."
+)]
+internal sealed class SQLiteCommandDeadLetterStore : ICommandDeadLetterStore
+{
+    /// <summary>The SQLite connection string used to open new connections for each store operation.</summary>
+    private readonly string _connectionString;
+
+    /// <summary>Whether to apply WAL journal mode to the database.</summary>
+    private readonly bool _enableWalMode;
+
+    /// <summary>Tracks whether the persistent WAL journal mode has already been applied to the database.</summary>
+    private int _walModeApplied;
+
+    /// <summary>Cached SQL statement for inserting a command dead letter entry.</summary>
+    private readonly string _insertSql;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SQLiteCommandDeadLetterStore"/> class.
+    /// </summary>
+    /// <param name="options">The command dead letter configuration options.</param>
+    public SQLiteCommandDeadLetterStore(IOptions<CommandDeadLetterOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrWhiteSpace(options.Value.ConnectionString);
+
+        var opts = options.Value;
+        _connectionString = opts.ConnectionString;
+        _enableWalMode = opts.EnableWalMode;
+
+        SqlIdentifier.Validate(opts.TableName, nameof(opts.TableName));
+        var table = $"\"{opts.TableName}\"";
+
+        _insertSql = $"""
+            INSERT OR IGNORE INTO {table}
+            ("{CommandDeadLetterSchema.Columns.Id}",
+             "{CommandDeadLetterSchema.Columns.CommandType}",
+             "{CommandDeadLetterSchema.Columns.Payload}",
+             "{CommandDeadLetterSchema.Columns.ExceptionType}",
+             "{CommandDeadLetterSchema.Columns.ExceptionMessage}",
+             "{CommandDeadLetterSchema.Columns.OccurredAt}",
+             "{CommandDeadLetterSchema.Columns.AttemptCount}",
+             "{CommandDeadLetterSchema.Columns.Status}")
+            VALUES (@id, @commandType, @payload, @exceptionType, @exceptionMessage, @occurredAt, @attemptCount, @status);
+            """;
+    }
+
+    /// <inheritdoc />
+    public async Task StoreAsync(
+        string commandType,
+        string payload,
+        Exception exception,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(commandType);
+        ArgumentException.ThrowIfNullOrWhiteSpace(payload);
+        ArgumentNullException.ThrowIfNull(exception);
+
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var command = new SqliteCommand(_insertSql, connection);
+            await using (command.ConfigureAwait(false))
+            {
+                _ = command.Parameters.AddWithValue("@id", Guid.NewGuid().ToString());
+                _ = command.Parameters.AddWithValue("@commandType", commandType);
+                _ = command.Parameters.AddWithValue("@payload", payload);
+                _ = command.Parameters.AddWithValue("@exceptionType", exception.GetType().AssemblyQualifiedName);
+                _ = command.Parameters.AddWithValue("@exceptionMessage", exception.Message);
+                _ = command.Parameters.AddWithValue("@occurredAt", DateTimeOffset.UtcNow);
+                _ = command.Parameters.AddWithValue("@attemptCount", 1);
+                _ = command.Parameters.AddWithValue("@status", (int)CommandDeadLetterStatus.New);
+
+                _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Opens and returns a new <see cref="SqliteConnection"/> using the stored connection string.
+    /// Applies WAL mode once per store instance when <see cref="CommandDeadLetterOptions.EnableWalMode"/> is
+    /// <see langword="true"/>; the journal mode is a persistent database property and does not need
+    /// to be re-applied on subsequent connections.
+    /// The caller is responsible for disposing the connection.
+    /// </summary>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>An open <see cref="SqliteConnection"/>.</returns>
+    private async Task<SqliteConnection> CreateConnectionAsync(CancellationToken cancellationToken)
+    {
+        var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        if (_enableWalMode && Volatile.Read(ref _walModeApplied) == 0)
+        {
+            var walCmd = new SqliteCommand("PRAGMA journal_mode=WAL;", connection);
+            await using (walCmd.ConfigureAwait(false))
+            {
+                _ = await walCmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            Volatile.Write(ref _walModeApplied, 1);
+        }
+
+        return connection;
+    }
+}

--- a/src/NetEvolve.Pulse.SQLite/SQLiteCommandDeadLetterMediatorBuilderExtensions.cs
+++ b/src/NetEvolve.Pulse.SQLite/SQLiteCommandDeadLetterMediatorBuilderExtensions.cs
@@ -1,0 +1,65 @@
+namespace NetEvolve.Pulse;
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using NetEvolve.Pulse.DeadLetter;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+
+/// <summary>
+/// Extension methods for configuring the SQLite command dead letter store on <see cref="IMediatorBuilder"/>.
+/// </summary>
+public static class SQLiteCommandDeadLetterMediatorBuilderExtensions
+{
+    /// <summary>
+    /// Adds SQLite command dead letter persistence using ADO.NET with a full options configuration action.
+    /// </summary>
+    /// <param name="configurator">The mediator configurator.</param>
+    /// <param name="configureOptions">Action to configure <see cref="CommandDeadLetterOptions"/>.</param>
+    /// <returns>The configurator for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configurator"/> or <paramref name="configureOptions"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para><strong>Prerequisites:</strong></para>
+    /// Execute the schema script from <c>Scripts/003_CreateCommandDeadLetterTable.sql</c> to create the required
+    /// database objects before using this provider.
+    /// <para><strong>Registered Services:</strong></para>
+    /// <list type="bullet">
+    /// <item><description><see cref="ICommandDeadLetterStore"/> as <see cref="SQLiteCommandDeadLetterStore"/> (Scoped)</description></item>
+    /// <item><description><see cref="ICommandDeadLetterManagement"/> as <see cref="SQLiteCommandDeadLetterManagement"/> (Scoped)</description></item>
+    /// </list>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// services.AddPulse(config => config
+    ///     .AddSQLiteCommandDeadLetterStore(opts =>
+    ///     {
+    ///         opts.ConnectionString = "Data Source=deadletter.db";
+    ///         opts.TableName = "MyCommandDeadLetter";
+    ///     })
+    /// );
+    /// </code>
+    /// </example>
+    public static IMediatorBuilder AddSQLiteCommandDeadLetterStore(
+        this IMediatorBuilder configurator,
+        Action<CommandDeadLetterOptions> configureOptions
+    )
+    {
+        ArgumentNullException.ThrowIfNull(configurator);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+
+        var services = configurator.Services;
+
+        _ = services.Configure(configureOptions);
+
+        _ = services
+            .RemoveAll<ICommandDeadLetterStore>()
+            .AddScoped<ICommandDeadLetterStore, SQLiteCommandDeadLetterStore>();
+
+        _ = services
+            .RemoveAll<ICommandDeadLetterManagement>()
+            .AddScoped<ICommandDeadLetterManagement, SQLiteCommandDeadLetterManagement>();
+
+        return configurator;
+    }
+}

--- a/src/NetEvolve.Pulse.SQLite/Scripts/003_CreateCommandDeadLetterTable.sql
+++ b/src/NetEvolve.Pulse.SQLite/Scripts/003_CreateCommandDeadLetterTable.sql
@@ -1,0 +1,54 @@
+-- ============================================================================
+-- 003_CreateCommandDeadLetterTable.sql
+-- ============================================================================
+-- Purpose: Creates the CommandDeadLetter table for the SQLite command dead
+--          letter store.
+-- Compatible with: NetEvolve.Pulse.SQLite (ADO.NET)
+--
+-- Configuration:
+--   This script uses SQLite CLI .parameter to emulate SQLCMD-style variables.
+--   Set values before running (the defaults below are used when not provided):
+--     @table_name   (default: CommandDeadLetter)
+--     @journal_mode (default: wal)
+--
+-- Usage:
+--   sqlite3 deadletter.db -cmd ".parameter set @table_name CommandDeadLetter" \
+--                         -cmd ".parameter set @journal_mode wal" \
+--                         ".read 003_CreateCommandDeadLetterTable.sql"
+-- ============================================================================
+
+.bail on
+.mode list
+.headers off
+.separator ''
+
+.output deadletter.schema.tmp.sql
+SELECT 'PRAGMA journal_mode=' || lower(coalesce(@journal_mode, 'wal')) || ';';
+SELECT 'CREATE TABLE IF NOT EXISTS '
+       || printf('"%w"', coalesce(@table_name, 'CommandDeadLetter'))
+       || ' ('
+       || '"Id"               TEXT        NOT NULL,'
+       || '"CommandType"      TEXT        NOT NULL,'
+       || '"Payload"          TEXT        NOT NULL,'
+       || '"ExceptionType"    TEXT        NULL,'
+       || '"ExceptionMessage" TEXT        NULL,'
+       || '"OccurredAt"       TEXT        NOT NULL,'
+       || '"AttemptCount"     INTEGER     NOT NULL DEFAULT 1,'
+       || '"Status"           INTEGER     NOT NULL DEFAULT 0,'
+       || 'CONSTRAINT '
+       || printf('"PK_%w"', coalesce(@table_name, 'CommandDeadLetter'))
+       || ' PRIMARY KEY ("Id")'
+       || ');';
+SELECT 'CREATE INDEX IF NOT EXISTS '
+       || printf('"IX_%w_Status"', coalesce(@table_name, 'CommandDeadLetter'))
+       || ' ON '
+       || printf('"%w"', coalesce(@table_name, 'CommandDeadLetter'))
+       || ' ("Status");';
+SELECT 'CREATE INDEX IF NOT EXISTS '
+       || printf('"IX_%w_OccurredAt"', coalesce(@table_name, 'CommandDeadLetter'))
+       || ' ON '
+       || printf('"%w"', coalesce(@table_name, 'CommandDeadLetter'))
+       || ' ("OccurredAt");';
+.output stdout
+
+.read deadletter.schema.tmp.sql

--- a/src/NetEvolve.Pulse.SqlServer/DeadLetter/SqlServerCommandDeadLetterManagement.cs
+++ b/src/NetEvolve.Pulse.SqlServer/DeadLetter/SqlServerCommandDeadLetterManagement.cs
@@ -1,0 +1,338 @@
+namespace NetEvolve.Pulse.DeadLetter;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+using NetEvolve.Pulse.Extensibility.Outbox;
+
+/// <summary>
+/// SQL Server implementation of <see cref="ICommandDeadLetterManagement"/> using ADO.NET.
+/// Provides pending-entry inspection, replay, dismissal, and statistics queries for the command dead letter store.
+/// </summary>
+/// <remarks>
+/// <para><strong>Prerequisites:</strong></para>
+/// Execute the schema script from <c>Scripts/CommandDeadLetter.sql</c> to create the required
+/// database objects before using this provider.
+/// </remarks>
+[SuppressMessage(
+    "Reliability",
+    "CA2007:Consider calling ConfigureAwait on the awaited task",
+    Justification = "await using statements in library code; ConfigureAwait applied to all Task-returning awaits."
+)]
+[SuppressMessage(
+    "Security",
+    "CA2100:Review SQL queries for security vulnerabilities",
+    Justification = "The SQL command text is constructed from validated CommandDeadLetterOptions.Schema/TableName properties, not user input."
+)]
+internal sealed class SqlServerCommandDeadLetterManagement : ICommandDeadLetterManagement
+{
+    /// <summary>The SQL Server connection string used to open new connections for each management operation.</summary>
+    private readonly string _connectionString;
+
+    /// <summary>The mediator used to dispatch replayed commands.</summary>
+    private readonly IMediatorSendOnly _mediator;
+
+    /// <summary>The serializer used to deserialize stored payloads for replay.</summary>
+    private readonly IPayloadSerializer _payloadSerializer;
+
+    /// <summary>Cached SQL command text for retrieving pending dead letter entries.</summary>
+    private readonly string _getPendingSql;
+
+    /// <summary>Cached SQL command text for retrieving a single dead letter entry by identifier.</summary>
+    private readonly string _getByIdSql;
+
+    /// <summary>Cached SQL command text for updating the status of a dead letter entry.</summary>
+    private readonly string _updateStatusSql;
+
+    /// <summary>Cached SQL command text for retrieving aggregate status counts.</summary>
+    private readonly string _getStatisticsSql;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SqlServerCommandDeadLetterManagement"/> class.
+    /// </summary>
+    /// <param name="options">The command dead letter configuration options.</param>
+    /// <param name="mediator">The mediator used to dispatch replayed commands.</param>
+    /// <param name="payloadSerializer">The serializer used to deserialize stored payloads.</param>
+    public SqlServerCommandDeadLetterManagement(
+        IOptions<CommandDeadLetterOptions> options,
+        IMediatorSendOnly mediator,
+        IPayloadSerializer payloadSerializer
+    )
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrWhiteSpace(options.Value.ConnectionString);
+        ArgumentNullException.ThrowIfNull(mediator);
+        ArgumentNullException.ThrowIfNull(payloadSerializer);
+
+        _connectionString = options.Value.ConnectionString;
+        _mediator = mediator;
+        _payloadSerializer = payloadSerializer;
+
+        var schema = string.IsNullOrWhiteSpace(options.Value.Schema)
+            ? CommandDeadLetterSchema.DefaultSchema
+            : options.Value.Schema;
+        SqlIdentifier.Validate(schema, nameof(options.Value.Schema));
+        SqlIdentifier.Validate(options.Value.TableName, nameof(options.Value.TableName));
+
+        var fullTableName = $"[{schema}].[{options.Value.TableName}]";
+
+        _getPendingSql = $"""
+            SELECT TOP (@count)
+                   [{CommandDeadLetterSchema.Columns.Id}],
+                   [{CommandDeadLetterSchema.Columns.CommandType}],
+                   [{CommandDeadLetterSchema.Columns.Payload}],
+                   [{CommandDeadLetterSchema.Columns.ExceptionType}],
+                   [{CommandDeadLetterSchema.Columns.ExceptionMessage}],
+                   [{CommandDeadLetterSchema.Columns.OccurredAt}],
+                   [{CommandDeadLetterSchema.Columns.AttemptCount}],
+                   [{CommandDeadLetterSchema.Columns.Status}]
+            FROM {fullTableName}
+            WHERE [{CommandDeadLetterSchema.Columns.Status}] = {(short)CommandDeadLetterStatus.New}
+            ORDER BY [{CommandDeadLetterSchema.Columns.OccurredAt}] ASC
+            """;
+
+        _getByIdSql = $"""
+            SELECT [{CommandDeadLetterSchema.Columns.Id}],
+                   [{CommandDeadLetterSchema.Columns.CommandType}],
+                   [{CommandDeadLetterSchema.Columns.Payload}],
+                   [{CommandDeadLetterSchema.Columns.ExceptionType}],
+                   [{CommandDeadLetterSchema.Columns.ExceptionMessage}],
+                   [{CommandDeadLetterSchema.Columns.OccurredAt}],
+                   [{CommandDeadLetterSchema.Columns.AttemptCount}],
+                   [{CommandDeadLetterSchema.Columns.Status}]
+            FROM {fullTableName}
+            WHERE [{CommandDeadLetterSchema.Columns.Id}] = @Id
+            """;
+
+        _updateStatusSql = $"""
+            UPDATE {fullTableName}
+            SET [{CommandDeadLetterSchema.Columns.Status}] = @Status
+            WHERE [{CommandDeadLetterSchema.Columns.Id}] = @Id
+            """;
+
+        _getStatisticsSql = $"""
+            SELECT [{CommandDeadLetterSchema.Columns.Status}], COUNT(*) AS [Count]
+            FROM {fullTableName}
+            GROUP BY [{CommandDeadLetterSchema.Columns.Status}]
+            """;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<CommandDeadLetterEntry>> GetPendingAsync(
+        int count = 50,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var command = new SqlCommand(_getPendingSql, connection);
+            await using (command.ConfigureAwait(false))
+            {
+                _ = command.Parameters.AddWithValue("@count", count);
+
+                var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                await using (reader.ConfigureAwait(false))
+                {
+                    var entries = new List<CommandDeadLetterEntry>();
+                    while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                    {
+                        entries.Add(MapToEntry(reader));
+                    }
+
+                    return entries;
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task ReplayAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var entry =
+                await GetEntryByIdAsync(connection, id, cancellationToken).ConfigureAwait(false)
+                ?? throw new KeyNotFoundException($"CommandDeadLetterEntry '{id}' was not found.");
+
+            _ = await UpdateStatusAsync(connection, id, CommandDeadLetterStatus.Replaying, cancellationToken)
+                .ConfigureAwait(false);
+
+            await CommandDeadLetterReplayDispatcher
+                .ReplayAsync(_mediator, _payloadSerializer, entry.CommandType, entry.Payload, cancellationToken)
+                .ConfigureAwait(false);
+
+            _ = await UpdateStatusAsync(connection, id, CommandDeadLetterStatus.Resolved, cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task DismissAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var affected = await UpdateStatusAsync(connection, id, CommandDeadLetterStatus.Dismissed, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (affected == 0)
+            {
+                throw new KeyNotFoundException($"CommandDeadLetterEntry '{id}' was not found.");
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<CommandDeadLetterStatistics> GetStatisticsAsync(CancellationToken cancellationToken = default)
+    {
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var command = new SqlCommand(_getStatisticsSql, connection);
+            await using (command.ConfigureAwait(false))
+            {
+                var newCount = 0;
+                var replayingCount = 0;
+                var resolvedCount = 0;
+                var dismissedCount = 0;
+
+                var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                await using (reader.ConfigureAwait(false))
+                {
+                    var ordStatus = reader.GetOrdinal(CommandDeadLetterSchema.Columns.Status);
+                    var ordCount = reader.GetOrdinal("Count");
+
+                    while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                    {
+                        var status = (CommandDeadLetterStatus)reader.GetInt16(ordStatus);
+                        var count = reader.GetInt32(ordCount);
+
+                        switch (status)
+                        {
+                            case CommandDeadLetterStatus.New:
+                                newCount = count;
+                                break;
+                            case CommandDeadLetterStatus.Replaying:
+                                replayingCount = count;
+                                break;
+                            case CommandDeadLetterStatus.Resolved:
+                                resolvedCount = count;
+                                break;
+                            case CommandDeadLetterStatus.Dismissed:
+                                dismissedCount = count;
+                                break;
+                        }
+                    }
+                }
+
+                return new CommandDeadLetterStatistics(newCount, replayingCount, resolvedCount, dismissedCount);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Creates and opens a new SQL Server connection.
+    /// </summary>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>An open <see cref="SqlConnection"/>.</returns>
+    private async Task<SqlConnection> CreateConnectionAsync(CancellationToken cancellationToken)
+    {
+        var connection = new SqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        return connection;
+    }
+
+    /// <summary>
+    /// Retrieves the dead letter entry identified by <paramref name="id"/>, or <see langword="null"/>
+    /// when no matching entry exists.
+    /// </summary>
+    /// <param name="connection">The open connection to use for the query.</param>
+    /// <param name="id">The identifier of the dead letter entry to retrieve.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>The matching <see cref="CommandDeadLetterEntry"/>, or <see langword="null"/>.</returns>
+    private async Task<CommandDeadLetterEntry?> GetEntryByIdAsync(
+        SqlConnection connection,
+        Guid id,
+        CancellationToken cancellationToken
+    )
+    {
+        var command = new SqlCommand(_getByIdSql, connection);
+        await using (command.ConfigureAwait(false))
+        {
+            _ = command.Parameters.AddWithValue("@Id", id);
+
+            var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            await using (reader.ConfigureAwait(false))
+            {
+                if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    return null;
+                }
+
+                return MapToEntry(reader);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Updates the status of the dead letter entry identified by <paramref name="id"/>.
+    /// </summary>
+    /// <param name="connection">The open connection to use for the update.</param>
+    /// <param name="id">The identifier of the dead letter entry to update.</param>
+    /// <param name="status">The new status to apply.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>The number of rows affected by the update.</returns>
+    private async Task<int> UpdateStatusAsync(
+        SqlConnection connection,
+        Guid id,
+        CommandDeadLetterStatus status,
+        CancellationToken cancellationToken
+    )
+    {
+        var command = new SqlCommand(_updateStatusSql, connection);
+        await using (command.ConfigureAwait(false))
+        {
+            _ = command.Parameters.AddWithValue("@Id", id);
+            _ = command.Parameters.AddWithValue("@Status", (short)status);
+
+            return await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Maps the current row of a <see cref="SqlDataReader"/> to a new <see cref="CommandDeadLetterEntry"/> instance.
+    /// </summary>
+    /// <param name="reader">The reader positioned on the row to map.</param>
+    /// <returns>A populated <see cref="CommandDeadLetterEntry"/>.</returns>
+    private static CommandDeadLetterEntry MapToEntry(SqlDataReader reader)
+    {
+        var ordId = reader.GetOrdinal(CommandDeadLetterSchema.Columns.Id);
+        var ordCommandType = reader.GetOrdinal(CommandDeadLetterSchema.Columns.CommandType);
+        var ordPayload = reader.GetOrdinal(CommandDeadLetterSchema.Columns.Payload);
+        var ordExceptionType = reader.GetOrdinal(CommandDeadLetterSchema.Columns.ExceptionType);
+        var ordExceptionMessage = reader.GetOrdinal(CommandDeadLetterSchema.Columns.ExceptionMessage);
+        var ordOccurredAt = reader.GetOrdinal(CommandDeadLetterSchema.Columns.OccurredAt);
+        var ordAttemptCount = reader.GetOrdinal(CommandDeadLetterSchema.Columns.AttemptCount);
+        var ordStatus = reader.GetOrdinal(CommandDeadLetterSchema.Columns.Status);
+
+        return new CommandDeadLetterEntry
+        {
+            Id = reader.GetGuid(ordId),
+            CommandType = reader.GetString(ordCommandType),
+            Payload = reader.GetString(ordPayload),
+            ExceptionType = reader.IsDBNull(ordExceptionType) ? null : reader.GetString(ordExceptionType),
+            ExceptionMessage = reader.IsDBNull(ordExceptionMessage) ? null : reader.GetString(ordExceptionMessage),
+            OccurredAt = reader.GetDateTimeOffset(ordOccurredAt),
+            AttemptCount = reader.GetInt32(ordAttemptCount),
+            Status = (CommandDeadLetterStatus)reader.GetInt16(ordStatus),
+        };
+    }
+}

--- a/src/NetEvolve.Pulse.SqlServer/DeadLetter/SqlServerCommandDeadLetterStore.cs
+++ b/src/NetEvolve.Pulse.SqlServer/DeadLetter/SqlServerCommandDeadLetterStore.cs
@@ -1,0 +1,144 @@
+namespace NetEvolve.Pulse.DeadLetter;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+using NetEvolve.Pulse.Extensibility.Outbox;
+
+/// <summary>
+/// SQL Server implementation of <see cref="ICommandDeadLetterStore"/> using ADO.NET.
+/// Provides command dead letter persistence optimized for SQL Server.
+/// </summary>
+/// <remarks>
+/// <para><strong>Prerequisites:</strong></para>
+/// Execute the schema script from <c>Scripts/CommandDeadLetter.sql</c> to create the required
+/// database objects before using this provider.
+/// <para><strong>Duplicate Key Handling:</strong></para>
+/// Wraps the insert in a try/catch for unique-constraint/primary-key violations, since the
+/// dead letter entry <see cref="CommandDeadLetterEntry.Id"/> is a freshly generated <see cref="Guid"/>
+/// and a duplicate is only possible under extremely unlikely concurrent collisions.
+/// </remarks>
+[SuppressMessage(
+    "Reliability",
+    "CA2007:Consider calling ConfigureAwait on the awaited task",
+    Justification = "await using statements in library code; ConfigureAwait applied to all Task-returning awaits."
+)]
+[SuppressMessage(
+    "Security",
+    "CA2100:Review SQL queries for security vulnerabilities",
+    Justification = "The SQL command text is constructed from validated CommandDeadLetterOptions.Schema/TableName properties, not user input."
+)]
+internal sealed class SqlServerCommandDeadLetterStore : ICommandDeadLetterStore
+{
+    /// <summary>The SQL Server connection string used to open new connections for each store operation.</summary>
+    private readonly string _connectionString;
+
+    /// <summary>Cached SQL command text for inserting a new command dead letter entry.</summary>
+    private readonly string _insertSql;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SqlServerCommandDeadLetterStore"/> class.
+    /// </summary>
+    /// <param name="options">The command dead letter configuration options.</param>
+    public SqlServerCommandDeadLetterStore(IOptions<CommandDeadLetterOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrWhiteSpace(options.Value.ConnectionString);
+
+        _connectionString = options.Value.ConnectionString;
+
+        var schema = string.IsNullOrWhiteSpace(options.Value.Schema)
+            ? CommandDeadLetterSchema.DefaultSchema
+            : options.Value.Schema;
+        SqlIdentifier.Validate(schema, nameof(options.Value.Schema));
+        SqlIdentifier.Validate(options.Value.TableName, nameof(options.Value.TableName));
+
+        var fullTableName = $"[{schema}].[{options.Value.TableName}]";
+
+        _insertSql = $"""
+            INSERT INTO {fullTableName}
+                ([{CommandDeadLetterSchema.Columns.Id}],
+                 [{CommandDeadLetterSchema.Columns.CommandType}],
+                 [{CommandDeadLetterSchema.Columns.Payload}],
+                 [{CommandDeadLetterSchema.Columns.ExceptionType}],
+                 [{CommandDeadLetterSchema.Columns.ExceptionMessage}],
+                 [{CommandDeadLetterSchema.Columns.OccurredAt}],
+                 [{CommandDeadLetterSchema.Columns.AttemptCount}],
+                 [{CommandDeadLetterSchema.Columns.Status}])
+            VALUES
+                (@Id, @CommandType, @Payload, @ExceptionType, @ExceptionMessage, @OccurredAt, @AttemptCount, @Status)
+            """;
+    }
+
+    /// <inheritdoc />
+    public async Task StoreAsync(
+        string commandType,
+        string payload,
+        Exception exception,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(commandType);
+        ArgumentException.ThrowIfNullOrWhiteSpace(payload);
+        ArgumentNullException.ThrowIfNull(exception);
+
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var command = new SqlCommand(_insertSql, connection);
+            await using (command.ConfigureAwait(false))
+            {
+                _ = command.Parameters.AddWithValue("@Id", Guid.NewGuid());
+                _ = command.Parameters.AddWithValue("@CommandType", commandType);
+                _ = command.Parameters.AddWithValue("@Payload", payload);
+                _ = command.Parameters.AddWithValue(
+                    "@ExceptionType",
+                    (object?)exception.GetType().AssemblyQualifiedName ?? DBNull.Value
+                );
+                _ = command.Parameters.AddWithValue("@ExceptionMessage", (object?)exception.Message ?? DBNull.Value);
+                _ = command.Parameters.AddWithValue("@OccurredAt", DateTimeOffset.UtcNow);
+                _ = command.Parameters.AddWithValue("@AttemptCount", 1);
+                _ = command.Parameters.AddWithValue("@Status", (short)CommandDeadLetterStatus.New);
+
+                try
+                {
+                    _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+                }
+                catch (SqlException ex) when (IsDuplicateKeyException(ex))
+                {
+                    // A concurrent insert already used the same identifier — extremely unlikely for a
+                    // freshly generated Guid, but treated as idempotent and safe to ignore for safety.
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Creates and opens a new SQL Server connection.
+    /// </summary>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>An open <see cref="SqlConnection"/>.</returns>
+    private async Task<SqlConnection> CreateConnectionAsync(CancellationToken cancellationToken)
+    {
+        var connection = new SqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        return connection;
+    }
+
+    /// <summary>
+    /// Determines whether the given exception was caused by a unique-constraint or
+    /// primary-key violation (i.e., a duplicate key insert).
+    /// </summary>
+    /// <remarks>
+    /// SQL Server / Azure SQL:
+    /// <list type="bullet">
+    /// <item><description>Error 2627 (PK violation): "Violation of PRIMARY KEY constraint '...'. Cannot insert duplicate key ..."</description></item>
+    /// <item><description>Error 2601 (unique-ix violation): "Cannot insert duplicate key row in object '...' with unique index '...'"</description></item>
+    /// </list>
+    /// </remarks>
+    private static bool IsDuplicateKeyException(SqlException ex) => ex.Number is 2627 or 2601;
+}

--- a/src/NetEvolve.Pulse.SqlServer/Scripts/CommandDeadLetter.sql
+++ b/src/NetEvolve.Pulse.SqlServer/Scripts/CommandDeadLetter.sql
@@ -1,0 +1,52 @@
+-- ============================================================================
+-- CommandDeadLetter Table Schema
+-- ============================================================================
+-- Purpose: Stores commands that failed processing for later inspection, replay, or dismissal.
+-- Compatible with: NetEvolve.Pulse.SqlServer (ADO.NET)
+--
+-- Configuration:
+--   Adjust SchemaName and TableName below before executing.
+--   This script requires SQLCMD mode:
+--     - sqlcmd utility:    sqlcmd -i CommandDeadLetter.sql
+--     - SSMS:              Query > SQLCMD Mode (Ctrl+Shift+Q)
+--     - Azure Data Studio: Enable SQLCMD in the query toolbar
+-- ============================================================================
+
+-- ============================================================================
+-- Configuration
+-- ============================================================================
+:setvar SchemaName "pulse"
+:setvar TableName "CommandDeadLetter"
+
+-- Create schema if it doesn't exist
+IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE [name] = N'$(SchemaName)')
+BEGIN
+    EXEC('CREATE SCHEMA [$(SchemaName)]');
+END
+GO
+
+-- Create table if it doesn't exist
+IF NOT EXISTS (SELECT 1 FROM sys.objects WHERE [object_id] = OBJECT_ID(N'[$(SchemaName)].[$(TableName)]') AND [type] = N'U')
+BEGIN
+    CREATE TABLE [$(SchemaName)].[$(TableName)]
+    (
+        [Id] UNIQUEIDENTIFIER NOT NULL,
+        [CommandType] NVARCHAR(500) NOT NULL,
+        [Payload] NVARCHAR(MAX) NOT NULL,
+        [ExceptionType] NVARCHAR(500) NULL,
+        [ExceptionMessage] NVARCHAR(MAX) NULL,
+        [OccurredAt] DATETIMEOFFSET(7) NOT NULL,
+        [AttemptCount] INT NOT NULL CONSTRAINT [DF_$(TableName)_AttemptCount] DEFAULT (1),
+        [Status] SMALLINT NOT NULL CONSTRAINT [DF_$(TableName)_Status] DEFAULT (0),
+        CONSTRAINT [PK_$(TableName)] PRIMARY KEY CLUSTERED ([Id])
+    );
+
+    -- Index for efficient filtering of pending entries (Status = New)
+    CREATE NONCLUSTERED INDEX [IX_$(TableName)_Status]
+        ON [$(SchemaName)].[$(TableName)] ([Status]);
+
+    -- Index for ordering entries by occurrence time (oldest first)
+    CREATE NONCLUSTERED INDEX [IX_$(TableName)_OccurredAt]
+        ON [$(SchemaName)].[$(TableName)] ([OccurredAt]);
+END
+GO

--- a/src/NetEvolve.Pulse.SqlServer/SqlServerCommandDeadLetterMediatorBuilderExtensions.cs
+++ b/src/NetEvolve.Pulse.SqlServer/SqlServerCommandDeadLetterMediatorBuilderExtensions.cs
@@ -1,0 +1,65 @@
+namespace NetEvolve.Pulse;
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using NetEvolve.Pulse.DeadLetter;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+
+/// <summary>
+/// Extension methods for configuring the SQL Server command dead letter store on <see cref="IMediatorBuilder"/>.
+/// </summary>
+public static class SqlServerCommandDeadLetterMediatorBuilderExtensions
+{
+    /// <summary>
+    /// Adds SQL Server command dead letter persistence using ADO.NET.
+    /// </summary>
+    /// <param name="configurator">The mediator configurator.</param>
+    /// <param name="configureOptions">Action to configure <see cref="CommandDeadLetterOptions"/>.</param>
+    /// <returns>The configurator for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configurator"/> or <paramref name="configureOptions"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para><strong>Prerequisites:</strong></para>
+    /// Execute the schema script from <c>Scripts/CommandDeadLetter.sql</c> to create the required
+    /// database objects before using this provider.
+    /// <para><strong>Registered Services:</strong></para>
+    /// <list type="bullet">
+    /// <item><description><see cref="ICommandDeadLetterStore"/> as <see cref="SqlServerCommandDeadLetterStore"/> (Scoped)</description></item>
+    /// <item><description><see cref="ICommandDeadLetterManagement"/> as <see cref="SqlServerCommandDeadLetterManagement"/> (Scoped)</description></item>
+    /// </list>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// services.AddPulse(config => config
+    ///     .AddSqlServerCommandDeadLetterStore(opts =>
+    ///     {
+    ///         opts.ConnectionString = "Server=.;Database=MyDb;Integrated Security=true;";
+    ///         opts.Schema = "myschema";
+    ///     })
+    /// );
+    /// </code>
+    /// </example>
+    public static IMediatorBuilder AddSqlServerCommandDeadLetterStore(
+        this IMediatorBuilder configurator,
+        Action<CommandDeadLetterOptions> configureOptions
+    )
+    {
+        ArgumentNullException.ThrowIfNull(configurator);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+
+        var services = configurator.Services;
+
+        _ = services.Configure(configureOptions);
+
+        _ = services
+            .RemoveAll<ICommandDeadLetterStore>()
+            .AddScoped<ICommandDeadLetterStore, SqlServerCommandDeadLetterStore>();
+
+        _ = services
+            .RemoveAll<ICommandDeadLetterManagement>()
+            .AddScoped<ICommandDeadLetterManagement, SqlServerCommandDeadLetterManagement>();
+
+        return configurator;
+    }
+}

--- a/src/NetEvolve.Pulse/CommandDeadLetterMediatorBuilderExtensions.cs
+++ b/src/NetEvolve.Pulse/CommandDeadLetterMediatorBuilderExtensions.cs
@@ -1,0 +1,50 @@
+namespace NetEvolve.Pulse;
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+using NetEvolve.Pulse.Interceptors;
+
+/// <summary>
+/// Provides extension methods for registering the command dead letter interceptor
+/// with the Pulse mediator.
+/// </summary>
+/// <seealso cref="ICommand{TResponse}"/>
+/// <seealso cref="ICommandDeadLetterStore"/>
+public static class CommandDeadLetterMediatorBuilderExtensions
+{
+    /// <summary>
+    /// Registers the command dead letter interceptor. Commands whose handler execution throws
+    /// are recorded to <see cref="ICommandDeadLetterStore"/> before the original exception is rethrown.
+    /// </summary>
+    /// <param name="builder">The mediator builder.</param>
+    /// <returns>The builder for method chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// This method only registers the interceptor - it does not register an <see cref="ICommandDeadLetterStore"/>.
+    /// Callers must also register a store, e.g. via one of the provider-specific
+    /// <c>Add*CommandDeadLetterStore()</c> extensions (EF Core or an ADO.NET provider), for failed commands
+    /// to actually be persisted. Without a registered store, the interceptor is a harmless no-op.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// services.AddPulse(builder =>
+    /// {
+    ///     builder.AddCommandDeadLetter();
+    ///     // builder.AddSqlServerCommandDeadLetterStore(...); // registers the store
+    /// });
+    /// </code>
+    /// </example>
+    public static IMediatorBuilder AddCommandDeadLetter(this IMediatorBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton(typeof(IRequestInterceptor<,>), typeof(CommandDeadLetterInterceptor<,>))
+        );
+
+        return builder;
+    }
+}

--- a/src/NetEvolve.Pulse/DeadLetter/CommandDeadLetterOptions.cs
+++ b/src/NetEvolve.Pulse/DeadLetter/CommandDeadLetterOptions.cs
@@ -1,0 +1,44 @@
+namespace NetEvolve.Pulse.DeadLetter;
+
+using System;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+
+/// <summary>
+/// Configuration options for the command dead letter store.
+/// </summary>
+public sealed class CommandDeadLetterOptions
+{
+    /// <summary>
+    /// Gets or sets the connection string used by the command dead letter store provider.
+    /// </summary>
+    /// <remarks>
+    /// Required for database-backed providers. Leave <see langword="null"/> when the provider
+    /// obtains its connection through other means (e.g., a registered <c>DbContext</c>).
+    /// </remarks>
+    public string? ConnectionString { get; set; }
+
+    /// <summary>
+    /// Gets or sets the database schema name for the command dead letter table.
+    /// Default: <c>"pulse"</c>.
+    /// </summary>
+    /// <remarks>
+    /// Set to <c>null</c> or empty string to use the default schema (e.g., "dbo" for SQL Server).
+    /// Some database providers may not support schemas.
+    /// </remarks>
+    public string? Schema { get; set; } = CommandDeadLetterSchema.DefaultSchema;
+
+    /// <summary>
+    /// Gets or sets the table name for command dead letter entries.
+    /// Default: <c>"CommandDeadLetter"</c>.
+    /// </summary>
+    public string TableName { get; set; } = CommandDeadLetterSchema.DefaultTableName;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether WAL (Write-Ahead Logging) mode is enabled.
+    /// </summary>
+    /// <remarks>
+    /// This setting is used by SQLite-based providers.
+    /// Default: <see langword="true"/>.
+    /// </remarks>
+    public bool EnableWalMode { get; set; } = true;
+}

--- a/src/NetEvolve.Pulse/Interceptors/CommandDeadLetterInterceptor.cs
+++ b/src/NetEvolve.Pulse/Interceptors/CommandDeadLetterInterceptor.cs
@@ -1,0 +1,84 @@
+namespace NetEvolve.Pulse.Interceptors;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+
+/// <summary>
+/// Request interceptor that records commands whose handler execution failed to an
+/// <see cref="ICommandDeadLetterStore"/>, allowing operators to inspect and replay them later.
+/// </summary>
+/// <typeparam name="TRequest">The type of request being intercepted.</typeparam>
+/// <typeparam name="TResponse">The type of response produced by the request.</typeparam>
+/// <remarks>
+/// <para><strong>Behavior:</strong></para>
+/// <list type="number">
+/// <item><description>If the request does not implement <see cref="ICommand{TResponse}"/>, the interceptor passes through without any try/catch overhead - queries and other non-command requests are never intercepted.</description></item>
+/// <item><description>If the handler completes successfully, its result is returned unchanged and no store interaction occurs.</description></item>
+/// <item><description>If the handler throws, and <see cref="ICommandDeadLetterStore"/> is registered in the DI container, the command's serialized payload and the exception are recorded via <see cref="ICommandDeadLetterStore.StoreAsync"/> before the original exception is rethrown.</description></item>
+/// <item><description>If <see cref="ICommandDeadLetterStore"/> is not registered, the interceptor is a no-op on failure - the original exception is still rethrown unchanged.</description></item>
+/// <item><description>The original exception is always rethrown, whether or not a store is registered - this interceptor never swallows a command failure, it only optionally records it first.</description></item>
+/// </list>
+/// <para><strong>Registration:</strong></para>
+/// Use <c>AddCommandDeadLetter()</c> on the <see cref="IMediatorBuilder"/> to register this interceptor.
+/// </remarks>
+/// <seealso cref="ICommand{TResponse}"/>
+/// <seealso cref="ICommandDeadLetterStore"/>
+/// <seealso cref="IPayloadSerializer"/>
+internal sealed class CommandDeadLetterInterceptor<TRequest, TResponse> : IRequestInterceptor<TRequest, TResponse>
+    where TRequest : IRequest<TResponse>
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IPayloadSerializer _payloadSerializer;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandDeadLetterInterceptor{TRequest, TResponse}"/> class.
+    /// </summary>
+    /// <param name="serviceProvider">The service provider used to resolve the optional <see cref="ICommandDeadLetterStore"/>.</param>
+    /// <param name="payloadSerializer">The serializer used to serialize the failed command's payload.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="serviceProvider"/> or <paramref name="payloadSerializer"/> is <see langword="null"/>.</exception>
+    public CommandDeadLetterInterceptor(IServiceProvider serviceProvider, IPayloadSerializer payloadSerializer)
+    {
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+        ArgumentNullException.ThrowIfNull(payloadSerializer);
+
+        _serviceProvider = serviceProvider;
+        _payloadSerializer = payloadSerializer;
+    }
+
+    /// <inheritdoc />
+    public async Task<TResponse> HandleAsync(
+        TRequest request,
+        Func<TRequest, CancellationToken, Task<TResponse>> handler,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+
+        if (request is not ICommand<TResponse>)
+        {
+            return await handler(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        try
+        {
+            return await handler(request, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            var store = _serviceProvider.GetService<ICommandDeadLetterStore>();
+            if (store is not null)
+            {
+                var payload = _payloadSerializer.Serialize(request);
+                await store
+                    .StoreAsync(typeof(TRequest).AssemblyQualifiedName!, payload, ex, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            throw;
+        }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Integration/DeadLetter/CommandDeadLetterTestsBase.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/DeadLetter/CommandDeadLetterTestsBase.cs
@@ -1,0 +1,284 @@
+namespace NetEvolve.Pulse.Tests.Integration.DeadLetter;
+
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.DeadLetter;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+using NetEvolve.Pulse.Tests.Integration.Internals;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
+
+[TestGroup("DeadLetter")]
+[Timeout(300_000)] // Increased timeout to accommodate potential delays in CI environments.
+public abstract class CommandDeadLetterTestsBase(
+    IServiceFixture databaseServiceFixture,
+    IServiceInitializer databaseInitializer
+)
+{
+    protected IServiceFixture DatabaseServiceFixture { get; } = databaseServiceFixture;
+    protected IServiceInitializer DatabaseInitializer { get; } = databaseInitializer;
+
+    protected async ValueTask RunAndVerify(
+        Func<IServiceProvider, CancellationToken, Task> testableCode,
+        CancellationToken cancellationToken,
+        Action<IServiceCollection>? configureServices = null,
+        [CallerMemberName] string tableName = null!
+    )
+    {
+        ArgumentNullException.ThrowIfNull(testableCode);
+
+        using var host = new HostBuilder()
+            .ConfigureAppConfiguration((hostContext, configBuilder) => { })
+            .ConfigureServices(services =>
+            {
+                DatabaseInitializer.Initialize(services, DatabaseServiceFixture);
+                configureServices?.Invoke(services);
+                _ = services
+                    .AddPulse(mediatorBuilder => DatabaseInitializer.Configure(mediatorBuilder, DatabaseServiceFixture))
+                    .Configure<CommandDeadLetterOptions>(options =>
+                    {
+                        options.TableName = tableName;
+                        options.Schema = TestHelper.TargetFramework;
+                    });
+            })
+            .ConfigureWebHost(webBuilder => _ = webBuilder.UseTestServer().Configure(applicationBuilder => { }))
+            .Build();
+
+        await DatabaseInitializer.CreateDatabaseAsync(host.Services, cancellationToken).ConfigureAwait(false);
+        await host.StartAsync(cancellationToken).ConfigureAwait(false);
+
+        using var server = host.GetTestServer();
+
+        using (Assert.Multiple())
+        {
+            var scope = server.Services.CreateAsyncScope();
+            await using (scope.ConfigureAwait(false))
+            {
+                await testableCode.Invoke(scope.ServiceProvider, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task StoreAsync_Then_GetPendingAsync_Returns_entry_with_status_New(
+        CancellationToken cancellationToken
+    ) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var store = services.GetRequiredService<ICommandDeadLetterStore>();
+                    var management = services.GetRequiredService<ICommandDeadLetterManagement>();
+
+                    await store
+                        .StoreAsync(
+                            typeof(TestReplayCommand).AssemblyQualifiedName!,
+                            """{"Value":"n/a"}""",
+                            new InvalidOperationException("boom"),
+                            token
+                        )
+                        .ConfigureAwait(false);
+
+                    var pending = await management.GetPendingAsync(50, token).ConfigureAwait(false);
+
+                    _ = await Assert.That(pending).HasSingleItem();
+                    _ = await Assert.That(pending[0].Status).IsEqualTo(CommandDeadLetterStatus.New);
+                    _ = await Assert.That(pending[0].ExceptionMessage).IsEqualTo("boom");
+                    _ = await Assert
+                        .That(pending[0].CommandType)
+                        .IsEqualTo(typeof(TestReplayCommand).AssemblyQualifiedName);
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+    [Test]
+    public async Task GetPendingAsync_Respects_count_limit(CancellationToken cancellationToken) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var store = services.GetRequiredService<ICommandDeadLetterStore>();
+                    var management = services.GetRequiredService<ICommandDeadLetterManagement>();
+
+                    for (var i = 0; i < 3; i++)
+                    {
+                        await store
+                            .StoreAsync(
+                                typeof(TestReplayCommand).AssemblyQualifiedName!,
+                                """{"Value":"n/a"}""",
+                                new InvalidOperationException($"failure-{i}"),
+                                token
+                            )
+                            .ConfigureAwait(false);
+                    }
+
+                    var pending = await management.GetPendingAsync(2, token).ConfigureAwait(false);
+
+                    _ = await Assert.That(pending.Count).IsEqualTo(2);
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+    [Test]
+    public async Task ReplayAsync_Dispatches_command_and_sets_Resolved(CancellationToken cancellationToken) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var store = services.GetRequiredService<ICommandDeadLetterStore>();
+                    var management = services.GetRequiredService<ICommandDeadLetterManagement>();
+                    var serializer = services.GetRequiredService<IPayloadSerializer>();
+
+                    var command = new TestReplayCommand("replay-value");
+                    var payload = serializer.Serialize(command);
+                    await store
+                        .StoreAsync(
+                            typeof(TestReplayCommand).AssemblyQualifiedName!,
+                            payload,
+                            new InvalidOperationException("boom"),
+                            token
+                        )
+                        .ConfigureAwait(false);
+
+                    var pending = await management.GetPendingAsync(50, token).ConfigureAwait(false);
+                    var entryId = pending.Single().Id;
+
+                    await management.ReplayAsync(entryId, token).ConfigureAwait(false);
+
+                    var stillPending = await management.GetPendingAsync(50, token).ConfigureAwait(false);
+                    _ = await Assert.That(stillPending).IsEmpty();
+
+                    var stats = await management.GetStatisticsAsync(token).ConfigureAwait(false);
+                    _ = await Assert.That(stats.ResolvedCount).IsEqualTo(1);
+                },
+                cancellationToken,
+                configureServices: services =>
+                    services.AddSingleton<ICommandHandler<TestReplayCommand, Void>, TestReplayCommandHandler>()
+            )
+            .ConfigureAwait(false);
+
+    [Test]
+    public async Task ReplayAsync_When_id_not_found_throws_KeyNotFoundException(CancellationToken cancellationToken) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var management = services.GetRequiredService<ICommandDeadLetterManagement>();
+
+                    _ = await Assert
+                        .That(() => management.ReplayAsync(Guid.NewGuid(), token))
+                        .Throws<KeyNotFoundException>();
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+    [Test]
+    public async Task DismissAsync_Sets_status_Dismissed(CancellationToken cancellationToken) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var store = services.GetRequiredService<ICommandDeadLetterStore>();
+                    var management = services.GetRequiredService<ICommandDeadLetterManagement>();
+
+                    await store
+                        .StoreAsync(
+                            typeof(TestReplayCommand).AssemblyQualifiedName!,
+                            """{"Value":"n/a"}""",
+                            new InvalidOperationException("boom"),
+                            token
+                        )
+                        .ConfigureAwait(false);
+
+                    var pending = await management.GetPendingAsync(50, token).ConfigureAwait(false);
+                    var entryId = pending.Single().Id;
+
+                    await management.DismissAsync(entryId, token).ConfigureAwait(false);
+
+                    var stillPending = await management.GetPendingAsync(50, token).ConfigureAwait(false);
+                    _ = await Assert.That(stillPending).IsEmpty();
+
+                    var stats = await management.GetStatisticsAsync(token).ConfigureAwait(false);
+                    _ = await Assert.That(stats.DismissedCount).IsEqualTo(1);
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+    [Test]
+    public async Task DismissAsync_When_id_not_found_throws_KeyNotFoundException(CancellationToken cancellationToken) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var management = services.GetRequiredService<ICommandDeadLetterManagement>();
+
+                    _ = await Assert
+                        .That(() => management.DismissAsync(Guid.NewGuid(), token))
+                        .Throws<KeyNotFoundException>();
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+    [Test]
+    public async Task GetStatisticsAsync_Returns_correct_counts_per_status(CancellationToken cancellationToken) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var store = services.GetRequiredService<ICommandDeadLetterStore>();
+                    var management = services.GetRequiredService<ICommandDeadLetterManagement>();
+
+                    // Two New entries, one of which is dismissed afterward.
+                    await store
+                        .StoreAsync(
+                            typeof(TestReplayCommand).AssemblyQualifiedName!,
+                            """{"Value":"n/a"}""",
+                            new InvalidOperationException("boom-1"),
+                            token
+                        )
+                        .ConfigureAwait(false);
+                    await store
+                        .StoreAsync(
+                            typeof(TestReplayCommand).AssemblyQualifiedName!,
+                            """{"Value":"n/a"}""",
+                            new InvalidOperationException("boom-2"),
+                            token
+                        )
+                        .ConfigureAwait(false);
+
+                    var pending = await management.GetPendingAsync(50, token).ConfigureAwait(false);
+                    await management.DismissAsync(pending[0].Id, token).ConfigureAwait(false);
+
+                    var stats = await management.GetStatisticsAsync(token).ConfigureAwait(false);
+
+                    using (Assert.Multiple())
+                    {
+                        _ = await Assert.That(stats.NewCount).IsEqualTo(1);
+                        _ = await Assert.That(stats.DismissedCount).IsEqualTo(1);
+                        _ = await Assert.That(stats.ResolvedCount).IsEqualTo(0);
+                        _ = await Assert.That(stats.ReplayingCount).IsEqualTo(0);
+                        _ = await Assert.That(stats.TotalCount).IsEqualTo(2);
+                    }
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+    private sealed record TestReplayCommand(string Value) : ICommand<Void>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed class TestReplayCommandHandler : ICommandHandler<TestReplayCommand, Void>
+    {
+        public Task<Void> HandleAsync(TestReplayCommand command, CancellationToken cancellationToken = default) =>
+            Task.FromResult(Void.Completed);
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Integration/DeadLetter/MySqlAdoNetCommandDeadLetterTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/DeadLetter/MySqlAdoNetCommandDeadLetterTests.cs
@@ -1,0 +1,16 @@
+namespace NetEvolve.Pulse.Tests.Integration.DeadLetter;
+
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Tests.Integration.Internals;
+using NetEvolve.Pulse.Tests.Integration.Internals.DeadLetter;
+
+[ClassDataSource<MySqlDatabaseServiceFixture, MySqlAdoNetCommandDeadLetterInitializer>(
+    Shared = [SharedType.None, SharedType.None]
+)]
+[TestGroup("MySql")]
+[TestGroup("AdoNet")]
+[InheritsTests]
+public class MySqlAdoNetCommandDeadLetterTests(
+    IServiceFixture databaseServiceFixture,
+    IServiceInitializer databaseInitializer
+) : CommandDeadLetterTestsBase(databaseServiceFixture, databaseInitializer);

--- a/tests/NetEvolve.Pulse.Tests.Integration/DeadLetter/MySqlEntityFrameworkCommandDeadLetterTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/DeadLetter/MySqlEntityFrameworkCommandDeadLetterTests.cs
@@ -1,0 +1,16 @@
+namespace NetEvolve.Pulse.Tests.Integration.DeadLetter;
+
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Tests.Integration.Internals;
+using NetEvolve.Pulse.Tests.Integration.Internals.DeadLetter;
+
+[ClassDataSource<MySqlDatabaseServiceFixture, EntityFrameworkCommandDeadLetterInitializer>(
+    Shared = [SharedType.None, SharedType.None]
+)]
+[TestGroup("MySql")]
+[TestGroup("EntityFramework")]
+[InheritsTests]
+public class MySqlEntityFrameworkCommandDeadLetterTests(
+    IServiceFixture databaseServiceFixture,
+    IServiceInitializer databaseInitializer
+) : CommandDeadLetterTestsBase(databaseServiceFixture, databaseInitializer);

--- a/tests/NetEvolve.Pulse.Tests.Integration/DeadLetter/PostgreSqlAdoNetCommandDeadLetterTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/DeadLetter/PostgreSqlAdoNetCommandDeadLetterTests.cs
@@ -1,0 +1,16 @@
+namespace NetEvolve.Pulse.Tests.Integration.DeadLetter;
+
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Tests.Integration.Internals;
+using NetEvolve.Pulse.Tests.Integration.Internals.DeadLetter;
+
+[ClassDataSource<PostgreSqlDatabaseServiceFixture, PostgreSqlAdoNetCommandDeadLetterInitializer>(
+    Shared = [SharedType.None, SharedType.None]
+)]
+[TestGroup("PostgreSql")]
+[TestGroup("AdoNet")]
+[InheritsTests]
+public class PostgreSqlAdoNetCommandDeadLetterTests(
+    IServiceFixture databaseServiceFixture,
+    IServiceInitializer databaseInitializer
+) : CommandDeadLetterTestsBase(databaseServiceFixture, databaseInitializer);

--- a/tests/NetEvolve.Pulse.Tests.Integration/DeadLetter/SQLiteAdoNetCommandDeadLetterTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/DeadLetter/SQLiteAdoNetCommandDeadLetterTests.cs
@@ -1,0 +1,16 @@
+namespace NetEvolve.Pulse.Tests.Integration.DeadLetter;
+
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Tests.Integration.Internals;
+using NetEvolve.Pulse.Tests.Integration.Internals.DeadLetter;
+
+[ClassDataSource<SQLiteDatabaseServiceFixture, SQLiteAdoNetCommandDeadLetterInitializer>(
+    Shared = [SharedType.None, SharedType.None]
+)]
+[TestGroup("SQLite")]
+[TestGroup("AdoNet")]
+[InheritsTests]
+public class SQLiteAdoNetCommandDeadLetterTests(
+    IServiceFixture databaseServiceFixture,
+    IServiceInitializer databaseInitializer
+) : CommandDeadLetterTestsBase(databaseServiceFixture, databaseInitializer);

--- a/tests/NetEvolve.Pulse.Tests.Integration/DeadLetter/SqlServerAdoNetCommandDeadLetterTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/DeadLetter/SqlServerAdoNetCommandDeadLetterTests.cs
@@ -1,0 +1,16 @@
+namespace NetEvolve.Pulse.Tests.Integration.DeadLetter;
+
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Tests.Integration.Internals;
+using NetEvolve.Pulse.Tests.Integration.Internals.DeadLetter;
+
+[ClassDataSource<SqlServerDatabaseServiceFixture, SqlServerAdoNetCommandDeadLetterInitializer>(
+    Shared = [SharedType.None, SharedType.None]
+)]
+[TestGroup("SqlServer")]
+[TestGroup("AdoNet")]
+[InheritsTests]
+public class SqlServerAdoNetCommandDeadLetterTests(
+    IServiceFixture databaseServiceFixture,
+    IServiceInitializer databaseInitializer
+) : CommandDeadLetterTestsBase(databaseServiceFixture, databaseInitializer);

--- a/tests/NetEvolve.Pulse.Tests.Integration/Internals/DeadLetter/EntityFrameworkCommandDeadLetterInitializer.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Internals/DeadLetter/EntityFrameworkCommandDeadLetterInitializer.cs
@@ -1,0 +1,164 @@
+namespace NetEvolve.Pulse.Tests.Integration.Internals.DeadLetter;
+
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.DeadLetter;
+using NetEvolve.Pulse.Extensibility;
+
+public sealed class EntityFrameworkCommandDeadLetterInitializer : IServiceInitializer
+{
+    public void Configure(IMediatorBuilder mediatorBuilder, IServiceFixture serviceFixture) =>
+        mediatorBuilder.AddEntityFrameworkCommandDeadLetterStore<TestCommandDeadLetterDbContext>();
+
+    private static readonly SemaphoreSlim _gate = new(1, 1);
+
+    public async ValueTask CreateDatabaseAsync(IServiceProvider serviceProvider, CancellationToken cancellationToken)
+    {
+        using (var scope = serviceProvider.CreateScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<TestCommandDeadLetterDbContext>();
+            var databaseCreator = context.GetService<IDatabaseCreator>();
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (databaseCreator is IRelationalDatabaseCreator relationalDatabaseCreator)
+            {
+                if (!await relationalDatabaseCreator.CanConnectAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    await relationalDatabaseCreator.CreateAsync(cancellationToken).ConfigureAwait(false);
+                }
+            }
+            else
+            {
+                if (await databaseCreator.CanConnectAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    return;
+                }
+
+                await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+                try
+                {
+                    _ = await databaseCreator.EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+                    return;
+                }
+                finally
+                {
+                    _ = _gate.Release();
+                }
+            }
+
+            if (databaseCreator is IRelationalDatabaseCreator relationalTableCreator)
+            {
+                await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    await relationalTableCreator.CreateTablesAsync(cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    _ = _gate.Release();
+                }
+            }
+        }
+    }
+
+    public void Initialize(IServiceCollection services, IServiceFixture serviceFixture) =>
+        _ = services.AddDbContextFactory<TestCommandDeadLetterDbContext>(options =>
+        {
+            var connectionString = serviceFixture.ConnectionString;
+
+            // Register a custom model-cache key factory that includes the per-test table name.
+            _ = options.ReplaceService<IModelCacheKeyFactory, TestTableModelCacheKeyFactory>();
+
+            _ = serviceFixture.ServiceType switch
+            {
+                ServiceType.InMemory => options.UseInMemoryDatabase(connectionString),
+                ServiceType.MySql => options.UseMySQL(connectionString),
+                ServiceType.PostgreSQL => options.UseNpgsql(connectionString),
+                // Add a busy-timeout interceptor so that concurrent SaveChangesAsync calls from
+                // parallel tests wait and retry instead of failing with SQLITE_BUSY.
+                ServiceType.SQLite => options
+                    .UseSqlite(connectionString)
+                    .AddInterceptors(new SQLiteBusyTimeoutInterceptor()),
+                ServiceType.SqlServer => options.UseSqlServer(
+                    connectionString,
+                    sqlOptions => sqlOptions.EnableRetryOnFailure(maxRetryCount: 5)
+                ),
+                _ => throw new NotSupportedException($"Database type {serviceFixture.ServiceType} is not supported."),
+            };
+        });
+
+    /// <summary>
+    /// Sets <c>PRAGMA busy_timeout</c> on every SQLite connection when it is opened so that
+    /// concurrent write operations wait and retry rather than immediately failing with SQLITE_BUSY.
+    /// </summary>
+    private sealed class SQLiteBusyTimeoutInterceptor : DbConnectionInterceptor
+    {
+        private const string Pragmas = "PRAGMA busy_timeout = 60000; PRAGMA journal_mode = WAL;";
+
+        public override void ConnectionOpened(DbConnection connection, ConnectionEndEventData eventData)
+        {
+            using var command = connection.CreateCommand();
+            command.CommandText = Pragmas;
+            _ = command.ExecuteNonQuery();
+        }
+
+        public override async Task ConnectionOpenedAsync(
+            DbConnection connection,
+            ConnectionEndEventData eventData,
+            CancellationToken cancellationToken = default
+        )
+        {
+            var command = connection.CreateCommand();
+            await using (command.ConfigureAwait(false))
+            {
+                command.CommandText = Pragmas;
+                _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Custom EF Core model-cache key factory that incorporates <see cref="CommandDeadLetterOptions.TableName"/>
+    /// into the cache key to prevent model sharing between tests that use different table names.
+    /// </summary>
+    private sealed class TestTableModelCacheKeyFactory : IModelCacheKeyFactory
+    {
+        /// <inheritdoc />
+        public object Create(DbContext context, bool designTime)
+        {
+            string tableName;
+            try
+            {
+                tableName = context.GetService<IOptions<CommandDeadLetterOptions>>()?.Value?.TableName ?? string.Empty;
+            }
+            catch (InvalidOperationException)
+            {
+                tableName = string.Empty;
+            }
+
+            return (context.GetType(), tableName, designTime);
+        }
+    }
+
+    internal sealed class TestCommandDeadLetterDbContext : DbContext, ICommandDeadLetterDbContext
+    {
+        public DbSet<Extensibility.DeadLetter.CommandDeadLetterEntry> CommandDeadLetterEntries =>
+            Set<Extensibility.DeadLetter.CommandDeadLetterEntry>();
+
+        public TestCommandDeadLetterDbContext(DbContextOptions<TestCommandDeadLetterDbContext> configuration)
+            : base(configuration) { }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            _ = modelBuilder.ApplyPulseConfiguration(this);
+        }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Integration/Internals/DeadLetter/MySqlAdoNetCommandDeadLetterInitializer.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Internals/DeadLetter/MySqlAdoNetCommandDeadLetterInitializer.cs
@@ -1,0 +1,112 @@
+namespace NetEvolve.Pulse.Tests.Integration.Internals.DeadLetter;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using MySql.Data.MySqlClient;
+using NetEvolve.Pulse.DeadLetter;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+
+/// <summary>
+/// Configures the MySQL ADO.NET command dead letter store provider for integration tests.
+/// Executes <c>Scripts/MySql/CommandDeadLetter.sql</c> to create the required table before each test.
+/// </summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Security",
+    "CA2100:Review SQL queries for security vulnerabilities",
+    Justification = "SQL is read from a script file with table name substituted from validated CommandDeadLetterOptions properties."
+)]
+public sealed class MySqlAdoNetCommandDeadLetterInitializer : IServiceInitializer
+{
+    private static readonly string _scriptPath = Path.Combine(
+        AppContext.BaseDirectory,
+        "Scripts",
+        "MySql",
+        "CommandDeadLetter.sql"
+    );
+
+    /// <inheritdoc />
+    public void Configure(IMediatorBuilder mediatorBuilder, IServiceFixture serviceFixture)
+    {
+        ArgumentNullException.ThrowIfNull(serviceFixture);
+        _ = mediatorBuilder.AddMySqlCommandDeadLetterStore(options =>
+            options.ConnectionString = serviceFixture.ConnectionString
+        );
+    }
+
+    /// <inheritdoc />
+    public async ValueTask CreateDatabaseAsync(IServiceProvider serviceProvider, CancellationToken cancellationToken)
+    {
+        var options = serviceProvider.GetRequiredService<IOptions<CommandDeadLetterOptions>>().Value;
+
+        var connectionString =
+            options.ConnectionString
+            ?? throw new InvalidOperationException("CommandDeadLetterOptions.ConnectionString is not configured.");
+
+        var tableName = string.IsNullOrWhiteSpace(options.TableName)
+            ? CommandDeadLetterSchema.DefaultTableName
+            : options.TableName;
+
+        var script = await File.ReadAllTextAsync(_scriptPath, cancellationToken).ConfigureAwait(false);
+
+        // Replace only the table name occurrences (CREATE TABLE and ON clauses),
+        // not the identically-named column definition.
+        script = script
+            .Replace(
+                $"TABLE IF NOT EXISTS `{CommandDeadLetterSchema.DefaultTableName}`",
+                $"TABLE IF NOT EXISTS `{tableName}`",
+                StringComparison.Ordinal
+            )
+            .Replace(
+                $"\n    ON `{CommandDeadLetterSchema.DefaultTableName}`",
+                $"\n    ON `{tableName}`",
+                StringComparison.Ordinal
+            );
+
+        var connection = new MySqlConnection(connectionString);
+        await using (connection.ConfigureAwait(false))
+        {
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            // Execute each SQL statement individually (CREATE TABLE, CREATE INDEX)
+            foreach (
+                var statement in script.Split(
+                    ';',
+                    StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
+                )
+            )
+            {
+                if (IsCommentOrEmpty(statement))
+                {
+                    continue;
+                }
+
+                var command = new MySqlCommand(statement, connection);
+                await using (command.ConfigureAwait(false))
+                {
+                    _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public void Initialize(IServiceCollection services, IServiceFixture serviceFixture)
+    {
+        // No additional service initialization required for ADO.NET command dead letter tests.
+    }
+
+    private static bool IsCommentOrEmpty(string statement)
+    {
+        foreach (var line in statement.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var trimmed = line.Trim();
+            if (trimmed.Length > 0 && !trimmed.StartsWith("--", StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Integration/Internals/DeadLetter/PostgreSqlAdoNetCommandDeadLetterInitializer.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Internals/DeadLetter/PostgreSqlAdoNetCommandDeadLetterInitializer.cs
@@ -1,0 +1,84 @@
+namespace NetEvolve.Pulse.Tests.Integration.Internals.DeadLetter;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse;
+using NetEvolve.Pulse.DeadLetter;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+using Npgsql;
+
+[SuppressMessage(
+    "Security",
+    "CA2100:Review SQL queries for security vulnerabilities",
+    Justification = "SQL is read from a script file with schema and table names substituted from validated CommandDeadLetterOptions properties."
+)]
+public sealed partial class PostgreSqlAdoNetCommandDeadLetterInitializer : IServiceInitializer
+{
+    private static readonly string _scriptPath = Path.Combine(
+        AppContext.BaseDirectory,
+        "Scripts",
+        "PostgreSql",
+        "CommandDeadLetter.sql"
+    );
+
+    public void Configure(IMediatorBuilder mediatorBuilder, IServiceFixture serviceFixture)
+    {
+        ArgumentNullException.ThrowIfNull(serviceFixture);
+        _ = mediatorBuilder.AddPostgreSqlCommandDeadLetterStore(options =>
+            options.ConnectionString = serviceFixture.ConnectionString
+        );
+    }
+
+    public async ValueTask CreateDatabaseAsync(IServiceProvider serviceProvider, CancellationToken cancellationToken)
+    {
+        var options = serviceProvider.GetRequiredService<IOptions<CommandDeadLetterOptions>>().Value;
+
+        var connectionString =
+            options.ConnectionString
+            ?? throw new InvalidOperationException("CommandDeadLetterOptions.ConnectionString is not configured.");
+
+        var schema = string.IsNullOrWhiteSpace(options.Schema) ? CommandDeadLetterSchema.DefaultSchema : options.Schema;
+
+        var tableName = string.IsNullOrWhiteSpace(options.TableName)
+            ? CommandDeadLetterSchema.DefaultTableName
+            : options.TableName;
+
+        var script = await File.ReadAllTextAsync(_scriptPath, cancellationToken).ConfigureAwait(false);
+
+        // Remove psql-specific variable declarations (not valid SQL)
+        script = SearchSetVar().Replace(script, string.Empty);
+
+        // Substitute psql variables with actual values.
+        // PostgreSQL script uses :schema_name and :table_name as placeholders.
+        // The placeholders appear both unquoted (e.g., CREATE SCHEMA :schema_name)
+        // and within quotes (e.g., ":schema_name".":table_name").
+        // We replace all occurrences with the actual values directly.
+        script = script
+            .Replace(":schema_name", schema, StringComparison.Ordinal)
+            .Replace(":table_name", tableName, StringComparison.Ordinal);
+
+        var connection = new NpgsqlConnection(connectionString);
+        await using (connection.ConfigureAwait(false))
+        {
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            var command = new NpgsqlCommand(script, connection);
+            await using (command.ConfigureAwait(false))
+            {
+                _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    public void Initialize(IServiceCollection services, IServiceFixture serviceFixture)
+    {
+        // No additional service initialization required for ADO.NET command dead letter tests.
+        // The Configure method handles all necessary service registrations.
+    }
+
+    [GeneratedRegex(@"^\\set\s+\w+\s+.*$", RegexOptions.Multiline, 10000)]
+    private static partial Regex SearchSetVar();
+}

--- a/tests/NetEvolve.Pulse.Tests.Integration/Internals/DeadLetter/SQLiteAdoNetCommandDeadLetterInitializer.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Internals/DeadLetter/SQLiteAdoNetCommandDeadLetterInitializer.cs
@@ -1,0 +1,77 @@
+namespace NetEvolve.Pulse.Tests.Integration.Internals.DeadLetter;
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.DeadLetter;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+
+[SuppressMessage(
+    "Security",
+    "CA2100:Review SQL queries for security vulnerabilities",
+    Justification = "SQL is constructed from validated CommandDeadLetterOptions.TableName property, not user input."
+)]
+public sealed class SQLiteAdoNetCommandDeadLetterInitializer : IServiceInitializer
+{
+    public void Configure(IMediatorBuilder mediatorBuilder, IServiceFixture serviceFixture)
+    {
+        ArgumentNullException.ThrowIfNull(mediatorBuilder);
+        ArgumentNullException.ThrowIfNull(serviceFixture);
+        _ = mediatorBuilder.AddSQLiteCommandDeadLetterStore(options =>
+            options.ConnectionString = serviceFixture.ConnectionString
+        );
+    }
+
+    public async ValueTask CreateDatabaseAsync(IServiceProvider serviceProvider, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+        var options = serviceProvider.GetRequiredService<IOptions<CommandDeadLetterOptions>>().Value;
+
+        var connectionString =
+            options.ConnectionString
+            ?? throw new InvalidOperationException("CommandDeadLetterOptions.ConnectionString is not configured.");
+
+        var tableName = string.IsNullOrWhiteSpace(options.TableName)
+            ? CommandDeadLetterSchema.DefaultTableName
+            : options.TableName;
+
+        var quotedTable = $"\"{tableName}\"";
+        var quotedPk = $"\"PK_{tableName}\"";
+        var quotedIdx = $"\"IX_{tableName}_Status\"";
+
+        var createTableSql = $"""
+            PRAGMA journal_mode=WAL;
+            CREATE TABLE IF NOT EXISTS {quotedTable} (
+                "{CommandDeadLetterSchema.Columns.Id}"               TEXT NOT NULL,
+                "{CommandDeadLetterSchema.Columns.CommandType}"      TEXT NOT NULL,
+                "{CommandDeadLetterSchema.Columns.Payload}"          TEXT NOT NULL,
+                "{CommandDeadLetterSchema.Columns.ExceptionType}"    TEXT NULL,
+                "{CommandDeadLetterSchema.Columns.ExceptionMessage}" TEXT NULL,
+                "{CommandDeadLetterSchema.Columns.OccurredAt}"       TEXT NOT NULL,
+                "{CommandDeadLetterSchema.Columns.AttemptCount}"     INTEGER NOT NULL,
+                "{CommandDeadLetterSchema.Columns.Status}"           INTEGER NOT NULL,
+                CONSTRAINT {quotedPk} PRIMARY KEY ("{CommandDeadLetterSchema.Columns.Id}")
+            );
+            CREATE INDEX IF NOT EXISTS {quotedIdx}
+                ON {quotedTable} ("{CommandDeadLetterSchema.Columns.Status}");
+            """;
+
+        var connection = new SqliteConnection(connectionString);
+        await using (connection.ConfigureAwait(false))
+        {
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+#pragma warning disable S2077 // SQL is constructed from validated CommandDeadLetterOptions.TableName property, not user input.
+            var command = new SqliteCommand(createTableSql, connection);
+#pragma warning restore S2077
+            await using (command.ConfigureAwait(false))
+            {
+                _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    public void Initialize(IServiceCollection services, IServiceFixture serviceFixture) { }
+}

--- a/tests/NetEvolve.Pulse.Tests.Integration/Internals/DeadLetter/SqlServerAdoNetCommandDeadLetterInitializer.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Internals/DeadLetter/SqlServerAdoNetCommandDeadLetterInitializer.cs
@@ -1,0 +1,91 @@
+namespace NetEvolve.Pulse.Tests.Integration.Internals.DeadLetter;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse;
+using NetEvolve.Pulse.DeadLetter;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+
+[SuppressMessage(
+    "Security",
+    "CA2100:Review SQL queries for security vulnerabilities",
+    Justification = "SQL is read from a script file with schema and table names substituted from validated CommandDeadLetterOptions properties."
+)]
+public sealed partial class SqlServerAdoNetCommandDeadLetterInitializer : IServiceInitializer
+{
+    private static readonly string _scriptPath = Path.Combine(
+        AppContext.BaseDirectory,
+        "Scripts",
+        "SqlServer",
+        "CommandDeadLetter.sql"
+    );
+
+    public void Configure(IMediatorBuilder mediatorBuilder, IServiceFixture serviceFixture)
+    {
+        ArgumentNullException.ThrowIfNull(serviceFixture);
+        _ = mediatorBuilder.AddSqlServerCommandDeadLetterStore(options =>
+            options.ConnectionString = serviceFixture.ConnectionString
+        );
+    }
+
+    public async ValueTask CreateDatabaseAsync(IServiceProvider serviceProvider, CancellationToken cancellationToken)
+    {
+        var options = serviceProvider.GetRequiredService<IOptions<CommandDeadLetterOptions>>().Value;
+
+        var connectionString =
+            options.ConnectionString
+            ?? throw new InvalidOperationException("CommandDeadLetterOptions.ConnectionString is not configured.");
+
+        var schema = string.IsNullOrWhiteSpace(options.Schema) ? CommandDeadLetterSchema.DefaultSchema : options.Schema;
+
+        var tableName = string.IsNullOrWhiteSpace(options.TableName)
+            ? CommandDeadLetterSchema.DefaultTableName
+            : options.TableName;
+
+        var script = await File.ReadAllTextAsync(_scriptPath, cancellationToken).ConfigureAwait(false);
+
+        // Remove SQLCMD-specific variable declarations (not valid T-SQL)
+        script = SearchSetVar().Replace(script, string.Empty);
+
+        // Substitute SQLCMD variables with actual values
+        script = script
+            .Replace("$(SchemaName)", schema, StringComparison.Ordinal)
+            .Replace("$(TableName)", tableName, StringComparison.Ordinal);
+
+        // Split on GO (on its own line) and execute each batch independently
+        var batches = SearchGoStatements().Split(script);
+
+        var connection = new SqlConnection(connectionString);
+        await using (connection.ConfigureAwait(false))
+        {
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            foreach (var batch in batches)
+            {
+                var trimmed = batch.Trim();
+                if (string.IsNullOrWhiteSpace(trimmed))
+                {
+                    continue;
+                }
+
+                var command = new SqlCommand(trimmed, connection);
+                await using (command.ConfigureAwait(false))
+                {
+                    _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+    }
+
+    public void Initialize(IServiceCollection services, IServiceFixture serviceFixture) { }
+
+    [GeneratedRegex(@"^:setvar\s+\w+\s+.*$", RegexOptions.Multiline, 10000)]
+    private static partial Regex SearchSetVar();
+
+    [GeneratedRegex(@"^\s*GO\s*$", RegexOptions.IgnoreCase | RegexOptions.Multiline, 10000)]
+    private static partial Regex SearchGoStatements();
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/CommandDeadLetterMediatorBuilderExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/CommandDeadLetterMediatorBuilderExtensionsTests.cs
@@ -1,0 +1,79 @@
+namespace NetEvolve.Pulse.Tests.Unit;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Interceptors;
+using NetEvolve.Pulse.Internals;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
+
+[TestGroup("CommandDeadLetter")]
+public sealed class CommandDeadLetterMediatorBuilderExtensionsTests
+{
+    [Test]
+    public async Task AddCommandDeadLetter_NullBuilder_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() => CommandDeadLetterMediatorBuilderExtensions.AddCommandDeadLetter(null!))
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task AddCommandDeadLetter_RegistersRequestInterceptorAsSingleton()
+    {
+        var services = new ServiceCollection();
+        var builder = new MediatorBuilder(services);
+
+        var result = builder.AddCommandDeadLetter();
+
+        _ = await Assert.That(result).IsSameReferenceAs(builder);
+
+        var descriptor = services.FirstOrDefault(d =>
+            d.ServiceType == typeof(IRequestInterceptor<,>)
+            && d.ImplementationType == typeof(CommandDeadLetterInterceptor<,>)
+        );
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor).IsNotNull();
+            _ = await Assert.That(descriptor!.Lifetime).IsEqualTo(ServiceLifetime.Singleton);
+        }
+    }
+
+    [Test]
+    public async Task AddCommandDeadLetter_CalledMultipleTimes_DoesNotDuplicateInterceptor()
+    {
+        var services = new ServiceCollection();
+        var builder = new MediatorBuilder(services);
+
+        _ = builder.AddCommandDeadLetter();
+        _ = builder.AddCommandDeadLetter();
+
+        var descriptors = services
+            .Where(d =>
+                d.ServiceType == typeof(IRequestInterceptor<,>)
+                && d.ImplementationType == typeof(CommandDeadLetterInterceptor<,>)
+            )
+            .ToList();
+
+        _ = await Assert.That(descriptors).HasSingleItem();
+    }
+
+    [Test]
+    public async Task AddCommandDeadLetter_ReturnsSameBuilder()
+    {
+        var services = new ServiceCollection();
+        var builder = new MediatorBuilder(services);
+
+        var result = builder.AddCommandDeadLetter();
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(result).IsSameReferenceAs(builder);
+            _ = await Assert.That(result).IsTypeOf<IMediatorBuilder>();
+        }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/EntityFrameworkCommandDeadLetterManagementTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/EntityFrameworkCommandDeadLetterManagementTests.cs
@@ -1,0 +1,383 @@
+﻿namespace NetEvolve.Pulse.Tests.Unit.EntityFramework;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.DeadLetter;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
+
+[TestGroup("EntityFramework")]
+public sealed class EntityFrameworkCommandDeadLetterManagementTests
+{
+    private static TestCommandDeadLetterDbContext CreateContext(string databaseName)
+    {
+        var options = new DbContextOptionsBuilder<TestCommandDeadLetterDbContext>()
+            .UseInMemoryDatabase(databaseName)
+            .Options;
+        return new TestCommandDeadLetterDbContext(options);
+    }
+
+    private static CommandDeadLetterEntry CreateEntry(
+        CommandDeadLetterStatus status,
+        DateTimeOffset occurredAt,
+        string commandType = "Some.Command",
+        string payload = "{}"
+    ) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            CommandType = commandType,
+            Payload = payload,
+            OccurredAt = occurredAt,
+            AttemptCount = 1,
+            Status = status,
+        };
+
+    [Test]
+    public async Task Constructor_WithNullContext_ThrowsArgumentNullException()
+    {
+        var mediator = new NoOpMediator();
+        var serializer = new PassthroughPayloadSerializer();
+
+        _ = await Assert
+            .That(() =>
+                new EntityFrameworkCommandDeadLetterManagement<TestCommandDeadLetterDbContext>(
+                    null!,
+                    mediator,
+                    serializer
+                )
+            )
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Constructor_WithNullMediator_ThrowsArgumentNullException()
+    {
+        var context = CreateContext(nameof(Constructor_WithNullMediator_ThrowsArgumentNullException));
+        await using (context.ConfigureAwait(false))
+        {
+            var serializer = new PassthroughPayloadSerializer();
+
+            _ = await Assert
+                .That(() =>
+                    new EntityFrameworkCommandDeadLetterManagement<TestCommandDeadLetterDbContext>(
+                        context,
+                        null!,
+                        serializer
+                    )
+                )
+                .Throws<ArgumentNullException>();
+        }
+    }
+
+    [Test]
+    public async Task Constructor_WithNullPayloadSerializer_ThrowsArgumentNullException()
+    {
+        var context = CreateContext(nameof(Constructor_WithNullPayloadSerializer_ThrowsArgumentNullException));
+        await using (context.ConfigureAwait(false))
+        {
+            var mediator = new NoOpMediator();
+
+            _ = await Assert
+                .That(() =>
+                    new EntityFrameworkCommandDeadLetterManagement<TestCommandDeadLetterDbContext>(
+                        context,
+                        mediator,
+                        null!
+                    )
+                )
+                .Throws<ArgumentNullException>();
+        }
+    }
+
+    [Test]
+    public async Task GetPendingAsync_ReturnsOnlyNewStatusEntries_OrderedByOccurredAt(
+        CancellationToken cancellationToken
+    )
+    {
+        var context = CreateContext(nameof(GetPendingAsync_ReturnsOnlyNewStatusEntries_OrderedByOccurredAt));
+        await using (context.ConfigureAwait(false))
+        {
+            var now = DateTimeOffset.UtcNow;
+            var newest = CreateEntry(CommandDeadLetterStatus.New, now);
+            var oldest = CreateEntry(CommandDeadLetterStatus.New, now.AddMinutes(-10));
+            var resolved = CreateEntry(CommandDeadLetterStatus.Resolved, now.AddMinutes(-20));
+
+            await context
+                .CommandDeadLetterEntries.AddRangeAsync([newest, oldest, resolved], cancellationToken)
+                .ConfigureAwait(false);
+            _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            var management = new EntityFrameworkCommandDeadLetterManagement<TestCommandDeadLetterDbContext>(
+                context,
+                new NoOpMediator(),
+                new PassthroughPayloadSerializer()
+            );
+
+            var pending = await management.GetPendingAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            using (Assert.Multiple())
+            {
+                _ = await Assert.That(pending).HasCount(2);
+                _ = await Assert.That(pending[0].Id).IsEqualTo(oldest.Id);
+                _ = await Assert.That(pending[1].Id).IsEqualTo(newest.Id);
+            }
+        }
+    }
+
+    [Test]
+    public async Task GetPendingAsync_HonorsCountParameter(CancellationToken cancellationToken)
+    {
+        var context = CreateContext(nameof(GetPendingAsync_HonorsCountParameter));
+        await using (context.ConfigureAwait(false))
+        {
+            var now = DateTimeOffset.UtcNow;
+            var entries = new List<CommandDeadLetterEntry>();
+            for (var i = 0; i < 5; i++)
+            {
+                entries.Add(CreateEntry(CommandDeadLetterStatus.New, now.AddMinutes(-i)));
+            }
+
+            await context.CommandDeadLetterEntries.AddRangeAsync(entries, cancellationToken).ConfigureAwait(false);
+            _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            var management = new EntityFrameworkCommandDeadLetterManagement<TestCommandDeadLetterDbContext>(
+                context,
+                new NoOpMediator(),
+                new PassthroughPayloadSerializer()
+            );
+
+            var pending = await management.GetPendingAsync(2, cancellationToken).ConfigureAwait(false);
+
+            _ = await Assert.That(pending).HasCount(2);
+        }
+    }
+
+    [Test]
+    public async Task ReplayAsync_WithUnknownId_ThrowsKeyNotFoundException(CancellationToken cancellationToken)
+    {
+        var context = CreateContext(nameof(ReplayAsync_WithUnknownId_ThrowsKeyNotFoundException));
+        await using (context.ConfigureAwait(false))
+        {
+            var management = new EntityFrameworkCommandDeadLetterManagement<TestCommandDeadLetterDbContext>(
+                context,
+                new NoOpMediator(),
+                new PassthroughPayloadSerializer()
+            );
+
+            _ = await Assert
+                .That(async () => await management.ReplayAsync(Guid.NewGuid(), cancellationToken).ConfigureAwait(false))
+                .Throws<KeyNotFoundException>();
+        }
+    }
+
+    [Test]
+    public async Task ReplayAsync_ExecutesHandlerAndResolvesEntry(CancellationToken cancellationToken)
+    {
+        var handler = new TestReplayCommandHandler();
+        var services = new ServiceCollection();
+        _ = services.AddLogging();
+        _ = services.AddPulse();
+        _ = services.AddScoped<ICommandHandler<TestReplayCommand, string>>(_ => handler);
+        var provider = services.BuildServiceProvider();
+        await using (provider.ConfigureAwait(false))
+        {
+            var scope = provider.CreateAsyncScope();
+            await using (scope.ConfigureAwait(false))
+            {
+                var mediator = scope.ServiceProvider.GetRequiredService<IMediatorSendOnly>();
+                var payloadSerializer = scope.ServiceProvider.GetRequiredService<IPayloadSerializer>();
+
+                var context = CreateContext(nameof(ReplayAsync_ExecutesHandlerAndResolvesEntry));
+                await using (context.ConfigureAwait(false))
+                {
+                    var command = new TestReplayCommand { OrderId = 42 };
+                    var payload = payloadSerializer.Serialize(command);
+                    var entry = CreateEntry(
+                        CommandDeadLetterStatus.New,
+                        DateTimeOffset.UtcNow,
+                        typeof(TestReplayCommand).AssemblyQualifiedName!,
+                        payload
+                    );
+                    _ = await context.CommandDeadLetterEntries.AddAsync(entry, cancellationToken);
+                    _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+                    var management = new EntityFrameworkCommandDeadLetterManagement<TestCommandDeadLetterDbContext>(
+                        context,
+                        mediator,
+                        payloadSerializer
+                    );
+
+                    await management.ReplayAsync(entry.Id, cancellationToken).ConfigureAwait(false);
+
+                    var reloaded = await context
+                        .CommandDeadLetterEntries.SingleAsync(e => e.Id == entry.Id, cancellationToken)
+                        .ConfigureAwait(false);
+
+                    using (Assert.Multiple())
+                    {
+                        _ = await Assert.That(reloaded.Status).IsEqualTo(CommandDeadLetterStatus.Resolved);
+                        _ = await Assert.That(handler.HandledCommands).HasSingleItem();
+                        _ = await Assert.That(handler.HandledCommands[0].OrderId).IsEqualTo(42);
+                    }
+                }
+            }
+        }
+    }
+
+    [Test]
+    public async Task DismissAsync_WithUnknownId_ThrowsKeyNotFoundException(CancellationToken cancellationToken)
+    {
+        var context = CreateContext(nameof(DismissAsync_WithUnknownId_ThrowsKeyNotFoundException));
+        await using (context.ConfigureAwait(false))
+        {
+            var management = new EntityFrameworkCommandDeadLetterManagement<TestCommandDeadLetterDbContext>(
+                context,
+                new NoOpMediator(),
+                new PassthroughPayloadSerializer()
+            );
+
+            _ = await Assert
+                .That(async () =>
+                    await management.DismissAsync(Guid.NewGuid(), cancellationToken).ConfigureAwait(false)
+                )
+                .Throws<KeyNotFoundException>();
+        }
+    }
+
+    [Test]
+    public async Task DismissAsync_SetsStatusToDismissed(CancellationToken cancellationToken)
+    {
+        var context = CreateContext(nameof(DismissAsync_SetsStatusToDismissed));
+        await using (context.ConfigureAwait(false))
+        {
+            var entry = CreateEntry(CommandDeadLetterStatus.New, DateTimeOffset.UtcNow);
+            _ = await context.CommandDeadLetterEntries.AddAsync(entry, cancellationToken);
+            _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            var management = new EntityFrameworkCommandDeadLetterManagement<TestCommandDeadLetterDbContext>(
+                context,
+                new NoOpMediator(),
+                new PassthroughPayloadSerializer()
+            );
+
+            await management.DismissAsync(entry.Id, cancellationToken).ConfigureAwait(false);
+
+            var reloaded = await context
+                .CommandDeadLetterEntries.SingleAsync(e => e.Id == entry.Id, cancellationToken)
+                .ConfigureAwait(false);
+
+            _ = await Assert.That(reloaded.Status).IsEqualTo(CommandDeadLetterStatus.Dismissed);
+        }
+    }
+
+    [Test]
+    public async Task GetStatisticsAsync_ReturnsCorrectCountsPerStatus(CancellationToken cancellationToken)
+    {
+        var context = CreateContext(nameof(GetStatisticsAsync_ReturnsCorrectCountsPerStatus));
+        await using (context.ConfigureAwait(false))
+        {
+            var now = DateTimeOffset.UtcNow;
+            var entries = new[]
+            {
+                CreateEntry(CommandDeadLetterStatus.New, now),
+                CreateEntry(CommandDeadLetterStatus.New, now),
+                CreateEntry(CommandDeadLetterStatus.Replaying, now),
+                CreateEntry(CommandDeadLetterStatus.Resolved, now),
+                CreateEntry(CommandDeadLetterStatus.Resolved, now),
+                CreateEntry(CommandDeadLetterStatus.Resolved, now),
+                CreateEntry(CommandDeadLetterStatus.Dismissed, now),
+            };
+
+            await context.CommandDeadLetterEntries.AddRangeAsync(entries, cancellationToken).ConfigureAwait(false);
+            _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            var management = new EntityFrameworkCommandDeadLetterManagement<TestCommandDeadLetterDbContext>(
+                context,
+                new NoOpMediator(),
+                new PassthroughPayloadSerializer()
+            );
+
+            var statistics = await management.GetStatisticsAsync(cancellationToken).ConfigureAwait(false);
+
+            using (Assert.Multiple())
+            {
+                _ = await Assert.That(statistics.NewCount).IsEqualTo(2);
+                _ = await Assert.That(statistics.ReplayingCount).IsEqualTo(1);
+                _ = await Assert.That(statistics.ResolvedCount).IsEqualTo(3);
+                _ = await Assert.That(statistics.DismissedCount).IsEqualTo(1);
+                _ = await Assert.That(statistics.TotalCount).IsEqualTo(7);
+            }
+        }
+    }
+
+    [Test]
+    public async Task GetStatisticsAsync_EmptyDatabase_ReturnsAllZero(CancellationToken cancellationToken)
+    {
+        var context = CreateContext(nameof(GetStatisticsAsync_EmptyDatabase_ReturnsAllZero));
+        await using (context.ConfigureAwait(false))
+        {
+            var management = new EntityFrameworkCommandDeadLetterManagement<TestCommandDeadLetterDbContext>(
+                context,
+                new NoOpMediator(),
+                new PassthroughPayloadSerializer()
+            );
+
+            var statistics = await management.GetStatisticsAsync(cancellationToken).ConfigureAwait(false);
+
+            _ = await Assert.That(statistics.TotalCount).IsEqualTo(0);
+        }
+    }
+
+    private sealed class NoOpMediator : IMediatorSendOnly
+    {
+        public Task PublishAsync<TEvent>([NotNull] TEvent message, CancellationToken cancellationToken = default)
+            where TEvent : IEvent => Task.CompletedTask;
+
+        public Task<TResponse> SendAsync<TCommand, TResponse>(
+            [NotNull] TCommand command,
+            CancellationToken cancellationToken = default
+        )
+            where TCommand : ICommand<TResponse> => Task.FromResult(default(TResponse)!);
+    }
+
+    private sealed class PassthroughPayloadSerializer : IPayloadSerializer
+    {
+        public string Serialize<T>(T value) => value?.ToString() ?? string.Empty;
+
+        public string Serialize(object value, Type type) => value.ToString() ?? string.Empty;
+
+        public byte[] SerializeToBytes<T>(T value) => [];
+
+        public T? Deserialize<T>(string payload) => default;
+
+        public T? Deserialize<T>(byte[] payload) => default;
+    }
+
+    private sealed class TestReplayCommand : ICommand<string>
+    {
+        public int OrderId { get; set; }
+
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed class TestReplayCommandHandler : ICommandHandler<TestReplayCommand, string>
+    {
+        public List<TestReplayCommand> HandledCommands { get; } = [];
+
+        public Task<string> HandleAsync(TestReplayCommand command, CancellationToken cancellationToken = default)
+        {
+            HandledCommands.Add(command);
+            return Task.FromResult("handled");
+        }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/EntityFrameworkCommandDeadLetterStoreTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/EntityFrameworkCommandDeadLetterStoreTests.cs
@@ -1,0 +1,199 @@
+﻿namespace NetEvolve.Pulse.Tests.Unit.EntityFramework;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.DeadLetter;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
+
+[TestGroup("EntityFramework")]
+public sealed class EntityFrameworkCommandDeadLetterStoreTests
+{
+    private static TestCommandDeadLetterDbContext CreateContext(string databaseName)
+    {
+        var options = new DbContextOptionsBuilder<TestCommandDeadLetterDbContext>()
+            .UseInMemoryDatabase(databaseName)
+            .Options;
+        return new TestCommandDeadLetterDbContext(options);
+    }
+
+    private static EntityFrameworkCommandDeadLetterStore<TestCommandDeadLetterDbContext> CreateStore(
+        TestCommandDeadLetterDbContext context
+    ) => new(context);
+
+    [Test]
+    public async Task Constructor_WithNullContext_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() => new EntityFrameworkCommandDeadLetterStore<TestCommandDeadLetterDbContext>(null!))
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Constructor_WithValidContext_CreatesInstance()
+    {
+        var context = CreateContext(nameof(Constructor_WithValidContext_CreatesInstance));
+        await using (context.ConfigureAwait(false))
+        {
+            var store = CreateStore(context);
+
+            _ = await Assert.That(store).IsNotNull();
+        }
+    }
+
+    [Test]
+    public async Task StoreAsync_WithNullCommandType_ThrowsArgumentException(CancellationToken cancellationToken)
+    {
+        var context = CreateContext(nameof(StoreAsync_WithNullCommandType_ThrowsArgumentException));
+        await using (context.ConfigureAwait(false))
+        {
+            var store = CreateStore(context);
+
+            _ = await Assert
+                .That(async () =>
+                    await store
+                        .StoreAsync(null!, "{}", new InvalidOperationException("boom"), cancellationToken)
+                        .ConfigureAwait(false)
+                )
+                .Throws<ArgumentException>();
+        }
+    }
+
+    [Test]
+    public async Task StoreAsync_WithNullPayload_ThrowsArgumentException(CancellationToken cancellationToken)
+    {
+        var context = CreateContext(nameof(StoreAsync_WithNullPayload_ThrowsArgumentException));
+        await using (context.ConfigureAwait(false))
+        {
+            var store = CreateStore(context);
+
+            _ = await Assert
+                .That(async () =>
+                    await store
+                        .StoreAsync("Some.Command", null!, new InvalidOperationException("boom"), cancellationToken)
+                        .ConfigureAwait(false)
+                )
+                .Throws<ArgumentException>();
+        }
+    }
+
+    [Test]
+    public async Task StoreAsync_WithNullException_ThrowsArgumentNullException(CancellationToken cancellationToken)
+    {
+        var context = CreateContext(nameof(StoreAsync_WithNullException_ThrowsArgumentNullException));
+        await using (context.ConfigureAwait(false))
+        {
+            var store = CreateStore(context);
+
+            _ = await Assert
+                .That(async () =>
+                    await store.StoreAsync("Some.Command", "{}", null!, cancellationToken).ConfigureAwait(false)
+                )
+                .Throws<ArgumentNullException>();
+        }
+    }
+
+    [Test]
+    public async Task StoreAsync_WithValidArguments_StoresNewEntryWithAllFieldsPopulated(
+        CancellationToken cancellationToken
+    )
+    {
+        var context = CreateContext(nameof(StoreAsync_WithValidArguments_StoresNewEntryWithAllFieldsPopulated));
+        await using (context.ConfigureAwait(false))
+        {
+            var store = CreateStore(context);
+            var exception = new InvalidOperationException("Something went wrong");
+
+            await store
+                .StoreAsync("MyApp.Commands.CreateOrderCommand", "{\"orderId\":42}", exception, cancellationToken)
+                .ConfigureAwait(false);
+
+            var entry = await context.CommandDeadLetterEntries.SingleAsync(cancellationToken).ConfigureAwait(false);
+
+            using (Assert.Multiple())
+            {
+                _ = await Assert.That(entry.Id).IsNotEqualTo(Guid.Empty);
+                _ = await Assert.That(entry.CommandType).IsEqualTo("MyApp.Commands.CreateOrderCommand");
+                _ = await Assert.That(entry.Payload).IsEqualTo("{\"orderId\":42}");
+                _ = await Assert.That(entry.ExceptionType).IsEqualTo(exception.GetType().AssemblyQualifiedName);
+                _ = await Assert.That(entry.ExceptionMessage).IsEqualTo("Something went wrong");
+                _ = await Assert.That(entry.AttemptCount).IsEqualTo(1);
+                _ = await Assert.That(entry.Status).IsEqualTo(CommandDeadLetterStatus.New);
+            }
+        }
+    }
+
+    [Test]
+    public async Task StoreAsync_CalledTwice_StoresTwoDistinctEntries(CancellationToken cancellationToken)
+    {
+        var context = CreateContext(nameof(StoreAsync_CalledTwice_StoresTwoDistinctEntries));
+        await using (context.ConfigureAwait(false))
+        {
+            var store = CreateStore(context);
+            var exception = new InvalidOperationException("boom");
+
+            await store.StoreAsync("Some.Command", "{}", exception, cancellationToken).ConfigureAwait(false);
+            await store.StoreAsync("Some.Command", "{}", exception, cancellationToken).ConfigureAwait(false);
+
+            var count = await context.CommandDeadLetterEntries.CountAsync(cancellationToken).ConfigureAwait(false);
+            _ = await Assert.That(count).IsEqualTo(2);
+        }
+    }
+
+    [Test]
+    public async Task IsDuplicateKeyException_WithInMemoryArgumentException_ReturnsTrue()
+    {
+        var ex = new ArgumentException("An item with the same key has already been added. Key: some-id");
+
+        var result = EntityFrameworkCommandDeadLetterStore<TestCommandDeadLetterDbContext>.IsDuplicateKeyException(ex);
+
+        _ = await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task IsDuplicateKeyException_WithUnrelatedArgumentException_ReturnsFalse()
+    {
+        var ex = new ArgumentException("Value does not fall within the expected range.");
+
+        var result = EntityFrameworkCommandDeadLetterStore<TestCommandDeadLetterDbContext>.IsDuplicateKeyException(ex);
+
+        _ = await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task IsDuplicateKeyException_WithDbUpdateExceptionContainingSqlServer2627_ReturnsTrue()
+    {
+        var inner = new InvalidOperationException(
+            "Violation of PRIMARY KEY constraint 'PK_pulse_CommandDeadLetter'. Cannot insert duplicate key in object 'pulse.CommandDeadLetter'. The duplicate key value is (id). The statement has been terminated."
+        );
+        var ex = new DbUpdateException("An error occurred", inner);
+
+        var result = EntityFrameworkCommandDeadLetterStore<TestCommandDeadLetterDbContext>.IsDuplicateKeyException(ex);
+
+        _ = await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task IsDuplicateKeyException_WithDbUpdateExceptionContainingPostgres23505_ReturnsTrue()
+    {
+        var inner = new InvalidOperationException("23505: duplicate key value violates unique constraint");
+        var ex = new DbUpdateException("An error occurred", inner);
+
+        var result = EntityFrameworkCommandDeadLetterStore<TestCommandDeadLetterDbContext>.IsDuplicateKeyException(ex);
+
+        _ = await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task IsDuplicateKeyException_WithUnrelatedExceptionType_ReturnsFalse()
+    {
+        var ex = new InvalidOperationException("Something went wrong");
+
+        var result = EntityFrameworkCommandDeadLetterStore<TestCommandDeadLetterDbContext>.IsDuplicateKeyException(ex);
+
+        _ = await Assert.That(result).IsFalse();
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/TestCommandDeadLetterDbContext.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/TestCommandDeadLetterDbContext.cs
@@ -1,0 +1,29 @@
+﻿namespace NetEvolve.Pulse.Tests.Unit.EntityFramework;
+
+using Microsoft.EntityFrameworkCore;
+using NetEvolve.Pulse.DeadLetter;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+
+/// <summary>
+/// Minimal <see cref="DbContext"/> used in unit tests to verify Entity Framework command dead letter
+/// behaviour without requiring a real database provider.
+/// </summary>
+internal sealed class TestCommandDeadLetterDbContext : DbContext, ICommandDeadLetterDbContext
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TestCommandDeadLetterDbContext"/> class.
+    /// </summary>
+    /// <param name="options">The options for this context.</param>
+    public TestCommandDeadLetterDbContext(DbContextOptions<TestCommandDeadLetterDbContext> options)
+        : base(options) { }
+
+    /// <inheritdoc />
+    public DbSet<CommandDeadLetterEntry> CommandDeadLetterEntries => Set<CommandDeadLetterEntry>();
+
+    /// <inheritdoc />
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        _ = modelBuilder.ApplyPulseConfiguration(this);
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/CommandDeadLetterInterceptorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/CommandDeadLetterInterceptorTests.cs
@@ -1,0 +1,191 @@
+namespace NetEvolve.Pulse.Tests.Unit.Interceptors;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+using NetEvolve.Pulse.Interceptors;
+using NetEvolve.Pulse.Serialization;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
+
+[SuppressMessage(
+    "IDisposableAnalyzers.Correctness",
+    "CA2000:Dispose objects before losing scope",
+    Justification = "ServiceProvider instances are short-lived within test methods"
+)]
+[TestGroup("Interceptors")]
+public sealed class CommandDeadLetterInterceptorTests
+{
+    private static IPayloadSerializer DefaultSerializer =>
+        new SystemTextJsonPayloadSerializer(Options.Create(JsonSerializerOptions.Default));
+
+    [Test]
+    public async Task Constructor_NullServiceProvider_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() => new CommandDeadLetterInterceptor<TestCommand, string>(null!, DefaultSerializer))
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Constructor_NullPayloadSerializer_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() =>
+                new CommandDeadLetterInterceptor<TestCommand, string>(
+                    new ServiceCollection().BuildServiceProvider(),
+                    null!
+                )
+            )
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task HandleAsync_FailingCommandWithStoreRegistered_StoresEntryAndRethrows(
+        CancellationToken cancellationToken
+    )
+    {
+        var store = new FakeCommandDeadLetterStore();
+        var services = new ServiceCollection();
+        _ = services.AddSingleton<ICommandDeadLetterStore>(store);
+        var provider = services.BuildServiceProvider();
+        var interceptor = new CommandDeadLetterInterceptor<TestCommand, string>(provider, DefaultSerializer);
+        var command = new TestCommand { Value = "payload-value" };
+        var thrown = new InvalidOperationException("handler failed");
+
+        _ = await Assert
+            .That(async () =>
+                await interceptor
+                    .HandleAsync(command, (_, _) => Task.FromException<string>(thrown), cancellationToken)
+                    .ConfigureAwait(false)
+            )
+            .Throws<InvalidOperationException>();
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(store.StoreCallCount).IsEqualTo(1);
+            _ = await Assert.That(store.LastCommandType).IsEqualTo(typeof(TestCommand).AssemblyQualifiedName);
+            _ = await Assert.That(store.LastPayload).Contains("payload-value");
+            _ = await Assert.That(store.LastException).IsSameReferenceAs(thrown);
+        }
+    }
+
+    [Test]
+    public async Task HandleAsync_SuccessfulCommand_NeverCallsStoreAsync(CancellationToken cancellationToken)
+    {
+        var store = new FakeCommandDeadLetterStore();
+        var services = new ServiceCollection();
+        _ = services.AddSingleton<ICommandDeadLetterStore>(store);
+        var provider = services.BuildServiceProvider();
+        var interceptor = new CommandDeadLetterInterceptor<TestCommand, string>(provider, DefaultSerializer);
+        var command = new TestCommand { Value = "ok" };
+
+        var result = await interceptor
+            .HandleAsync(command, (_, _) => Task.FromResult("response"), cancellationToken)
+            .ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(result).IsEqualTo("response");
+            _ = await Assert.That(store.StoreCallCount).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task HandleAsync_NoStoreRegistered_FailingCommandStillRethrowsWithoutError(
+        CancellationToken cancellationToken
+    )
+    {
+        var provider = new ServiceCollection().BuildServiceProvider();
+        var interceptor = new CommandDeadLetterInterceptor<TestCommand, string>(provider, DefaultSerializer);
+        var command = new TestCommand { Value = "no-store" };
+        var thrown = new InvalidOperationException("handler failed without store");
+
+        _ = await Assert
+            .That(async () =>
+                await interceptor
+                    .HandleAsync(command, (_, _) => Task.FromException<string>(thrown), cancellationToken)
+                    .ConfigureAwait(false)
+            )
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task HandleAsync_FailingQuery_IsNotInterceptedAndStoreIsNeverCalled(
+        CancellationToken cancellationToken
+    )
+    {
+        var store = new FakeCommandDeadLetterStore();
+        var services = new ServiceCollection();
+        _ = services.AddSingleton<ICommandDeadLetterStore>(store);
+        var provider = services.BuildServiceProvider();
+        var interceptor = new CommandDeadLetterInterceptor<TestQuery, string>(provider, DefaultSerializer);
+        var query = new TestQuery();
+        var thrown = new InvalidOperationException("query handler failed");
+
+        _ = await Assert
+            .That(async () =>
+                await interceptor
+                    .HandleAsync(query, (_, _) => Task.FromException<string>(thrown), cancellationToken)
+                    .ConfigureAwait(false)
+            )
+            .Throws<InvalidOperationException>();
+
+        _ = await Assert.That(store.StoreCallCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task HandleAsync_FailingQuery_NoStoreRegistered_StillRethrows(CancellationToken cancellationToken)
+    {
+        var provider = new ServiceCollection().BuildServiceProvider();
+        var interceptor = new CommandDeadLetterInterceptor<TestQuery, string>(provider, DefaultSerializer);
+        var query = new TestQuery();
+        var thrown = new InvalidOperationException("query handler failed without store");
+
+        _ = await Assert
+            .That(async () =>
+                await interceptor
+                    .HandleAsync(query, (_, _) => Task.FromException<string>(thrown), cancellationToken)
+                    .ConfigureAwait(false)
+            )
+            .Throws<InvalidOperationException>();
+    }
+
+    private sealed record TestCommand : ICommand<string>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+        public string Value { get; init; } = string.Empty;
+    }
+
+    private sealed record TestQuery : IQuery<string>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed class FakeCommandDeadLetterStore : ICommandDeadLetterStore
+    {
+        public int StoreCallCount { get; private set; }
+        public string? LastCommandType { get; private set; }
+        public string? LastPayload { get; private set; }
+        public Exception? LastException { get; private set; }
+
+        public Task StoreAsync(
+            string commandType,
+            string payload,
+            Exception exception,
+            CancellationToken cancellationToken = default
+        )
+        {
+            StoreCallCount++;
+            LastCommandType = commandType;
+            LastPayload = payload;
+            LastException = exception;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/MySql/MySqlCommandDeadLetterTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/MySql/MySqlCommandDeadLetterTests.cs
@@ -1,0 +1,277 @@
+namespace NetEvolve.Pulse.Tests.Unit.MySql;
+
+using System;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.DeadLetter;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+using TUnit.Core;
+using TUnit.Mocks;
+
+[TestGroup("MySql")]
+public sealed class MySqlCommandDeadLetterTests
+{
+    private const string ValidConnectionString = "Server=localhost;Database=Test;Uid=root;Pwd=secret;";
+
+    [Test]
+    public async Task Store_Constructor_WithNullOptions_ThrowsArgumentNullException() =>
+        _ = await Assert.That(() => new MySqlCommandDeadLetterStore(null!)).Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Store_Constructor_WithNullConnectionString_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() =>
+                new MySqlCommandDeadLetterStore(
+                    Options.Create(new CommandDeadLetterOptions { ConnectionString = null })
+                )
+            )
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Store_Constructor_WithEmptyConnectionString_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() =>
+                new MySqlCommandDeadLetterStore(
+                    Options.Create(new CommandDeadLetterOptions { ConnectionString = string.Empty })
+                )
+            )
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task Store_Constructor_WithWhitespaceConnectionString_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() =>
+                new MySqlCommandDeadLetterStore(
+                    Options.Create(new CommandDeadLetterOptions { ConnectionString = "   " })
+                )
+            )
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task Store_Constructor_WithValidConnectionString_CreatesInstance()
+    {
+        var store = new MySqlCommandDeadLetterStore(
+            Options.Create(new CommandDeadLetterOptions { ConnectionString = ValidConnectionString })
+        );
+
+        _ = await Assert.That(store).IsNotNull();
+    }
+
+    [Test]
+    public async Task Store_Constructor_WithCustomTableName_CreatesInstance()
+    {
+        var options = new CommandDeadLetterOptions
+        {
+            ConnectionString = ValidConnectionString,
+            TableName = "CustomCommandDeadLetter",
+        };
+
+        var store = new MySqlCommandDeadLetterStore(Options.Create(options));
+
+        _ = await Assert.That(store).IsNotNull();
+    }
+
+    [Test]
+    public async Task Management_Constructor_WithNullOptions_ThrowsArgumentNullException()
+    {
+        var mediator = Mock.Of<IMediatorSendOnly>();
+        var serializer = Mock.Of<IPayloadSerializer>();
+
+        _ = await Assert
+            .That(() => new MySqlCommandDeadLetterManagement(null!, mediator.Object, serializer.Object))
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Management_Constructor_WithNullConnectionString_ThrowsArgumentNullException()
+    {
+        var mediator = Mock.Of<IMediatorSendOnly>();
+        var serializer = Mock.Of<IPayloadSerializer>();
+
+        _ = await Assert
+            .That(() =>
+                new MySqlCommandDeadLetterManagement(
+                    Options.Create(new CommandDeadLetterOptions { ConnectionString = null }),
+                    mediator.Object,
+                    serializer.Object
+                )
+            )
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Management_Constructor_WithEmptyConnectionString_ThrowsArgumentException()
+    {
+        var mediator = Mock.Of<IMediatorSendOnly>();
+        var serializer = Mock.Of<IPayloadSerializer>();
+
+        _ = await Assert
+            .That(() =>
+                new MySqlCommandDeadLetterManagement(
+                    Options.Create(new CommandDeadLetterOptions { ConnectionString = string.Empty }),
+                    mediator.Object,
+                    serializer.Object
+                )
+            )
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task Management_Constructor_WithWhitespaceConnectionString_ThrowsArgumentException()
+    {
+        var mediator = Mock.Of<IMediatorSendOnly>();
+        var serializer = Mock.Of<IPayloadSerializer>();
+
+        _ = await Assert
+            .That(() =>
+                new MySqlCommandDeadLetterManagement(
+                    Options.Create(new CommandDeadLetterOptions { ConnectionString = "   " }),
+                    mediator.Object,
+                    serializer.Object
+                )
+            )
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task Management_Constructor_WithNullMediator_ThrowsArgumentNullException()
+    {
+        var serializer = Mock.Of<IPayloadSerializer>();
+
+        _ = await Assert
+            .That(() =>
+                new MySqlCommandDeadLetterManagement(
+                    Options.Create(new CommandDeadLetterOptions { ConnectionString = ValidConnectionString }),
+                    null!,
+                    serializer.Object
+                )
+            )
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Management_Constructor_WithNullPayloadSerializer_ThrowsArgumentNullException()
+    {
+        var mediator = Mock.Of<IMediatorSendOnly>();
+
+        _ = await Assert
+            .That(() =>
+                new MySqlCommandDeadLetterManagement(
+                    Options.Create(new CommandDeadLetterOptions { ConnectionString = ValidConnectionString }),
+                    mediator.Object,
+                    null!
+                )
+            )
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Management_Constructor_WithValidArguments_CreatesInstance()
+    {
+        var mediator = Mock.Of<IMediatorSendOnly>();
+        var serializer = Mock.Of<IPayloadSerializer>();
+
+        var management = new MySqlCommandDeadLetterManagement(
+            Options.Create(new CommandDeadLetterOptions { ConnectionString = ValidConnectionString }),
+            mediator.Object,
+            serializer.Object
+        );
+
+        _ = await Assert.That(management).IsNotNull();
+    }
+
+    [Test]
+    public async Task AddMySqlCommandDeadLetterStore_WithNullConfigurator_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() =>
+                MySqlCommandDeadLetterMediatorBuilderExtensions.AddMySqlCommandDeadLetterStore(
+                    null!,
+                    opts => opts.ConnectionString = ValidConnectionString
+                )
+            )
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task AddMySqlCommandDeadLetterStore_WithNullConfigureOptions_ThrowsArgumentNullException()
+    {
+        var mock = Mock.Of<IMediatorBuilder>();
+        _ = mock.Services.Returns(new ServiceCollection());
+
+        _ = await Assert.That(() => mock.Object.AddMySqlCommandDeadLetterStore(null!)).Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task AddMySqlCommandDeadLetterStore_WithValidOptions_ReturnsConfiguratorForChaining()
+    {
+        var mock = Mock.Of<IMediatorBuilder>();
+        _ = mock.Services.Returns(new ServiceCollection());
+
+        var result = mock.Object.AddMySqlCommandDeadLetterStore(opts => opts.ConnectionString = ValidConnectionString);
+
+        _ = await Assert.That(result).IsSameReferenceAs(mock.Object);
+    }
+
+    [Test]
+    public async Task AddMySqlCommandDeadLetterStore_RegistersCommandDeadLetterStoreAsScoped()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddPulse(config =>
+            config.AddMySqlCommandDeadLetterStore(opts => opts.ConnectionString = ValidConnectionString)
+        );
+
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(ICommandDeadLetterStore));
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor).IsNotNull();
+            _ = await Assert.That(descriptor!.Lifetime).IsEqualTo(ServiceLifetime.Scoped);
+            _ = await Assert.That(descriptor.ImplementationType).IsEqualTo(typeof(MySqlCommandDeadLetterStore));
+        }
+    }
+
+    [Test]
+    public async Task AddMySqlCommandDeadLetterStore_RegistersCommandDeadLetterManagementAsScoped()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddPulse(config =>
+            config.AddMySqlCommandDeadLetterStore(opts => opts.ConnectionString = ValidConnectionString)
+        );
+
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(ICommandDeadLetterManagement));
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor).IsNotNull();
+            _ = await Assert.That(descriptor!.Lifetime).IsEqualTo(ServiceLifetime.Scoped);
+            _ = await Assert.That(descriptor.ImplementationType).IsEqualTo(typeof(MySqlCommandDeadLetterManagement));
+        }
+    }
+
+    [Test]
+    public async Task AddMySqlCommandDeadLetterStore_WithConfigureOptions_AppliesOptions()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddPulse(config =>
+            config.AddMySqlCommandDeadLetterStore(opts =>
+            {
+                opts.ConnectionString = ValidConnectionString;
+                opts.TableName = "CustomCommandDeadLetter";
+            })
+        );
+
+        var provider = services.BuildServiceProvider();
+        await using (provider.ConfigureAwait(false))
+        {
+            var options = provider.GetRequiredService<IOptions<CommandDeadLetterOptions>>();
+
+            using (Assert.Multiple())
+            {
+                _ = await Assert.That(options.Value.ConnectionString).IsEqualTo(ValidConnectionString);
+                _ = await Assert.That(options.Value.TableName).IsEqualTo("CustomCommandDeadLetter");
+            }
+        }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/PostgreSql/PostgreSqlCommandDeadLetterTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/PostgreSql/PostgreSqlCommandDeadLetterTests.cs
@@ -1,0 +1,272 @@
+namespace NetEvolve.Pulse.Tests.Unit.PostgreSql;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.DeadLetter;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+using TUnit.Core;
+using TUnit.Mocks;
+
+[TestGroup("PostgreSql")]
+public sealed class PostgreSqlCommandDeadLetterTests
+{
+    private const string ValidConnectionString = "Host=localhost;Database=Test;Username=postgres;Password=secret;";
+
+    [Test]
+    public async Task Store_Constructor_WithNullOptions_ThrowsArgumentNullException() =>
+        _ = await Assert.That(() => new PostgreSqlCommandDeadLetterStore(null!)).Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Store_Constructor_WithNullConnectionString_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() =>
+                new PostgreSqlCommandDeadLetterStore(
+                    Options.Create(new CommandDeadLetterOptions { ConnectionString = null })
+                )
+            )
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Store_Constructor_WithEmptyConnectionString_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() =>
+                new PostgreSqlCommandDeadLetterStore(
+                    Options.Create(new CommandDeadLetterOptions { ConnectionString = string.Empty })
+                )
+            )
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task Store_Constructor_WithWhitespaceConnectionString_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() =>
+                new PostgreSqlCommandDeadLetterStore(
+                    Options.Create(new CommandDeadLetterOptions { ConnectionString = "   " })
+                )
+            )
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task Store_Constructor_WithValidConnectionString_CreatesInstance()
+    {
+        var options = new CommandDeadLetterOptions { ConnectionString = ValidConnectionString };
+
+        var store = new PostgreSqlCommandDeadLetterStore(Options.Create(options));
+
+        _ = await Assert.That(store).IsNotNull();
+    }
+
+    [Test]
+    public async Task Store_Constructor_WithCustomSchemaAndTableName_CreatesInstance()
+    {
+        var options = new CommandDeadLetterOptions
+        {
+            ConnectionString = ValidConnectionString,
+            Schema = "custom",
+            TableName = "CustomDeadLetter",
+        };
+
+        var store = new PostgreSqlCommandDeadLetterStore(Options.Create(options));
+
+        _ = await Assert.That(store).IsNotNull();
+    }
+
+    [Test]
+    public async Task Store_Constructor_WithNullSchema_CreatesInstance()
+    {
+        var options = new CommandDeadLetterOptions { ConnectionString = ValidConnectionString, Schema = null };
+
+        var store = new PostgreSqlCommandDeadLetterStore(Options.Create(options));
+
+        _ = await Assert.That(store).IsNotNull();
+    }
+
+    [Test]
+    public async Task Management_Constructor_WithNullOptions_ThrowsArgumentNullException()
+    {
+        var mediator = Mock.Of<IMediatorSendOnly>();
+        var serializer = Mock.Of<IPayloadSerializer>();
+
+        _ = await Assert
+            .That(() => new PostgreSqlCommandDeadLetterManagement(null!, mediator.Object, serializer.Object))
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Management_Constructor_WithNullMediator_ThrowsArgumentNullException()
+    {
+        var options = Options.Create(new CommandDeadLetterOptions { ConnectionString = ValidConnectionString });
+        var serializer = Mock.Of<IPayloadSerializer>();
+
+        _ = await Assert
+            .That(() => new PostgreSqlCommandDeadLetterManagement(options, null!, serializer.Object))
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Management_Constructor_WithNullPayloadSerializer_ThrowsArgumentNullException()
+    {
+        var options = Options.Create(new CommandDeadLetterOptions { ConnectionString = ValidConnectionString });
+        var mediator = Mock.Of<IMediatorSendOnly>();
+
+        _ = await Assert
+            .That(() => new PostgreSqlCommandDeadLetterManagement(options, mediator.Object, null!))
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Management_Constructor_WithNullConnectionString_ThrowsArgumentNullException()
+    {
+        var options = Options.Create(new CommandDeadLetterOptions { ConnectionString = null });
+        var mediator = Mock.Of<IMediatorSendOnly>();
+        var serializer = Mock.Of<IPayloadSerializer>();
+
+        _ = await Assert
+            .That(() => new PostgreSqlCommandDeadLetterManagement(options, mediator.Object, serializer.Object))
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Management_Constructor_WithEmptyConnectionString_ThrowsArgumentException()
+    {
+        var options = Options.Create(new CommandDeadLetterOptions { ConnectionString = string.Empty });
+        var mediator = Mock.Of<IMediatorSendOnly>();
+        var serializer = Mock.Of<IPayloadSerializer>();
+
+        _ = await Assert
+            .That(() => new PostgreSqlCommandDeadLetterManagement(options, mediator.Object, serializer.Object))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task Management_Constructor_WithWhitespaceConnectionString_ThrowsArgumentException()
+    {
+        var options = Options.Create(new CommandDeadLetterOptions { ConnectionString = "   " });
+        var mediator = Mock.Of<IMediatorSendOnly>();
+        var serializer = Mock.Of<IPayloadSerializer>();
+
+        _ = await Assert
+            .That(() => new PostgreSqlCommandDeadLetterManagement(options, mediator.Object, serializer.Object))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task Management_Constructor_WithValidArguments_CreatesInstance()
+    {
+        var options = Options.Create(new CommandDeadLetterOptions { ConnectionString = ValidConnectionString });
+        var mediator = Mock.Of<IMediatorSendOnly>();
+        var serializer = Mock.Of<IPayloadSerializer>();
+
+        var management = new PostgreSqlCommandDeadLetterManagement(options, mediator.Object, serializer.Object);
+
+        _ = await Assert.That(management).IsNotNull();
+    }
+
+    [Test]
+    public async Task AddPostgreSqlCommandDeadLetterStore_WithNullConfigurator_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() =>
+                PostgreSqlCommandDeadLetterMediatorBuilderExtensions.AddPostgreSqlCommandDeadLetterStore(
+                    null!,
+                    opts => opts.ConnectionString = ValidConnectionString
+                )
+            )
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task AddPostgreSqlCommandDeadLetterStore_WithNullConfigureOptions_ThrowsArgumentNullException()
+    {
+        var mock = Mock.Of<IMediatorBuilder>();
+        _ = mock.Services.Returns(new ServiceCollection());
+
+        _ = await Assert
+            .That(() => mock.Object.AddPostgreSqlCommandDeadLetterStore(null!))
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task AddPostgreSqlCommandDeadLetterStore_WithValidOptions_ReturnsConfiguratorForChaining()
+    {
+        var mock = Mock.Of<IMediatorBuilder>();
+        _ = mock.Services.Returns(new ServiceCollection());
+
+        var result = mock.Object.AddPostgreSqlCommandDeadLetterStore(opts =>
+            opts.ConnectionString = ValidConnectionString
+        );
+
+        _ = await Assert.That(result).IsSameReferenceAs(mock.Object);
+    }
+
+    [Test]
+    public async Task AddPostgreSqlCommandDeadLetterStore_RegistersCommandDeadLetterStoreAsScoped()
+    {
+        var mock = Mock.Of<IMediatorBuilder>();
+        var services = new ServiceCollection();
+        _ = mock.Services.Returns(services);
+
+        _ = mock.Object.AddPostgreSqlCommandDeadLetterStore(opts => opts.ConnectionString = ValidConnectionString);
+
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(ICommandDeadLetterStore));
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor).IsNotNull();
+            _ = await Assert.That(descriptor!.Lifetime).IsEqualTo(ServiceLifetime.Scoped);
+            _ = await Assert.That(descriptor.ImplementationType).IsEqualTo(typeof(PostgreSqlCommandDeadLetterStore));
+        }
+    }
+
+    [Test]
+    public async Task AddPostgreSqlCommandDeadLetterStore_RegistersCommandDeadLetterManagementAsScoped()
+    {
+        var mock = Mock.Of<IMediatorBuilder>();
+        var services = new ServiceCollection();
+        _ = mock.Services.Returns(services);
+
+        _ = mock.Object.AddPostgreSqlCommandDeadLetterStore(opts => opts.ConnectionString = ValidConnectionString);
+
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(ICommandDeadLetterManagement));
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor).IsNotNull();
+            _ = await Assert.That(descriptor!.Lifetime).IsEqualTo(ServiceLifetime.Scoped);
+            _ = await Assert
+                .That(descriptor.ImplementationType)
+                .IsEqualTo(typeof(PostgreSqlCommandDeadLetterManagement));
+        }
+    }
+
+    [Test]
+    public async Task AddPostgreSqlCommandDeadLetterStore_AppliesOptions()
+    {
+        var mock = Mock.Of<IMediatorBuilder>();
+        var services = new ServiceCollection();
+        _ = mock.Services.Returns(services);
+
+        _ = mock.Object.AddPostgreSqlCommandDeadLetterStore(opts =>
+        {
+            opts.ConnectionString = ValidConnectionString;
+            opts.Schema = "custom";
+            opts.TableName = "CustomDeadLetter";
+        });
+
+        var provider = services.BuildServiceProvider();
+        await using (provider.ConfigureAwait(false))
+        {
+            var options = provider.GetRequiredService<IOptions<CommandDeadLetterOptions>>();
+
+            using (Assert.Multiple())
+            {
+                _ = await Assert.That(options.Value.ConnectionString).IsEqualTo(ValidConnectionString);
+                _ = await Assert.That(options.Value.Schema).IsEqualTo("custom");
+                _ = await Assert.That(options.Value.TableName).IsEqualTo("CustomDeadLetter");
+            }
+        }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/SQLite/SQLiteCommandDeadLetterTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/SQLite/SQLiteCommandDeadLetterTests.cs
@@ -1,0 +1,293 @@
+namespace NetEvolve.Pulse.Tests.Unit.SQLite;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse;
+using NetEvolve.Pulse.DeadLetter;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+using TUnit.Core;
+using TUnit.Mocks;
+
+[TestGroup("SQLite")]
+public sealed class SQLiteCommandDeadLetterTests
+{
+    private const string ValidConnectionString = "Data Source=:memory:";
+
+    [Test]
+    public async Task Store_Constructor_WithNullOptions_ThrowsArgumentNullException() =>
+        _ = await Assert.That(() => new SQLiteCommandDeadLetterStore(null!)).Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Store_Constructor_WithNullConnectionString_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() =>
+                new SQLiteCommandDeadLetterStore(
+                    Options.Create(new CommandDeadLetterOptions { ConnectionString = null })
+                )
+            )
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Store_Constructor_WithEmptyConnectionString_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() =>
+                new SQLiteCommandDeadLetterStore(
+                    Options.Create(new CommandDeadLetterOptions { ConnectionString = string.Empty })
+                )
+            )
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task Store_Constructor_WithWhitespaceConnectionString_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() =>
+                new SQLiteCommandDeadLetterStore(
+                    Options.Create(new CommandDeadLetterOptions { ConnectionString = "   " })
+                )
+            )
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task Store_Constructor_WithValidConnectionString_CreatesInstance()
+    {
+        var options = new CommandDeadLetterOptions { ConnectionString = ValidConnectionString };
+
+        var store = new SQLiteCommandDeadLetterStore(Options.Create(options));
+
+        _ = await Assert.That(store).IsNotNull();
+    }
+
+    [Test]
+    public async Task Store_Constructor_WithCustomTableName_CreatesInstance()
+    {
+        var options = new CommandDeadLetterOptions
+        {
+            ConnectionString = ValidConnectionString,
+            TableName = "CustomCommandDeadLetter",
+        };
+
+        var store = new SQLiteCommandDeadLetterStore(Options.Create(options));
+
+        _ = await Assert.That(store).IsNotNull();
+    }
+
+    [Test]
+    public async Task Store_Constructor_WithWalModeDisabled_CreatesInstance()
+    {
+        var options = new CommandDeadLetterOptions { ConnectionString = ValidConnectionString, EnableWalMode = false };
+
+        var store = new SQLiteCommandDeadLetterStore(Options.Create(options));
+
+        _ = await Assert.That(store).IsNotNull();
+    }
+
+    [Test]
+    public async Task Store_Constructor_WithInvalidTableName_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() =>
+                new SQLiteCommandDeadLetterStore(
+                    Options.Create(
+                        new CommandDeadLetterOptions
+                        {
+                            ConnectionString = ValidConnectionString,
+                            TableName = "1invalid",
+                        }
+                    )
+                )
+            )
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task Management_Constructor_WithNullOptions_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() =>
+                new SQLiteCommandDeadLetterManagement(
+                    null!,
+                    Mock.Of<IMediatorSendOnly>().Object,
+                    Mock.Of<IPayloadSerializer>().Object
+                )
+            )
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Management_Constructor_WithNullMediator_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() =>
+                new SQLiteCommandDeadLetterManagement(
+                    Options.Create(new CommandDeadLetterOptions { ConnectionString = ValidConnectionString }),
+                    null!,
+                    Mock.Of<IPayloadSerializer>().Object
+                )
+            )
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Management_Constructor_WithNullPayloadSerializer_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() =>
+                new SQLiteCommandDeadLetterManagement(
+                    Options.Create(new CommandDeadLetterOptions { ConnectionString = ValidConnectionString }),
+                    Mock.Of<IMediatorSendOnly>().Object,
+                    null!
+                )
+            )
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Management_Constructor_WithNullConnectionString_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() =>
+                new SQLiteCommandDeadLetterManagement(
+                    Options.Create(new CommandDeadLetterOptions { ConnectionString = null }),
+                    Mock.Of<IMediatorSendOnly>().Object,
+                    Mock.Of<IPayloadSerializer>().Object
+                )
+            )
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Management_Constructor_WithEmptyConnectionString_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() =>
+                new SQLiteCommandDeadLetterManagement(
+                    Options.Create(new CommandDeadLetterOptions { ConnectionString = string.Empty }),
+                    Mock.Of<IMediatorSendOnly>().Object,
+                    Mock.Of<IPayloadSerializer>().Object
+                )
+            )
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task Management_Constructor_WithValidConnectionString_CreatesInstance()
+    {
+        var options = new CommandDeadLetterOptions { ConnectionString = ValidConnectionString };
+
+        var management = new SQLiteCommandDeadLetterManagement(
+            Options.Create(options),
+            Mock.Of<IMediatorSendOnly>().Object,
+            Mock.Of<IPayloadSerializer>().Object
+        );
+
+        _ = await Assert.That(management).IsNotNull();
+    }
+
+    [Test]
+    public async Task Management_Constructor_WithInvalidTableName_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() =>
+                new SQLiteCommandDeadLetterManagement(
+                    Options.Create(
+                        new CommandDeadLetterOptions
+                        {
+                            ConnectionString = ValidConnectionString,
+                            TableName = "1invalid",
+                        }
+                    ),
+                    Mock.Of<IMediatorSendOnly>().Object,
+                    Mock.Of<IPayloadSerializer>().Object
+                )
+            )
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task AddSQLiteCommandDeadLetterStore_WithNullConfigurator_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() =>
+                SQLiteCommandDeadLetterMediatorBuilderExtensions.AddSQLiteCommandDeadLetterStore(
+                    null!,
+                    opts => opts.ConnectionString = ValidConnectionString
+                )
+            )
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task AddSQLiteCommandDeadLetterStore_WithNullConfigureOptions_ThrowsArgumentNullException()
+    {
+        var mock = Mock.Of<IMediatorBuilder>();
+        _ = mock.Services.Returns(new ServiceCollection());
+
+        _ = await Assert.That(() => mock.Object.AddSQLiteCommandDeadLetterStore(null!)).Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task AddSQLiteCommandDeadLetterStore_ReturnsConfiguratorForChaining()
+    {
+        var mock = Mock.Of<IMediatorBuilder>();
+        _ = mock.Services.Returns(new ServiceCollection());
+
+        var result = mock.Object.AddSQLiteCommandDeadLetterStore(opts => opts.ConnectionString = ValidConnectionString);
+
+        _ = await Assert.That(result).IsSameReferenceAs(mock.Object);
+    }
+
+    [Test]
+    public async Task AddSQLiteCommandDeadLetterStore_RegistersCommandDeadLetterStoreAsScoped()
+    {
+        var services = new ServiceCollection();
+        var mock = Mock.Of<IMediatorBuilder>();
+        _ = mock.Services.Returns(services);
+
+        _ = mock.Object.AddSQLiteCommandDeadLetterStore(opts => opts.ConnectionString = ValidConnectionString);
+
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(ICommandDeadLetterStore));
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor).IsNotNull();
+            _ = await Assert.That(descriptor!.Lifetime).IsEqualTo(ServiceLifetime.Scoped);
+            _ = await Assert.That(descriptor.ImplementationType).IsEqualTo(typeof(SQLiteCommandDeadLetterStore));
+        }
+    }
+
+    [Test]
+    public async Task AddSQLiteCommandDeadLetterStore_RegistersCommandDeadLetterManagementAsScoped()
+    {
+        var services = new ServiceCollection();
+        var mock = Mock.Of<IMediatorBuilder>();
+        _ = mock.Services.Returns(services);
+
+        _ = mock.Object.AddSQLiteCommandDeadLetterStore(opts => opts.ConnectionString = ValidConnectionString);
+
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(ICommandDeadLetterManagement));
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor).IsNotNull();
+            _ = await Assert.That(descriptor!.Lifetime).IsEqualTo(ServiceLifetime.Scoped);
+            _ = await Assert.That(descriptor.ImplementationType).IsEqualTo(typeof(SQLiteCommandDeadLetterManagement));
+        }
+    }
+
+    [Test]
+    public async Task AddSQLiteCommandDeadLetterStore_AppliesOptions()
+    {
+        var services = new ServiceCollection();
+        var mock = Mock.Of<IMediatorBuilder>();
+        _ = mock.Services.Returns(services);
+
+        _ = mock.Object.AddSQLiteCommandDeadLetterStore(opts =>
+        {
+            opts.ConnectionString = ValidConnectionString;
+            opts.TableName = "CustomCommandDeadLetter";
+            opts.EnableWalMode = false;
+        });
+
+        var provider = services.BuildServiceProvider();
+        await using (provider.ConfigureAwait(false))
+        {
+            var options = provider.GetRequiredService<IOptions<CommandDeadLetterOptions>>();
+
+            using (Assert.Multiple())
+            {
+                _ = await Assert.That(options.Value.ConnectionString).IsEqualTo(ValidConnectionString);
+                _ = await Assert.That(options.Value.TableName).IsEqualTo("CustomCommandDeadLetter");
+                _ = await Assert.That(options.Value.EnableWalMode).IsFalse();
+            }
+        }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/SqlServer/SqlServerCommandDeadLetterTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/SqlServer/SqlServerCommandDeadLetterTests.cs
@@ -1,0 +1,328 @@
+namespace NetEvolve.Pulse.Tests.Unit.SqlServer;
+
+using System;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.DeadLetter;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+using TUnit.Core;
+using TUnit.Mocks;
+
+[TestGroup("SqlServer")]
+public sealed class SqlServerCommandDeadLetterTests
+{
+    private const string ValidConnectionString = "Server=.;Database=Test;Integrated Security=true;";
+
+    [Test]
+    public async Task Store_Constructor_WithNullOptions_ThrowsArgumentNullException() =>
+        _ = await Assert.That(() => new SqlServerCommandDeadLetterStore(null!)).Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Store_Constructor_WithNullConnectionString_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() =>
+                new SqlServerCommandDeadLetterStore(
+                    Options.Create(new CommandDeadLetterOptions { ConnectionString = null })
+                )
+            )
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Store_Constructor_WithEmptyConnectionString_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() =>
+                new SqlServerCommandDeadLetterStore(
+                    Options.Create(new CommandDeadLetterOptions { ConnectionString = string.Empty })
+                )
+            )
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task Store_Constructor_WithWhitespaceConnectionString_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() =>
+                new SqlServerCommandDeadLetterStore(
+                    Options.Create(new CommandDeadLetterOptions { ConnectionString = "   " })
+                )
+            )
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task Store_Constructor_WithValidConnectionString_CreatesInstance()
+    {
+        var store = new SqlServerCommandDeadLetterStore(
+            Options.Create(new CommandDeadLetterOptions { ConnectionString = ValidConnectionString })
+        );
+
+        _ = await Assert.That(store).IsNotNull();
+    }
+
+    [Test]
+    public async Task Store_Constructor_WithCustomTableName_CreatesInstance()
+    {
+        var options = new CommandDeadLetterOptions
+        {
+            ConnectionString = ValidConnectionString,
+            TableName = "CustomCommandDeadLetter",
+        };
+
+        var store = new SqlServerCommandDeadLetterStore(Options.Create(options));
+
+        _ = await Assert.That(store).IsNotNull();
+    }
+
+    // Defense-in-depth: pin that an attacker-controlled Schema value cannot reach the SQL
+    // builder. The constructor must fail fast when Schema contains characters that would
+    // break out of the [bracketed] identifier (e.g. ']' followed by injected SQL).
+    [Test]
+    public async Task Store_Constructor_WithMaliciousSchema_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() =>
+                new SqlServerCommandDeadLetterStore(
+                    Options.Create(
+                        new CommandDeadLetterOptions
+                        {
+                            ConnectionString = ValidConnectionString,
+                            Schema = "pulse].[evil] -- ",
+                        }
+                    )
+                )
+            )
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task Management_Constructor_WithNullOptions_ThrowsArgumentNullException()
+    {
+        var mediator = Mock.Of<IMediatorSendOnly>();
+        var serializer = Mock.Of<IPayloadSerializer>();
+
+        _ = await Assert
+            .That(() => new SqlServerCommandDeadLetterManagement(null!, mediator.Object, serializer.Object))
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Management_Constructor_WithNullConnectionString_ThrowsArgumentNullException()
+    {
+        var mediator = Mock.Of<IMediatorSendOnly>();
+        var serializer = Mock.Of<IPayloadSerializer>();
+
+        _ = await Assert
+            .That(() =>
+                new SqlServerCommandDeadLetterManagement(
+                    Options.Create(new CommandDeadLetterOptions { ConnectionString = null }),
+                    mediator.Object,
+                    serializer.Object
+                )
+            )
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Management_Constructor_WithEmptyConnectionString_ThrowsArgumentException()
+    {
+        var mediator = Mock.Of<IMediatorSendOnly>();
+        var serializer = Mock.Of<IPayloadSerializer>();
+
+        _ = await Assert
+            .That(() =>
+                new SqlServerCommandDeadLetterManagement(
+                    Options.Create(new CommandDeadLetterOptions { ConnectionString = string.Empty }),
+                    mediator.Object,
+                    serializer.Object
+                )
+            )
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task Management_Constructor_WithWhitespaceConnectionString_ThrowsArgumentException()
+    {
+        var mediator = Mock.Of<IMediatorSendOnly>();
+        var serializer = Mock.Of<IPayloadSerializer>();
+
+        _ = await Assert
+            .That(() =>
+                new SqlServerCommandDeadLetterManagement(
+                    Options.Create(new CommandDeadLetterOptions { ConnectionString = "   " }),
+                    mediator.Object,
+                    serializer.Object
+                )
+            )
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task Management_Constructor_WithNullMediator_ThrowsArgumentNullException()
+    {
+        var serializer = Mock.Of<IPayloadSerializer>();
+
+        _ = await Assert
+            .That(() =>
+                new SqlServerCommandDeadLetterManagement(
+                    Options.Create(new CommandDeadLetterOptions { ConnectionString = ValidConnectionString }),
+                    null!,
+                    serializer.Object
+                )
+            )
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Management_Constructor_WithNullPayloadSerializer_ThrowsArgumentNullException()
+    {
+        var mediator = Mock.Of<IMediatorSendOnly>();
+
+        _ = await Assert
+            .That(() =>
+                new SqlServerCommandDeadLetterManagement(
+                    Options.Create(new CommandDeadLetterOptions { ConnectionString = ValidConnectionString }),
+                    mediator.Object,
+                    null!
+                )
+            )
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Management_Constructor_WithValidArguments_CreatesInstance()
+    {
+        var mediator = Mock.Of<IMediatorSendOnly>();
+        var serializer = Mock.Of<IPayloadSerializer>();
+
+        var management = new SqlServerCommandDeadLetterManagement(
+            Options.Create(new CommandDeadLetterOptions { ConnectionString = ValidConnectionString }),
+            mediator.Object,
+            serializer.Object
+        );
+
+        _ = await Assert.That(management).IsNotNull();
+    }
+
+    // Defense-in-depth: pin that an attacker-controlled Schema value cannot reach the SQL
+    // builder. The constructor must fail fast when Schema contains characters that would
+    // break out of the [bracketed] identifier (e.g. ']' followed by injected SQL).
+    [Test]
+    public async Task Management_Constructor_WithMaliciousSchema_ThrowsArgumentException()
+    {
+        var mediator = Mock.Of<IMediatorSendOnly>();
+        var serializer = Mock.Of<IPayloadSerializer>();
+
+        _ = await Assert
+            .That(() =>
+                new SqlServerCommandDeadLetterManagement(
+                    Options.Create(
+                        new CommandDeadLetterOptions
+                        {
+                            ConnectionString = ValidConnectionString,
+                            Schema = "pulse].[evil] -- ",
+                        }
+                    ),
+                    mediator.Object,
+                    serializer.Object
+                )
+            )
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task AddSqlServerCommandDeadLetterStore_WithNullConfigurator_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() =>
+                SqlServerCommandDeadLetterMediatorBuilderExtensions.AddSqlServerCommandDeadLetterStore(
+                    null!,
+                    opts => opts.ConnectionString = ValidConnectionString
+                )
+            )
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task AddSqlServerCommandDeadLetterStore_WithNullConfigureOptions_ThrowsArgumentNullException()
+    {
+        var mock = Mock.Of<IMediatorBuilder>();
+        _ = mock.Services.Returns(new ServiceCollection());
+
+        _ = await Assert
+            .That(() => mock.Object.AddSqlServerCommandDeadLetterStore(null!))
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task AddSqlServerCommandDeadLetterStore_WithValidOptions_ReturnsConfiguratorForChaining()
+    {
+        var mock = Mock.Of<IMediatorBuilder>();
+        _ = mock.Services.Returns(new ServiceCollection());
+
+        var result = mock.Object.AddSqlServerCommandDeadLetterStore(opts =>
+            opts.ConnectionString = ValidConnectionString
+        );
+
+        _ = await Assert.That(result).IsSameReferenceAs(mock.Object);
+    }
+
+    [Test]
+    public async Task AddSqlServerCommandDeadLetterStore_RegistersCommandDeadLetterStoreAsScoped()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddPulse(config =>
+            config.AddSqlServerCommandDeadLetterStore(opts => opts.ConnectionString = ValidConnectionString)
+        );
+
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(ICommandDeadLetterStore));
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor).IsNotNull();
+            _ = await Assert.That(descriptor!.Lifetime).IsEqualTo(ServiceLifetime.Scoped);
+            _ = await Assert.That(descriptor.ImplementationType).IsEqualTo(typeof(SqlServerCommandDeadLetterStore));
+        }
+    }
+
+    [Test]
+    public async Task AddSqlServerCommandDeadLetterStore_RegistersCommandDeadLetterManagementAsScoped()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddPulse(config =>
+            config.AddSqlServerCommandDeadLetterStore(opts => opts.ConnectionString = ValidConnectionString)
+        );
+
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(ICommandDeadLetterManagement));
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor).IsNotNull();
+            _ = await Assert.That(descriptor!.Lifetime).IsEqualTo(ServiceLifetime.Scoped);
+            _ = await Assert
+                .That(descriptor.ImplementationType)
+                .IsEqualTo(typeof(SqlServerCommandDeadLetterManagement));
+        }
+    }
+
+    [Test]
+    public async Task AddSqlServerCommandDeadLetterStore_WithConfigureOptions_AppliesOptions()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddPulse(config =>
+            config.AddSqlServerCommandDeadLetterStore(opts =>
+            {
+                opts.ConnectionString = ValidConnectionString;
+                opts.TableName = "CustomCommandDeadLetter";
+            })
+        );
+
+        var provider = services.BuildServiceProvider();
+        await using (provider.ConfigureAwait(false))
+        {
+            var options = provider.GetRequiredService<IOptions<CommandDeadLetterOptions>>();
+
+            using (Assert.Multiple())
+            {
+                _ = await Assert.That(options.Value.ConnectionString).IsEqualTo(ValidConnectionString);
+                _ = await Assert.That(options.Value.TableName).IsEqualTo("CustomCommandDeadLetter");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `CommandDeadLetterSchema`/`CommandDeadLetterEntry`/`CommandDeadLetterStatistics`, `ICommandDeadLetterStore`, and `ICommandDeadLetterManagement` (`NetEvolve.Pulse.Extensibility`).
- Adds a shared `CommandDeadLetterReplayDispatcher`: since `ICommandDeadLetterManagement.ReplayAsync` only has a `Guid` at compile time, it resolves the command/response types from persisted metadata via reflection and dispatches through `IMediatorSendOnly.SendAsync<TCommand,TResponse>` — implemented once and reused by every store below instead of duplicating the reflection logic five times.
- Adds `CommandDeadLetterInterceptor` + `AddCommandDeadLetter()`: records a failed command's serialized payload and exception to `ICommandDeadLetterStore` (when registered) before rethrowing; pass-through for queries and for successful commands.
- Adds `CommandDeadLetterOptions` (`NetEvolve.Pulse`) and five store implementations, each with its own `Add*CommandDeadLetterStore()` registration extension:
  - **Entity Framework Core** — reuses `CommandDeadLetterEntry` directly as the EF entity (matching the `OutboxMessage` precedent), with SQL Server/PostgreSQL/SQLite/MySQL/InMemory `IEntityTypeConfiguration` derivations wired into `ModelBuilderExtensions.ApplyPulseConfiguration`.
  - **SQL Server / PostgreSQL / SQLite / MySQL** — native ADO.NET providers with DDL scripts, following this repo's existing Idempotency-provider conventions (parameterized SQL, provider-specific duplicate-key handling: exception-catch for SQL Server/PostgreSQL, `INSERT OR IGNORE`/`INSERT IGNORE` for SQLite/MySQL).
- Unit tests for every layer (interceptor, extension, EF Core store + management, all four ADO.NET providers).

Closes #266
Closes #267
Closes #268
Closes #269
Closes #270
Closes #271
Closes #272
Closes #273

## Test plan
- [x] `dotnet build` clean on net8.0/net9.0/net10.0 (all 20 projects)
- [x] `dotnet test` — full `NetEvolve.Pulse.Tests.Unit` suite passes (1799 tests)
- [x] `csharpier format .`