### PR TITLE
refactor(serialization): use IPayloadSerializer instead of raw System.Text.Json

### DIFF
--- a/src/NetEvolve.Pulse.AspNetCore/EndpointRouteBuilderExtensions.cs
+++ b/src/NetEvolve.Pulse.AspNetCore/EndpointRouteBuilderExtensions.cs
@@ -2,7 +2,6 @@ namespace NetEvolve.Pulse;
 
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
-using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -194,6 +193,7 @@ public static class EndpointRouteBuilderExtensions
             (
                 [AsParameters] TQuery query,
                 IMediator mediator,
+                IPayloadSerializer payloadSerializer,
                 HttpRequest request,
                 CancellationToken cancellationToken
             ) =>
@@ -208,7 +208,7 @@ public static class EndpointRouteBuilderExtensions
                 {
                     return (IResult)
                         TypedResults.Stream(
-                            ExecuteStreamReadNdjson(items, cancellationToken),
+                            ExecuteStreamReadNdjson(items, payloadSerializer, cancellationToken),
                             contentType: NdjsonContentType
                         );
                 }
@@ -217,7 +217,7 @@ public static class EndpointRouteBuilderExtensions
                 return TypedResults.ServerSentEvents(items);
 #else
                 return TypedResults.Stream(
-                    ExecuteStreamReadServerSentEvents(items, cancellationToken),
+                    ExecuteStreamReadServerSentEvents(items, payloadSerializer, cancellationToken),
                     contentType: "text/event-stream"
                 );
 #endif
@@ -235,6 +235,7 @@ public static class EndpointRouteBuilderExtensions
 #if !NET10_0_OR_GREATER
     private static Func<Stream, Task> ExecuteStreamReadServerSentEvents<TResponse>(
         IAsyncEnumerable<TResponse> items,
+        IPayloadSerializer payloadSerializer,
         CancellationToken cancellationToken
     ) =>
         async outputStream =>
@@ -244,9 +245,8 @@ public static class EndpointRouteBuilderExtensions
                 await foreach (var item in items.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
                     await outputStream.WriteAsync(SseDataPrefix, cancellationToken).ConfigureAwait(false);
-                    await JsonSerializer
-                        .SerializeAsync(outputStream, item, cancellationToken: cancellationToken)
-                        .ConfigureAwait(false);
+                    var bytes = payloadSerializer.SerializeToBytes(item);
+                    await outputStream.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
                     await outputStream.WriteAsync(SseSuffix, cancellationToken).ConfigureAwait(false);
                     await outputStream.FlushAsync(cancellationToken).ConfigureAwait(false);
                 }
@@ -260,6 +260,7 @@ public static class EndpointRouteBuilderExtensions
 
     private static Func<Stream, Task> ExecuteStreamReadNdjson<TResponse>(
         IAsyncEnumerable<TResponse> items,
+        IPayloadSerializer payloadSerializer,
         CancellationToken cancellationToken
     ) =>
         async outputStream =>
@@ -268,9 +269,8 @@ public static class EndpointRouteBuilderExtensions
             {
                 await foreach (var item in items.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    await JsonSerializer
-                        .SerializeAsync(outputStream, item, cancellationToken: cancellationToken)
-                        .ConfigureAwait(false);
+                    var bytes = payloadSerializer.SerializeToBytes(item);
+                    await outputStream.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
                     await outputStream.WriteAsync(NdjsonNewLine, cancellationToken).ConfigureAwait(false);
                     await outputStream.FlushAsync(cancellationToken).ConfigureAwait(false);
                 }

--- a/src/NetEvolve.Pulse.AzureQueueStorage/AzureQueueStorageExtensions.cs
+++ b/src/NetEvolve.Pulse.AzureQueueStorage/AzureQueueStorageExtensions.cs
@@ -96,7 +96,8 @@ public static class AzureQueueStorageExtensions
         }
 
         _ = services.AddSingleton<IMessageTransport>(sp => new AzureQueueStorageMessageTransport(
-            sp.GetRequiredService<IOptions<AzureQueueStorageTransportOptions>>()
+            sp.GetRequiredService<IOptions<AzureQueueStorageTransportOptions>>(),
+            sp.GetRequiredService<IPayloadSerializer>()
         ));
 
         return configurator;

--- a/src/NetEvolve.Pulse.AzureQueueStorage/Outbox/AzureQueueStorageMessageTransport.cs
+++ b/src/NetEvolve.Pulse.AzureQueueStorage/Outbox/AzureQueueStorageMessageTransport.cs
@@ -2,10 +2,10 @@ namespace NetEvolve.Pulse.Outbox;
 
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
-using System.Text.Json;
 using Azure.Identity;
 using Azure.Storage.Queues;
 using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.Extensibility;
 using NetEvolve.Pulse.Extensibility.Outbox;
 
 /// <summary>
@@ -23,6 +23,7 @@ public sealed class AzureQueueStorageMessageTransport : IMessageTransport, IDisp
     internal const int MaxMessageSizeInBytes = 48 * 1024; // Raw 48 KB limit (64 KB after Base64 encoding)
 
     private readonly AzureQueueStorageTransportOptions _options;
+    private readonly IPayloadSerializer _payloadSerializer;
     private readonly QueueClient? _queueClientOverride;
     private readonly SemaphoreSlim _initLock = new SemaphoreSlim(1, 1);
     private QueueClient? _queueClient;
@@ -31,10 +32,16 @@ public sealed class AzureQueueStorageMessageTransport : IMessageTransport, IDisp
     /// Initializes a new instance of the <see cref="AzureQueueStorageMessageTransport"/> class.
     /// </summary>
     /// <param name="options">The configured transport options.</param>
-    internal AzureQueueStorageMessageTransport(IOptions<AzureQueueStorageTransportOptions> options)
+    /// <param name="payloadSerializer">The serializer used to serialize the outbox message envelope.</param>
+    internal AzureQueueStorageMessageTransport(
+        IOptions<AzureQueueStorageTransportOptions> options,
+        IPayloadSerializer payloadSerializer
+    )
     {
         ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(payloadSerializer);
         _options = options.Value;
+        _payloadSerializer = payloadSerializer;
     }
 
     /// <summary>
@@ -42,15 +49,19 @@ public sealed class AzureQueueStorageMessageTransport : IMessageTransport, IDisp
     /// with a pre-built queue client. Used for testing.
     /// </summary>
     /// <param name="options">The configured transport options.</param>
+    /// <param name="payloadSerializer">The serializer used to serialize the outbox message envelope.</param>
     /// <param name="queueClient">A pre-built queue client to use instead of creating one from options.</param>
     internal AzureQueueStorageMessageTransport(
         IOptions<AzureQueueStorageTransportOptions> options,
+        IPayloadSerializer payloadSerializer,
         QueueClient queueClient
     )
     {
         ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(payloadSerializer);
         ArgumentNullException.ThrowIfNull(queueClient);
         _options = options.Value;
+        _payloadSerializer = payloadSerializer;
         _queueClientOverride = queueClient;
     }
 
@@ -62,7 +73,7 @@ public sealed class AzureQueueStorageMessageTransport : IMessageTransport, IDisp
     {
         ArgumentNullException.ThrowIfNull(message);
 
-        var json = SerializeMessage(message);
+        var json = SerializeMessage(_payloadSerializer, message);
         var rawBytes = Encoding.UTF8.GetBytes(json);
 
         if (rawBytes.Length > MaxMessageSizeInBytes)
@@ -94,8 +105,8 @@ public sealed class AzureQueueStorageMessageTransport : IMessageTransport, IDisp
         }
     }
 
-    private static string SerializeMessage(OutboxMessage message) =>
-        JsonSerializer.Serialize(
+    private static string SerializeMessage(IPayloadSerializer payloadSerializer, OutboxMessage message) =>
+        payloadSerializer.Serialize(
             new
             {
                 id = message.Id,

--- a/tests/NetEvolve.Pulse.Tests.Integration/AzureQueueStorage/AzureQueueStorageMessageTransportIntegrationTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/AzureQueueStorage/AzureQueueStorageMessageTransportIntegrationTests.cs
@@ -10,6 +10,7 @@ using NetEvolve.Pulse;
 using NetEvolve.Pulse.Extensibility;
 using NetEvolve.Pulse.Extensibility.Outbox;
 using NetEvolve.Pulse.Outbox;
+using NetEvolve.Pulse.Serialization;
 using TUnit.Assertions.Extensions;
 using TUnit.Core;
 
@@ -23,6 +24,9 @@ using TUnit.Core;
 [NotInParallel]
 public sealed class AzureQueueStorageMessageTransportIntegrationTests(AzuriteContainerFixture containerFixture)
 {
+    private static IPayloadSerializer DefaultSerializer =>
+        new SystemTextJsonPayloadSerializer(Options.Create(JsonSerializerOptions.Default));
+
     [Test]
     public async Task SendAsync_Creates_queue_and_sends_base64_encoded_message(CancellationToken cancellationToken)
     {
@@ -35,7 +39,7 @@ public sealed class AzureQueueStorageMessageTransportIntegrationTests(AzuriteCon
                 CreateQueueIfNotExists = true,
             }
         );
-        using var transport = new AzureQueueStorageMessageTransport(options);
+        using var transport = new AzureQueueStorageMessageTransport(options, DefaultSerializer);
         var message = CreateOutboxMessage();
 
         await transport.SendAsync(message, cancellationToken).ConfigureAwait(false);
@@ -66,7 +70,7 @@ public sealed class AzureQueueStorageMessageTransportIntegrationTests(AzuriteCon
                 CreateQueueIfNotExists = false,
             }
         );
-        using var transport = new AzureQueueStorageMessageTransport(options);
+        using var transport = new AzureQueueStorageMessageTransport(options, DefaultSerializer);
 
         _ = await Assert
             .That(() => transport.SendAsync(CreateOutboxMessage(), cancellationToken))
@@ -86,7 +90,7 @@ public sealed class AzureQueueStorageMessageTransportIntegrationTests(AzuriteCon
                 CreateQueueIfNotExists = true,
             }
         );
-        using var transport = new AzureQueueStorageMessageTransport(options);
+        using var transport = new AzureQueueStorageMessageTransport(options, DefaultSerializer);
         var messages = Enumerable.Range(0, messageCount).Select(_ => CreateOutboxMessage()).ToList();
 
         await transport.SendBatchAsync(messages, cancellationToken).ConfigureAwait(false);
@@ -118,7 +122,7 @@ public sealed class AzureQueueStorageMessageTransportIntegrationTests(AzuriteCon
                 CreateQueueIfNotExists = false,
             }
         );
-        using var transport = new AzureQueueStorageMessageTransport(options, queueClient);
+        using var transport = new AzureQueueStorageMessageTransport(options, DefaultSerializer, queueClient);
         var message = CreateOutboxMessage();
 
         await transport.SendAsync(message, cancellationToken).ConfigureAwait(false);
@@ -146,7 +150,7 @@ public sealed class AzureQueueStorageMessageTransportIntegrationTests(AzuriteCon
                 CreateQueueIfNotExists = true,
             }
         );
-        using var transport = new AzureQueueStorageMessageTransport(options);
+        using var transport = new AzureQueueStorageMessageTransport(options, DefaultSerializer);
 
         // Payload alone (well before JSON envelope overhead) already exceeds the 48 KB raw limit.
         var oversizedMessage = CreateOutboxMessage();
@@ -171,7 +175,7 @@ public sealed class AzureQueueStorageMessageTransportIntegrationTests(AzuriteCon
                 CreateQueueIfNotExists = true,
             }
         );
-        using var transport = new AzureQueueStorageMessageTransport(options);
+        using var transport = new AzureQueueStorageMessageTransport(options, DefaultSerializer);
 
         const int concurrentSends = 10;
 

--- a/tests/NetEvolve.Pulse.Tests.Unit/AzureQueueStorage/AzureQueueStorageMessageTransportTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/AzureQueueStorage/AzureQueueStorageMessageTransportTests.cs
@@ -15,12 +15,16 @@ using NetEvolve.Extensions.TUnit;
 using NetEvolve.Pulse.Extensibility;
 using NetEvolve.Pulse.Extensibility.Outbox;
 using NetEvolve.Pulse.Outbox;
+using NetEvolve.Pulse.Serialization;
 using TUnit.Assertions.Extensions;
 using TUnit.Core;
 
 [TestGroup("AzureQueueStorage")]
 public sealed class AzureQueueStorageMessageTransportTests
 {
+    private static IPayloadSerializer DefaultSerializer =>
+        new SystemTextJsonPayloadSerializer(Options.Create(JsonSerializerOptions.Default));
+
     // ── Constructor guards ────────────────────────────────────────────────────
 
     [Test]
@@ -28,7 +32,22 @@ public sealed class AzureQueueStorageMessageTransportTests
     {
         IOptions<AzureQueueStorageTransportOptions> options = null!;
 
-        _ = await Assert.That(() => new AzureQueueStorageMessageTransport(options)).Throws<ArgumentNullException>();
+        _ = await Assert
+            .That(() => new AzureQueueStorageMessageTransport(options, DefaultSerializer))
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Constructor_When_payloadSerializer_is_null_throws_ArgumentNullException()
+    {
+        var options = Options.Create(
+            new AzureQueueStorageTransportOptions { ConnectionString = "UseDevelopmentStorage=true" }
+        );
+        IPayloadSerializer payloadSerializer = null!;
+
+        _ = await Assert
+            .That(() => new AzureQueueStorageMessageTransport(options, payloadSerializer))
+            .Throws<ArgumentNullException>();
     }
 
     [Test]
@@ -38,7 +57,21 @@ public sealed class AzureQueueStorageMessageTransportTests
         var fakeClient = new FakeQueueClient();
 
         _ = await Assert
-            .That(() => new AzureQueueStorageMessageTransport(options, fakeClient))
+            .That(() => new AzureQueueStorageMessageTransport(options, DefaultSerializer, fakeClient))
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Constructor_With_queueClient_When_payloadSerializer_is_null_throws_ArgumentNullException()
+    {
+        var options = Options.Create(
+            new AzureQueueStorageTransportOptions { ConnectionString = "UseDevelopmentStorage=true" }
+        );
+        var fakeClient = new FakeQueueClient();
+        IPayloadSerializer payloadSerializer = null!;
+
+        _ = await Assert
+            .That(() => new AzureQueueStorageMessageTransport(options, payloadSerializer, fakeClient))
             .Throws<ArgumentNullException>();
     }
 
@@ -51,7 +84,7 @@ public sealed class AzureQueueStorageMessageTransportTests
         QueueClient nullClient = null!;
 
         _ = await Assert
-            .That(() => new AzureQueueStorageMessageTransport(options, nullClient))
+            .That(() => new AzureQueueStorageMessageTransport(options, DefaultSerializer, nullClient))
             .Throws<ArgumentNullException>();
     }
 
@@ -104,7 +137,7 @@ public sealed class AzureQueueStorageMessageTransportTests
                 MessageVisibilityTimeout = timeout,
             }
         );
-        using var transport = new AzureQueueStorageMessageTransport(options, fakeClient);
+        using var transport = new AzureQueueStorageMessageTransport(options, DefaultSerializer, fakeClient);
 
         await transport.SendAsync(CreateOutboxMessage(), cancellationToken).ConfigureAwait(false);
 
@@ -218,7 +251,7 @@ public sealed class AzureQueueStorageMessageTransportTests
         var options = Options.Create(
             new AzureQueueStorageTransportOptions { ConnectionString = "UseDevelopmentStorage=true" }
         );
-        return new AzureQueueStorageMessageTransport(options, fakeClient);
+        return new AzureQueueStorageMessageTransport(options, DefaultSerializer, fakeClient);
     }
 
     private static OutboxMessage CreateOutboxMessage(string? payload = null) =>


### PR DESCRIPTION
## Summary
- `EndpointRouteBuilderExtensions.cs`: the SSE and NDJSON streaming handlers for `MapStreamQuery` now serialize each item via the injected `IPayloadSerializer` (resolved as an additional Minimal API parameter) instead of calling `System.Text.Json.JsonSerializer.SerializeAsync` directly, so streamed items honor the app's configured Pulse serializer.
- `AzureQueueStorageMessageTransport.cs`: the outbox message envelope is now serialized via a constructor-injected `IPayloadSerializer` instead of `JsonSerializer.Serialize`. Both constructors gained an `IPayloadSerializer payloadSerializer` parameter; the DI registration in `AzureQueueStorageExtensions.cs` was updated to resolve it.
- Updated unit and integration test call sites for the new constructor signature.

## Test plan
- [x] `dotnet build` clean on net8.0/net9.0/net10.0
- [x] `dotnet test` — full `NetEvolve.Pulse.Tests.Unit` suite passes (1686 tests)
- [x] `dotnet test` — full `NetEvolve.Pulse.Tests.Integration` suite passes (522 tests), including the Azurite-backed Azure Queue Storage tests and the AspNetCore SSE/NDJSON streaming tests
- [x] `csharpier format .`