### PR TITLE
feat(audit): Audit Trail (EF Core + 4 ADO.NET providers)

### DIFF
--- a/src/NetEvolve.Pulse.AspNetCore/Audit/AuditExtensions.cs
+++ b/src/NetEvolve.Pulse.AspNetCore/Audit/AuditExtensions.cs
@@ -1,0 +1,47 @@
+namespace NetEvolve.Pulse;
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using NetEvolve.Pulse.AspNetCore;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.Audit;
+
+/// <summary>
+/// Provides extension methods for integrating the audit trail with the ASP.NET Core hosting model.
+/// </summary>
+/// <seealso cref="IAuditUserAccessor"/>
+public static class AuditExtensions
+{
+    /// <summary>
+    /// Replaces the default no-op <see cref="IAuditUserAccessor"/> with one that reads the current
+    /// authenticated user's name from the ambient <c>HttpContext</c>.
+    /// </summary>
+    /// <param name="builder">The mediator builder.</param>
+    /// <returns>The builder for method chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para><strong>Prerequisites:</strong></para>
+    /// Must be called after <c>AddAudit()</c>, and only makes sense in an ASP.NET Core host.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// services.AddPulse(builder =>
+    /// {
+    ///     builder.AddAudit();
+    ///     builder.AddHttpContextAuditUserAccessor();
+    /// });
+    /// </code>
+    /// </example>
+    public static IMediatorBuilder AddHttpContextAuditUserAccessor(this IMediatorBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        _ = builder.Services.AddHttpContextAccessor();
+
+        _ = builder.Services.RemoveAll<IAuditUserAccessor>();
+        _ = builder.Services.AddSingleton<IAuditUserAccessor, HttpContextAuditUserAccessor>();
+
+        return builder;
+    }
+}

--- a/src/NetEvolve.Pulse.AspNetCore/Audit/HttpContextAuditUserAccessor.cs
+++ b/src/NetEvolve.Pulse.AspNetCore/Audit/HttpContextAuditUserAccessor.cs
@@ -1,0 +1,34 @@
+namespace NetEvolve.Pulse.AspNetCore;
+
+using System;
+using Microsoft.AspNetCore.Http;
+using NetEvolve.Pulse.Extensibility.Audit;
+
+/// <summary>
+/// An <see cref="IAuditUserAccessor"/> implementation that reads the current authenticated user's
+/// name from the ambient <see cref="HttpContext"/>.
+/// </summary>
+/// <remarks>
+/// <para><strong>Requirements:</strong></para>
+/// Requires ASP.NET Core hosting and an <see cref="IHttpContextAccessor"/> registered in the DI
+/// container. Register this accessor via <c>AddHttpContextAuditUserAccessor()</c>.
+/// </remarks>
+internal sealed class HttpContextAuditUserAccessor : IAuditUserAccessor
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HttpContextAuditUserAccessor"/> class.
+    /// </summary>
+    /// <param name="httpContextAccessor">The accessor used to obtain the ambient <see cref="HttpContext"/>.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="httpContextAccessor"/> is <see langword="null"/>.</exception>
+    public HttpContextAuditUserAccessor(IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    /// <inheritdoc/>
+    public string? GetCurrentUser() => _httpContextAccessor.HttpContext?.User?.Identity?.Name;
+}

--- a/src/NetEvolve.Pulse.EntityFramework/Audit/EntityFrameworkAuditManagement.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Audit/EntityFrameworkAuditManagement.cs
@@ -1,0 +1,92 @@
+namespace NetEvolve.Pulse.Audit;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using NetEvolve.Pulse.Extensibility.Audit;
+
+/// <summary>
+/// Entity Framework Core implementation of <see cref="IAuditManagement"/>.
+/// Provides audit trail querying and statistics using any EF Core database provider.
+/// </summary>
+/// <remarks>
+/// All read operations run directly against <see cref="IAuditStoreDbContext.AuditEntries"/>
+/// using plain LINQ queries, and are therefore provider-agnostic.
+/// </remarks>
+/// <typeparam name="TContext">The DbContext type that implements <see cref="IAuditStoreDbContext"/>.</typeparam>
+internal sealed class EntityFrameworkAuditManagement<TContext> : IAuditManagement
+    where TContext : DbContext, IAuditStoreDbContext
+{
+    private readonly TContext _context;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EntityFrameworkAuditManagement{TContext}"/> class.
+    /// </summary>
+    /// <param name="context">The DbContext for database operations.</param>
+    public EntityFrameworkAuditManagement(TContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        _context = context;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<AuditRecord>> QueryAsync(
+        AuditFilter filter,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+
+        var query = _context.AuditEntries.AsQueryable();
+
+        if (filter.CommandType is not null)
+        {
+            query = query.Where(e => e.CommandType == filter.CommandType);
+        }
+
+        if (filter.UserId is not null)
+        {
+            query = query.Where(e => e.UserId == filter.UserId);
+        }
+
+        if (filter.From is not null)
+        {
+            query = query.Where(e => e.OccurredAt >= filter.From.Value);
+        }
+
+        if (filter.To is not null)
+        {
+            query = query.Where(e => e.OccurredAt <= filter.To.Value);
+        }
+
+        if (filter.Result is not null)
+        {
+            query = query.Where(e => e.Result == filter.Result.Value);
+        }
+
+        return await query
+            .OrderByDescending(e => e.OccurredAt)
+            .Skip(filter.Skip)
+            .Take(filter.Take)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<AuditStatistics> GetStatisticsAsync(CancellationToken cancellationToken = default)
+    {
+        var counts = await _context
+            .AuditEntries.GroupBy(e => e.Result)
+            .Select(g => new { Result = g.Key, Count = g.Count() })
+            .ToDictionaryAsync(g => g.Result, g => g.Count, cancellationToken)
+            .ConfigureAwait(false);
+
+        return new AuditStatistics(
+            SuccessCount: counts.GetValueOrDefault(AuditResult.Success),
+            FailureCount: counts.GetValueOrDefault(AuditResult.Failure)
+        );
+    }
+}

--- a/src/NetEvolve.Pulse.EntityFramework/Audit/EntityFrameworkAuditStore.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Audit/EntityFrameworkAuditStore.cs
@@ -1,0 +1,41 @@
+namespace NetEvolve.Pulse.Audit;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using NetEvolve.Pulse.Extensibility.Audit;
+
+/// <summary>
+/// Entity Framework Core implementation of <see cref="IAuditStore"/>.
+/// Provides audit trail persistence using any EF Core database provider.
+/// </summary>
+/// <remarks>
+/// <para><strong>Provider Agnostic:</strong></para>
+/// Works with any EF Core database provider (SQL Server, PostgreSQL, SQLite, etc.).
+/// </remarks>
+/// <typeparam name="TContext">The DbContext type that implements <see cref="IAuditStoreDbContext"/>.</typeparam>
+internal sealed class EntityFrameworkAuditStore<TContext> : IAuditStore
+    where TContext : DbContext, IAuditStoreDbContext
+{
+    private readonly TContext _context;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EntityFrameworkAuditStore{TContext}"/> class.
+    /// </summary>
+    /// <param name="context">The DbContext for database operations.</param>
+    public EntityFrameworkAuditStore(TContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        _context = context;
+    }
+
+    /// <inheritdoc />
+    public async Task RecordAsync(AuditRecord record, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        _ = await _context.AuditEntries.AddAsync(record, cancellationToken).ConfigureAwait(false);
+        _ = await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/NetEvolve.Pulse.EntityFramework/Audit/IAuditStoreDbContext.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Audit/IAuditStoreDbContext.cs
@@ -1,0 +1,42 @@
+namespace NetEvolve.Pulse.Audit;
+
+using Microsoft.EntityFrameworkCore;
+using NetEvolve.Pulse.Extensibility.Audit;
+
+/// <summary>
+/// Defines the contract for a DbContext that supports audit trail persistence.
+/// Implement this interface in your application's DbContext to enable Entity Framework audit trail store support.
+/// </summary>
+/// <remarks>
+/// <para><strong>Implementation:</strong></para>
+/// Your DbContext must expose a <see cref="DbSet{TEntity}"/> for <see cref="AuditRecord"/>
+/// and apply the appropriate <c>AuditEntryConfiguration</c> in <c>OnModelCreating</c>.
+/// <para><strong>Migration Workflow:</strong></para>
+/// <list type="number">
+/// <item><description>Implement <see cref="IAuditStoreDbContext"/> in your DbContext</description></item>
+/// <item><description>Apply the audit entry configuration via <c>modelBuilder.ApplyPulseConfiguration(this)</c> in OnModelCreating</description></item>
+/// <item><description>Run <c>dotnet ef migrations add AddAuditTrail</c> with your chosen provider</description></item>
+/// <item><description>Apply migration with <c>dotnet ef database update</c></description></item>
+/// </list>
+/// </remarks>
+/// <example>
+/// <code>
+/// public class ApplicationDbContext : DbContext, IAuditStoreDbContext
+/// {
+///     public DbSet&lt;AuditRecord&gt; AuditEntries =&gt; Set&lt;AuditRecord&gt;();
+///
+///     protected override void OnModelCreating(ModelBuilder modelBuilder)
+///     {
+///         base.OnModelCreating(modelBuilder);
+///         modelBuilder.ApplyPulseConfiguration(this);
+///     }
+/// }
+/// </code>
+/// </example>
+public interface IAuditStoreDbContext
+{
+    /// <summary>
+    /// Gets the <see cref="DbSet{TEntity}"/> for audit entries.
+    /// </summary>
+    DbSet<AuditRecord> AuditEntries { get; }
+}

--- a/src/NetEvolve.Pulse.EntityFramework/Configurations/AuditEntryConfigurationBase.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Configurations/AuditEntryConfigurationBase.cs
@@ -1,0 +1,106 @@
+namespace NetEvolve.Pulse.Configurations;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.Audit;
+using NetEvolve.Pulse.Extensibility.Audit;
+using NetEvolve.Pulse.Extensibility.Outbox;
+
+/// <summary>
+/// Abstract base class for Entity Framework Core configuration of <see cref="AuditRecord"/>.
+/// Encapsulates all provider-agnostic column and key mappings, leaving column type overrides
+/// as optional members to be implemented per database provider.
+/// </summary>
+/// <remarks>
+/// <para><strong>Provider-specific column types:</strong></para>
+/// Derived classes may override <see cref="ApplyColumnTypes"/> to add explicit
+/// <c>HasColumnType</c> calls. Without overrides, EF Core convention-based defaults apply.
+/// <para><strong>Customization:</strong></para>
+/// Override schema and table names via <see cref="AuditStoreOptions"/> before applying this configuration.
+/// </remarks>
+internal abstract class AuditEntryConfigurationBase : IEntityTypeConfiguration<AuditRecord>
+{
+    private readonly AuditStoreOptions _options;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="AuditEntryConfigurationBase"/>.
+    /// </summary>
+    /// <param name="options">The audit store options containing schema and table configuration.</param>
+    protected AuditEntryConfigurationBase(IOptions<AuditStoreOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        _options = options.Value;
+    }
+
+    /// <summary>
+    /// Applies provider-specific column type overrides to the entity mapping.
+    /// Called from <see cref="Configure"/> after all shared column mappings are applied.
+    /// </summary>
+    /// <remarks>
+    /// Override this method to call <c>HasColumnType</c> for columns whose native type
+    /// differs between providers.
+    /// The default implementation is a no-op.
+    /// </remarks>
+    /// <param name="builder">The entity type builder for <see cref="AuditRecord"/>.</param>
+    protected virtual void ApplyColumnTypes(EntityTypeBuilder<AuditRecord> builder) { }
+
+    /// <inheritdoc />
+    public void Configure(EntityTypeBuilder<AuditRecord> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        // Table configuration
+        var schema = string.IsNullOrWhiteSpace(_options.Schema)
+            ? AuditEntrySchema.DefaultSchema
+            : _options.Schema.Trim();
+        var tableName = _options.TableName;
+        SqlIdentifier.Validate(schema, nameof(_options.Schema));
+        SqlIdentifier.Validate(tableName, nameof(_options.TableName));
+
+        _ = builder.ToTable(tableName, schema);
+
+        // Primary key
+        _ = builder.HasKey(e => e.Id).HasName($"PK_{schema}_{tableName}");
+
+        // Id column
+        _ = builder.Property(e => e.Id).HasColumnName(AuditEntrySchema.Columns.Id).IsRequired();
+
+        // CommandType column
+        _ = builder
+            .Property(e => e.CommandType)
+            .HasColumnName(AuditEntrySchema.Columns.CommandType)
+            .HasMaxLength(AuditEntrySchema.MaxLengths.CommandType)
+            .IsRequired();
+
+        // UserId column
+        _ = builder
+            .Property(e => e.UserId)
+            .HasColumnName(AuditEntrySchema.Columns.UserId)
+            .HasMaxLength(AuditEntrySchema.MaxLengths.UserId);
+
+        // CorrelationId column
+        _ = builder
+            .Property(e => e.CorrelationId)
+            .HasColumnName(AuditEntrySchema.Columns.CorrelationId)
+            .HasMaxLength(AuditEntrySchema.MaxLengths.CorrelationId);
+
+        // OccurredAt column
+        _ = builder.Property(e => e.OccurredAt).HasColumnName(AuditEntrySchema.Columns.OccurredAt).IsRequired();
+
+        // DurationMs column
+        _ = builder.Property(e => e.DurationMs).HasColumnName(AuditEntrySchema.Columns.DurationMs).IsRequired();
+
+        // Result column
+        _ = builder.Property(e => e.Result).HasColumnName(AuditEntrySchema.Columns.Result).IsRequired();
+
+        // Payload column
+        _ = builder.Property(e => e.Payload).HasColumnName(AuditEntrySchema.Columns.Payload);
+
+        // ExceptionMessage column
+        _ = builder.Property(e => e.ExceptionMessage).HasColumnName(AuditEntrySchema.Columns.ExceptionMessage);
+
+        // Provider-specific column type overrides
+        ApplyColumnTypes(builder);
+    }
+}

--- a/src/NetEvolve.Pulse.EntityFramework/Configurations/InMemoryAuditEntryConfiguration.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Configurations/InMemoryAuditEntryConfiguration.cs
@@ -1,0 +1,26 @@
+namespace NetEvolve.Pulse.Configurations;
+
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.Audit;
+
+/// <summary>
+/// Entity Framework Core configuration for <see cref="Extensibility.Audit.AuditRecord"/> targeting the
+/// <c>Microsoft.EntityFrameworkCore.InMemory</c> provider.
+/// Intended for testing only.
+/// </summary>
+internal sealed class InMemoryAuditEntryConfiguration : AuditEntryConfigurationBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InMemoryAuditEntryConfiguration"/> class
+    /// with default options.
+    /// </summary>
+    public InMemoryAuditEntryConfiguration()
+        : this(Options.Create(new AuditStoreOptions())) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InMemoryAuditEntryConfiguration"/> class.
+    /// </summary>
+    /// <param name="options">The audit store options containing schema and table configuration.</param>
+    public InMemoryAuditEntryConfiguration(IOptions<AuditStoreOptions> options)
+        : base(options) { }
+}

--- a/src/NetEvolve.Pulse.EntityFramework/Configurations/MySqlAuditEntryConfiguration.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Configurations/MySqlAuditEntryConfiguration.cs
@@ -1,0 +1,64 @@
+namespace NetEvolve.Pulse.Configurations;
+
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.Audit;
+using NetEvolve.Pulse.Extensibility.Audit;
+
+/// <summary>
+/// Entity Framework Core configuration for <see cref="AuditRecord"/> targeting MySQL
+/// via the Oracle provider (<c>MySql.EntityFrameworkCore</c>).
+/// </summary>
+/// <remarks>
+/// <para><strong>Column Types:</strong></para>
+/// <list type="bullet">
+/// <item><description><c>varchar(500)</c> for the command type column</description></item>
+/// <item><description><c>varchar(256)</c> for the user id column</description></item>
+/// <item><description><c>varchar(100)</c> for the correlation id column</description></item>
+/// <item><description><c>longtext</c> for the payload and exception message columns</description></item>
+/// <item><description><c>bigint</c> for <see cref="DateTimeOffset"/> — stored as UTC ticks via a <see langword="long"/> value converter</description></item>
+/// </list>
+/// <para><strong>Why bigint for DateTimeOffset:</strong></para>
+/// The Oracle MySQL provider (<c>MySql.EntityFrameworkCore</c>) lacks a proper
+/// <c>datetimeoffset</c> type mapping. Converting to <see langword="long"/> (UTC ticks)
+/// eliminates the broken provider-specific type resolution and ensures correct ordering
+/// and comparison semantics.
+/// </remarks>
+internal sealed class MySqlAuditEntryConfiguration : AuditEntryConfigurationBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MySqlAuditEntryConfiguration"/> class with default options.
+    /// </summary>
+    public MySqlAuditEntryConfiguration()
+        : this(Options.Create(new AuditStoreOptions())) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MySqlAuditEntryConfiguration"/> class.
+    /// </summary>
+    /// <param name="options">The audit store options containing schema and table configuration.</param>
+    public MySqlAuditEntryConfiguration(IOptions<AuditStoreOptions> options)
+        : base(options) { }
+
+    /// <inheritdoc />
+    protected override void ApplyColumnTypes(EntityTypeBuilder<AuditRecord> builder)
+    {
+        _ = builder.Property(e => e.CommandType).HasColumnType("varchar(500)");
+        _ = builder.Property(e => e.UserId).HasColumnType("varchar(256)");
+        _ = builder.Property(e => e.CorrelationId).HasColumnType("varchar(100)");
+        _ = builder.Property(e => e.Payload).HasColumnType("longtext");
+        _ = builder.Property(e => e.ExceptionMessage).HasColumnType("longtext");
+
+        // DateTimeOffset is stored as BIGINT (UTC ticks).
+        // The Oracle MySQL provider lacks a proper DateTimeOffset type mapping for
+        // parameterised operations. Converting to long eliminates the broken provider-specific
+        // type resolution and ensures correct ordering and comparison semantics.
+        // The read-back uses TimeSpan.Zero because the value is always persisted as UTC ticks
+        // (v.UtcTicks), so the reconstructed DateTimeOffset correctly represents UTC.
+        _ = builder
+            .Property(e => e.OccurredAt)
+            .HasColumnType("bigint")
+            .HasConversion(v => v.UtcTicks, v => new DateTimeOffset(v, TimeSpan.Zero));
+    }
+}

--- a/src/NetEvolve.Pulse.EntityFramework/Configurations/PostgreSqlAuditEntryConfiguration.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Configurations/PostgreSqlAuditEntryConfiguration.cs
@@ -1,0 +1,39 @@
+namespace NetEvolve.Pulse.Configurations;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.Audit;
+using NetEvolve.Pulse.Extensibility.Audit;
+
+/// <summary>
+/// Entity Framework Core configuration for <see cref="AuditRecord"/> targeting PostgreSQL.
+/// Uses native PostgreSQL column types for optimal compatibility.
+/// </summary>
+internal sealed class PostgreSqlAuditEntryConfiguration : AuditEntryConfigurationBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PostgreSqlAuditEntryConfiguration"/> class with default options.
+    /// </summary>
+    public PostgreSqlAuditEntryConfiguration()
+        : this(Options.Create(new AuditStoreOptions())) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PostgreSqlAuditEntryConfiguration"/> class.
+    /// </summary>
+    /// <param name="options">The audit store options containing schema and table configuration.</param>
+    public PostgreSqlAuditEntryConfiguration(IOptions<AuditStoreOptions> options)
+        : base(options) { }
+
+    /// <inheritdoc />
+    protected override void ApplyColumnTypes(EntityTypeBuilder<AuditRecord> builder)
+    {
+        _ = builder.Property(e => e.CommandType).HasColumnType("character varying(500)");
+        _ = builder.Property(e => e.UserId).HasColumnType("character varying(256)");
+        _ = builder.Property(e => e.CorrelationId).HasColumnType("character varying(100)");
+        _ = builder.Property(e => e.Payload).HasColumnType("text");
+        _ = builder.Property(e => e.ExceptionMessage).HasColumnType("text");
+        // "timestamp with time zone" (timestamptz) preserves UTC correctly.
+        _ = builder.Property(e => e.OccurredAt).HasColumnType("timestamp with time zone");
+    }
+}

--- a/src/NetEvolve.Pulse.EntityFramework/Configurations/SqlServerAuditEntryConfiguration.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Configurations/SqlServerAuditEntryConfiguration.cs
@@ -1,0 +1,38 @@
+namespace NetEvolve.Pulse.Configurations;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.Audit;
+using NetEvolve.Pulse.Extensibility.Audit;
+
+/// <summary>
+/// Entity Framework Core configuration for <see cref="AuditRecord"/> targeting SQL Server.
+/// Applies the canonical schema to ensure interchangeability with other persistence providers.
+/// </summary>
+internal sealed class SqlServerAuditEntryConfiguration : AuditEntryConfigurationBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SqlServerAuditEntryConfiguration"/> class with default options.
+    /// </summary>
+    public SqlServerAuditEntryConfiguration()
+        : this(Options.Create(new AuditStoreOptions())) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SqlServerAuditEntryConfiguration"/> class.
+    /// </summary>
+    /// <param name="options">The audit store options containing schema and table configuration.</param>
+    public SqlServerAuditEntryConfiguration(IOptions<AuditStoreOptions> options)
+        : base(options) { }
+
+    /// <inheritdoc />
+    protected override void ApplyColumnTypes(EntityTypeBuilder<AuditRecord> builder)
+    {
+        _ = builder.Property(e => e.CommandType).HasColumnType("nvarchar(500)");
+        _ = builder.Property(e => e.UserId).HasColumnType("nvarchar(256)");
+        _ = builder.Property(e => e.CorrelationId).HasColumnType("nvarchar(100)");
+        _ = builder.Property(e => e.Payload).HasColumnType("nvarchar(max)");
+        _ = builder.Property(e => e.ExceptionMessage).HasColumnType("nvarchar(max)");
+        _ = builder.Property(e => e.OccurredAt).HasColumnType("datetimeoffset");
+    }
+}

--- a/src/NetEvolve.Pulse.EntityFramework/Configurations/SqliteAuditEntryConfiguration.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/Configurations/SqliteAuditEntryConfiguration.cs
@@ -1,0 +1,47 @@
+namespace NetEvolve.Pulse.Configurations;
+
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.Audit;
+using NetEvolve.Pulse.Extensibility.Audit;
+
+/// <summary>
+/// Entity Framework Core configuration for <see cref="AuditRecord"/> targeting SQLite.
+/// Uses native SQLite storage classes for optimal compatibility.
+/// </summary>
+/// <remarks>
+/// SQLite does not support named schemas. If <see cref="AuditStoreOptions.Schema"/> is set,
+/// it will be passed to EF Core which silently ignores it for SQLite.
+/// </remarks>
+internal sealed class SqliteAuditEntryConfiguration : AuditEntryConfigurationBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SqliteAuditEntryConfiguration"/> class with default options.
+    /// </summary>
+    public SqliteAuditEntryConfiguration()
+        : this(Options.Create(new AuditStoreOptions())) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SqliteAuditEntryConfiguration"/> class.
+    /// </summary>
+    /// <param name="options">The audit store options containing schema and table configuration.</param>
+    public SqliteAuditEntryConfiguration(IOptions<AuditStoreOptions> options)
+        : base(options) { }
+
+    /// <inheritdoc />
+    protected override void ApplyColumnTypes(EntityTypeBuilder<AuditRecord> builder)
+    {
+        _ = builder.Property(e => e.CommandType).HasColumnType("TEXT");
+        _ = builder.Property(e => e.UserId).HasColumnType("TEXT");
+        _ = builder.Property(e => e.CorrelationId).HasColumnType("TEXT");
+        _ = builder.Property(e => e.Payload).HasColumnType("TEXT");
+        _ = builder.Property(e => e.ExceptionMessage).HasColumnType("TEXT");
+        // DateTimeOffset stored as INTEGER (UTC ticks) for correct ordering in SQLite.
+        _ = builder
+            .Property(e => e.OccurredAt)
+            .HasColumnType("INTEGER")
+            .HasConversion(v => v.UtcTicks, v => new DateTimeOffset(v, TimeSpan.Zero));
+    }
+}

--- a/src/NetEvolve.Pulse.EntityFramework/EntityFrameworkAuditExtensions.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/EntityFrameworkAuditExtensions.cs
@@ -1,0 +1,72 @@
+namespace NetEvolve.Pulse;
+
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using NetEvolve.Pulse.Audit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.Audit;
+
+/// <summary>
+/// Extension methods for configuring the Entity Framework Core audit trail store on <see cref="IMediatorBuilder"/>.
+/// </summary>
+public static class EntityFrameworkAuditExtensions
+{
+    /// <summary>
+    /// Adds Entity Framework Core-backed audit trail persistence with the specified DbContext.
+    /// </summary>
+    /// <typeparam name="TContext">The DbContext type that implements <see cref="IAuditStoreDbContext"/>.</typeparam>
+    /// <param name="configurator">The mediator configurator.</param>
+    /// <param name="configureOptions">Optional action to configure <see cref="AuditStoreOptions"/>.</param>
+    /// <returns>The configurator for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configurator"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para><strong>Prerequisites:</strong></para>
+    /// <list type="number">
+    /// <item><description>Your DbContext must implement <see cref="IAuditStoreDbContext"/></description></item>
+    /// <item><description>Apply <see cref="ModelBuilderExtensions.ApplyPulseConfiguration{TContext}(ModelBuilder, TContext)"/> in OnModelCreating</description></item>
+    /// <item><description>Generate and apply migrations with your chosen provider</description></item>
+    /// </list>
+    /// <para><strong>Registered Services:</strong></para>
+    /// <list type="bullet">
+    /// <item><description><see cref="IAuditStore"/> as <see cref="EntityFrameworkAuditStore{TContext}"/> (Scoped)</description></item>
+    /// <item><description><see cref="IAuditManagement"/> as <see cref="EntityFrameworkAuditManagement{TContext}"/> (Scoped)</description></item>
+    /// </list>
+    /// <para><strong>Note:</strong></para>
+    /// The DbContext must already be registered in the service collection.
+    /// This method does not register the DbContext itself.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// // Register DbContext with your chosen provider
+    /// services.AddDbContext&lt;MyDbContext&gt;(options =&gt;
+    ///     options.UseSqlServer(connectionString));
+    ///
+    /// // Add audit trail support
+    /// services.AddPulse(config =&gt; config
+    ///     .AddEntityFrameworkAuditStore&lt;MyDbContext&gt;()
+    /// );
+    /// </code>
+    /// </example>
+    public static IMediatorBuilder AddEntityFrameworkAuditStore<TContext>(
+        this IMediatorBuilder configurator,
+        Action<AuditStoreOptions>? configureOptions = null
+    )
+        where TContext : DbContext, IAuditStoreDbContext
+    {
+        ArgumentNullException.ThrowIfNull(configurator);
+
+        var services = configurator.Services;
+
+        _ = services.Configure(configureOptions ?? (_ => { }));
+
+        _ = services.RemoveAll<IAuditStore>().AddScoped<IAuditStore, EntityFrameworkAuditStore<TContext>>();
+
+        _ = services
+            .RemoveAll<IAuditManagement>()
+            .AddScoped<IAuditManagement, EntityFrameworkAuditManagement<TContext>>();
+
+        return configurator;
+    }
+}

--- a/src/NetEvolve.Pulse.EntityFramework/ModelBuilderExtensions.cs
+++ b/src/NetEvolve.Pulse.EntityFramework/ModelBuilderExtensions.cs
@@ -3,8 +3,10 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.Audit;
 using NetEvolve.Pulse.Configurations;
 using NetEvolve.Pulse.DeadLetter;
+using NetEvolve.Pulse.Extensibility.Audit;
 using NetEvolve.Pulse.Extensibility.DeadLetter;
 using NetEvolve.Pulse.Extensibility.Outbox;
 using NetEvolve.Pulse.Idempotency;
@@ -18,7 +20,7 @@ public static class ModelBuilderExtensions
     /// <summary>
     /// Applies all Pulse-related entity configurations to the model builder.
     /// </summary>
-    /// <typeparam name="TContext">The DbContext type. When it implements <see cref="IOutboxDbContext"/>, the outbox message configuration is applied automatically. When it implements <see cref="IIdempotencyStoreDbContext"/>, the idempotency key configuration is applied automatically. When it implements <see cref="ICommandDeadLetterDbContext"/>, the command dead letter entry configuration is applied automatically.</typeparam>
+    /// <typeparam name="TContext">The DbContext type. When it implements <see cref="IOutboxDbContext"/>, the outbox message configuration is applied automatically. When it implements <see cref="IIdempotencyStoreDbContext"/>, the idempotency key configuration is applied automatically. When it implements <see cref="ICommandDeadLetterDbContext"/>, the command dead letter entry configuration is applied automatically. When it implements <see cref="IAuditStoreDbContext"/>, the audit entry configuration is applied automatically.</typeparam>
     /// <param name="modelBuilder">The model builder to apply the configuration to.</param>
     /// <param name="context">The DbContext instance used to resolve provider-specific configuration.</param>
     /// <returns>The <paramref name="modelBuilder"/> for chaining.</returns>
@@ -47,6 +49,13 @@ public static class ModelBuilderExtensions
         if (context is ICommandDeadLetterDbContext)
         {
             var configuration = GetCommandDeadLetterConfiguration(context, providerName);
+
+            _ = modelBuilder.ApplyConfiguration(configuration);
+        }
+
+        if (context is IAuditStoreDbContext)
+        {
+            var configuration = GetAuditEntryConfiguration(context, providerName);
 
             _ = modelBuilder.ApplyConfiguration(configuration);
         }
@@ -173,6 +182,45 @@ public static class ModelBuilderExtensions
                 resolvedOptions
             ),
             ProviderName.InMemory => new InMemoryCommandDeadLetterEntryConfiguration(resolvedOptions),
+            _ => throw new NotSupportedException($"Unsupported EF Core provider: {providerName}"),
+        };
+    }
+
+    /// <summary>
+    /// Selects and instantiates the provider-appropriate <see cref="IEntityTypeConfiguration{TEntity}"/>
+    /// for <see cref="AuditRecord"/> based on the active EF Core provider.
+    /// </summary>
+    /// <typeparam name="TContext">The DbContext type, used to resolve registered <see cref="AuditStoreOptions"/>.</typeparam>
+    /// <param name="context">The DbContext instance used to resolve <see cref="IOptions{TOptions}"/> of <see cref="AuditStoreOptions"/>.</param>
+    /// <param name="providerName">The EF Core provider name read from <see cref="DatabaseFacade.ProviderName"/>.</param>
+    /// <returns>A provider-specific <see cref="IEntityTypeConfiguration{TEntity}"/> for <see cref="AuditRecord"/>.</returns>
+    /// <exception cref="NotSupportedException">Thrown when <paramref name="providerName"/> is not a supported EF Core provider.</exception>
+    private static IEntityTypeConfiguration<AuditRecord> GetAuditEntryConfiguration<TContext>(
+        TContext context,
+        string? providerName
+    )
+        where TContext : DbContext
+    {
+        IOptions<AuditStoreOptions>? resolvedOptions = null;
+        try
+        {
+            // EF Core's GetService throws InvalidOperationException when the service is not
+            // registered (instead of returning null), so we catch and fall back to defaults.
+            resolvedOptions = context.GetService<IOptions<AuditStoreOptions>>();
+        }
+        catch (InvalidOperationException)
+        {
+            // IOptions<AuditStoreOptions> not registered; use default options.
+        }
+
+        resolvedOptions ??= Options.Create(new AuditStoreOptions());
+        return providerName switch
+        {
+            ProviderName.Npgsql => new PostgreSqlAuditEntryConfiguration(resolvedOptions),
+            ProviderName.Sqlite => new SqliteAuditEntryConfiguration(resolvedOptions),
+            ProviderName.SqlServer => new SqlServerAuditEntryConfiguration(resolvedOptions),
+            ProviderName.PomeloMySql or ProviderName.OracleMySql => new MySqlAuditEntryConfiguration(resolvedOptions),
+            ProviderName.InMemory => new InMemoryAuditEntryConfiguration(resolvedOptions),
             _ => throw new NotSupportedException($"Unsupported EF Core provider: {providerName}"),
         };
     }

--- a/src/NetEvolve.Pulse.Extensibility/Audit/AuditEntrySchema.cs
+++ b/src/NetEvolve.Pulse.Extensibility/Audit/AuditEntrySchema.cs
@@ -1,0 +1,118 @@
+namespace NetEvolve.Pulse.Extensibility.Audit;
+
+using System.Diagnostics.CodeAnalysis;
+
+/// <summary>
+/// Defines the canonical database schema for audit trail entries.
+/// All persistence providers MUST use these constants to ensure interchangeability.
+/// </summary>
+public static class AuditEntrySchema
+{
+    /// <summary>
+    /// Default schema name for the audit entry table.
+    /// </summary>
+    public const string DefaultSchema = "pulse";
+
+    /// <summary>
+    /// Default table name for the audit entries.
+    /// </summary>
+    public const string DefaultTableName = "AuditEntry";
+
+    /// <summary>
+    /// Column name constants matching <see cref="AuditRecord"/> properties.
+    /// </summary>
+    [SuppressMessage(
+        "Design",
+        "CA1034:Nested types should not be visible",
+        Justification = "Intentionally nested for organizational clarity - constants grouped by purpose."
+    )]
+    public static class Columns
+    {
+        /// <summary>
+        /// The Id column name.
+        /// </summary>
+        public const string Id = "Id";
+
+        /// <summary>
+        /// The CommandType column name.
+        /// </summary>
+        public const string CommandType = "CommandType";
+
+        /// <summary>
+        /// The UserId column name.
+        /// </summary>
+        public const string UserId = "UserId";
+
+        /// <summary>
+        /// The CorrelationId column name.
+        /// </summary>
+        public const string CorrelationId = "CorrelationId";
+
+        /// <summary>
+        /// The OccurredAt column name.
+        /// </summary>
+        public const string OccurredAt = "OccurredAt";
+
+        /// <summary>
+        /// The DurationMs column name.
+        /// </summary>
+        public const string DurationMs = "DurationMs";
+
+        /// <summary>
+        /// The Result column name.
+        /// </summary>
+        public const string Result = "Result";
+
+        /// <summary>
+        /// The Payload column name.
+        /// </summary>
+        public const string Payload = "Payload";
+
+        /// <summary>
+        /// The ExceptionMessage column name.
+        /// </summary>
+        public const string ExceptionMessage = "ExceptionMessage";
+    }
+
+    /// <summary>
+    /// Recommended maximum lengths for string columns.
+    /// </summary>
+    [SuppressMessage(
+        "Design",
+        "CA1034:Nested types should not be visible",
+        Justification = "Intentionally nested for organizational clarity - constants grouped by purpose."
+    )]
+    public static class MaxLengths
+    {
+        /// <summary>
+        /// Maximum length for CommandType column (500 characters).
+        /// </summary>
+        public const int CommandType = 500;
+
+        /// <summary>
+        /// Maximum length for UserId column (256 characters).
+        /// </summary>
+        public const int UserId = 256;
+
+        /// <summary>
+        /// Maximum length for CorrelationId column (100 characters).
+        /// </summary>
+        public const int CorrelationId = 100;
+    }
+}
+
+/// <summary>
+/// Represents the outcome of a request that was recorded to the audit trail.
+/// </summary>
+public enum AuditResult
+{
+    /// <summary>
+    /// The request completed successfully.
+    /// </summary>
+    Success = 0,
+
+    /// <summary>
+    /// The request failed, i.e. the handler threw an exception.
+    /// </summary>
+    Failure = 1,
+}

--- a/src/NetEvolve.Pulse.Extensibility/Audit/AuditRecord.cs
+++ b/src/NetEvolve.Pulse.Extensibility/Audit/AuditRecord.cs
@@ -1,0 +1,89 @@
+namespace NetEvolve.Pulse.Extensibility.Audit;
+
+/// <summary>
+/// Represents a single audit trail entry recorded for a processed request.
+/// This entity serves as the canonical schema contract shared across all persistence providers.
+/// </summary>
+/// <remarks>
+/// <para><strong>Schema Contract:</strong></para>
+/// All persistence implementations (SQL Server, Entity Framework, etc.) MUST use
+/// identical column names and types to ensure interchangeability. This type is reused
+/// directly as the Entity Framework Core entity for the audit trail store, in the same
+/// manner <c>NetEvolve.Pulse.Extensibility.Outbox.OutboxMessage</c> is reused directly as
+/// the EF entity for the outbox, and <c>CommandDeadLetterEntry</c> is reused directly as
+/// the EF entity for the command dead letter store.
+/// <para><strong>Column Specifications:</strong></para>
+/// <list type="bullet">
+/// <item><description><see cref="Id"/>: UNIQUEIDENTIFIER / GUID, Primary Key</description></item>
+/// <item><description><see cref="CommandType"/>: NVARCHAR(500), NOT NULL - Runtime type name of the request</description></item>
+/// <item><description><see cref="UserId"/>: NVARCHAR(256), NULL - Identifier of the user who issued the request</description></item>
+/// <item><description><see cref="CorrelationId"/>: NVARCHAR(100), NULL - Correlation identifier associated with the request</description></item>
+/// <item><description><see cref="OccurredAt"/>: DATETIMEOFFSET, NOT NULL - Timestamp the request was recorded</description></item>
+/// <item><description><see cref="DurationMs"/>: FLOAT, NOT NULL - Elapsed time, in milliseconds, of the handler invocation</description></item>
+/// <item><description><see cref="Result"/>: INT, NOT NULL - Audit result enum value</description></item>
+/// <item><description><see cref="Payload"/>: NVARCHAR(MAX) / TEXT, NULL - JSON serialized request payload, only populated when capturing payloads is enabled</description></item>
+/// <item><description><see cref="ExceptionMessage"/>: NVARCHAR(MAX) / TEXT, NULL - Message of the exception that caused the failure</description></item>
+/// </list>
+/// </remarks>
+public sealed class AuditRecord
+{
+    /// <summary>
+    /// Gets or sets the unique identifier for this audit record.
+    /// </summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the type name of the request that was processed.
+    /// </summary>
+    /// <remarks>
+    /// Stored in the database as a string (maximum 500 characters).
+    /// </remarks>
+    public string CommandType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the identifier of the user who issued the request.
+    /// </summary>
+    /// <remarks>
+    /// Maximum length: 256 characters. <see langword="null"/> when no user could be resolved.
+    /// </remarks>
+    public string? UserId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the correlation identifier associated with the request.
+    /// </summary>
+    /// <remarks>
+    /// Maximum length: 100 characters.
+    /// </remarks>
+    public string? CorrelationId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the timestamp when this request was recorded.
+    /// </summary>
+    public DateTimeOffset OccurredAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the elapsed time, in milliseconds, of the handler invocation.
+    /// </summary>
+    public double DurationMs { get; set; }
+
+    /// <summary>
+    /// Gets or sets the outcome of the request.
+    /// </summary>
+    public AuditResult Result { get; set; }
+
+    /// <summary>
+    /// Gets or sets the JSON serialized request payload.
+    /// </summary>
+    /// <remarks>
+    /// Only populated when <c>AuditOptions.CapturePayload</c> is set to <see langword="true"/>.
+    /// </remarks>
+    public string? Payload { get; set; }
+
+    /// <summary>
+    /// Gets or sets the message of the exception that caused the failure.
+    /// </summary>
+    /// <remarks>
+    /// Only populated when <see cref="Result"/> is <see cref="AuditResult.Failure"/>.
+    /// </remarks>
+    public string? ExceptionMessage { get; set; }
+}

--- a/src/NetEvolve.Pulse.Extensibility/Audit/AuditStatistics.cs
+++ b/src/NetEvolve.Pulse.Extensibility/Audit/AuditStatistics.cs
@@ -1,0 +1,15 @@
+namespace NetEvolve.Pulse.Extensibility.Audit;
+
+/// <summary>
+/// Represents the aggregate counts of audit trail records per <see cref="AuditResult"/>.
+/// This is the value returned by <see cref="IAuditManagement.GetStatisticsAsync"/>.
+/// </summary>
+/// <param name="SuccessCount">The number of records with <see cref="AuditResult.Success"/> result.</param>
+/// <param name="FailureCount">The number of records with <see cref="AuditResult.Failure"/> result.</param>
+public sealed record AuditStatistics(int SuccessCount, int FailureCount)
+{
+    /// <summary>
+    /// Gets the total number of audit records across all results.
+    /// </summary>
+    public int TotalCount => SuccessCount + FailureCount;
+}

--- a/src/NetEvolve.Pulse.Extensibility/Audit/IAuditManagement.cs
+++ b/src/NetEvolve.Pulse.Extensibility/Audit/IAuditManagement.cs
@@ -1,0 +1,86 @@
+namespace NetEvolve.Pulse.Extensibility.Audit;
+
+/// <summary>
+/// Defines the contract for querying audit trail records.
+/// </summary>
+public interface IAuditManagement
+{
+    /// <summary>
+    /// Retrieves the audit records matching the given <paramref name="filter"/>.
+    /// </summary>
+    /// <param name="filter">The filter conditions to apply.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>
+    /// A read-only list of audit records matching all non-<see langword="null"/> conditions
+    /// of <paramref name="filter"/> (AND-combined), ordered by <see cref="AuditRecord.OccurredAt"/>
+    /// descending (most recent first), with <see cref="AuditFilter.Skip"/> and
+    /// <see cref="AuditFilter.Take"/> applied for pagination.
+    /// </returns>
+    Task<IReadOnlyList<AuditRecord>> QueryAsync(AuditFilter filter, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves aggregate counts of audit records per <see cref="AuditResult"/>.
+    /// </summary>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>
+    /// An <see cref="AuditStatistics"/> instance describing the aggregate counts across
+    /// all audit records.
+    /// </returns>
+    Task<AuditStatistics> GetStatisticsAsync(CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Describes the filter conditions applied by <see cref="IAuditManagement.QueryAsync"/>.
+/// </summary>
+public sealed class AuditFilter
+{
+    /// <summary>
+    /// Gets or sets the request type name to filter by.
+    /// </summary>
+    /// <remarks>
+    /// When <see langword="null"/>, records are not filtered by <see cref="AuditRecord.CommandType"/>.
+    /// </remarks>
+    public string? CommandType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the user identifier to filter by.
+    /// </summary>
+    /// <remarks>
+    /// When <see langword="null"/>, records are not filtered by <see cref="AuditRecord.UserId"/>.
+    /// </remarks>
+    public string? UserId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the inclusive lower bound of <see cref="AuditRecord.OccurredAt"/> to filter by.
+    /// </summary>
+    /// <remarks>
+    /// When <see langword="null"/>, records are not filtered by a lower bound.
+    /// </remarks>
+    public DateTimeOffset? From { get; set; }
+
+    /// <summary>
+    /// Gets or sets the inclusive upper bound of <see cref="AuditRecord.OccurredAt"/> to filter by.
+    /// </summary>
+    /// <remarks>
+    /// When <see langword="null"/>, records are not filtered by an upper bound.
+    /// </remarks>
+    public DateTimeOffset? To { get; set; }
+
+    /// <summary>
+    /// Gets or sets the audit result to filter by.
+    /// </summary>
+    /// <remarks>
+    /// When <see langword="null"/>, records are not filtered by <see cref="AuditRecord.Result"/>.
+    /// </remarks>
+    public AuditResult? Result { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of records to return. Default: <c>50</c>.
+    /// </summary>
+    public int Take { get; set; } = 50;
+
+    /// <summary>
+    /// Gets or sets the number of matching records to skip, for pagination. Default: <c>0</c>.
+    /// </summary>
+    public int Skip { get; set; }
+}

--- a/src/NetEvolve.Pulse.Extensibility/Audit/IAuditStore.cs
+++ b/src/NetEvolve.Pulse.Extensibility/Audit/IAuditStore.cs
@@ -1,0 +1,20 @@
+namespace NetEvolve.Pulse.Extensibility.Audit;
+
+/// <summary>
+/// Defines the contract for persisting audit trail records.
+/// </summary>
+/// <remarks>
+/// <para><strong>Implementation Guidelines:</strong></para>
+/// Implementations MUST persist the given <see cref="AuditRecord"/> as a new row, without
+/// modifying any of its property values.
+/// </remarks>
+public interface IAuditStore
+{
+    /// <summary>
+    /// Stores the given audit record.
+    /// </summary>
+    /// <param name="record">The audit record to persist.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task RecordAsync(AuditRecord record, CancellationToken cancellationToken = default);
+}

--- a/src/NetEvolve.Pulse.Extensibility/Audit/IAuditUserAccessor.cs
+++ b/src/NetEvolve.Pulse.Extensibility/Audit/IAuditUserAccessor.cs
@@ -1,0 +1,19 @@
+namespace NetEvolve.Pulse.Extensibility.Audit;
+
+/// <summary>
+/// Abstracts the retrieval of the current user for audit trail recording.
+/// </summary>
+/// <remarks>
+/// Decouples the core library from any specific hosting model (ASP.NET Core, a background
+/// service, a console application, etc.). Hosting integrations provide their own
+/// implementation, e.g. one backed by <c>IHttpContextAccessor</c> in ASP.NET Core.
+/// </remarks>
+public interface IAuditUserAccessor
+{
+    /// <summary>
+    /// Gets the identifier of the current user, or <see langword="null"/> when no user
+    /// could be resolved (e.g. no active request, or the request is unauthenticated).
+    /// </summary>
+    /// <returns>The identifier of the current user, or <see langword="null"/>.</returns>
+    string? GetCurrentUser();
+}

--- a/src/NetEvolve.Pulse.MySql/Audit/MySqlAuditManagement.cs
+++ b/src/NetEvolve.Pulse.MySql/Audit/MySqlAuditManagement.cs
@@ -1,0 +1,272 @@
+namespace NetEvolve.Pulse.Audit;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using MySql.Data.MySqlClient;
+using NetEvolve.Pulse.Extensibility.Audit;
+using NetEvolve.Pulse.Extensibility.Outbox;
+
+/// <summary>
+/// MySQL implementation of <see cref="IAuditManagement"/> using ADO.NET.
+/// Provides filtered querying and statistics aggregation for the audit trail store.
+/// </summary>
+/// <remarks>
+/// <para><strong>Prerequisites:</strong></para>
+/// Execute the schema script from <c>Scripts/AuditEntry.sql</c> to create the required
+/// database objects before using this provider.
+/// <para><strong>Schema:</strong></para>
+/// MySQL does not use schema namespaces in the same way as SQL Server or PostgreSQL.
+/// All tables reside in the active database specified by the connection string.
+/// The <see cref="AuditStoreOptions.Schema"/> property is ignored for MySQL.
+/// <para><strong>Timestamps:</strong></para>
+/// Stores <see cref="DateTimeOffset"/> values as <c>BIGINT</c> (UTC ticks), matching the
+/// interoperability contract with the Entity Framework MySQL provider.
+/// </remarks>
+[SuppressMessage(
+    "Reliability",
+    "CA2007:Consider calling ConfigureAwait on the awaited task",
+    Justification = "await using statements in library code; ConfigureAwait applied to all Task-returning awaits."
+)]
+[SuppressMessage(
+    "Security",
+    "CA2100:Review SQL queries for security vulnerabilities",
+    Justification = "SQL is constructed from validated AuditStoreOptions.TableName property, not user input."
+)]
+internal sealed class MySqlAuditManagement : IAuditManagement
+{
+    private readonly string _connectionString;
+    private readonly string _table;
+    private readonly string _getStatisticsSql;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MySqlAuditManagement"/> class.
+    /// </summary>
+    /// <param name="options">The audit trail store configuration options.</param>
+    public MySqlAuditManagement(IOptions<AuditStoreOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrWhiteSpace(options.Value.ConnectionString);
+
+        var opts = options.Value;
+        _connectionString = opts.ConnectionString;
+
+        SqlIdentifier.Validate(opts.TableName, nameof(opts.TableName));
+        _table = $"`{opts.TableName}`";
+
+        _getStatisticsSql = $"""
+            SELECT `{AuditEntrySchema.Columns.Result}`, COUNT(*)
+            FROM {_table}
+            GROUP BY `{AuditEntrySchema.Columns.Result}`
+            """;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<AuditRecord>> QueryAsync(
+        AuditFilter filter,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+
+        var sql = new StringBuilder();
+        _ = sql.Append(
+            CultureInfo.InvariantCulture,
+            $"""
+            SELECT
+                `{AuditEntrySchema.Columns.Id}`,
+                `{AuditEntrySchema.Columns.CommandType}`,
+                `{AuditEntrySchema.Columns.UserId}`,
+                `{AuditEntrySchema.Columns.CorrelationId}`,
+                `{AuditEntrySchema.Columns.OccurredAt}`,
+                `{AuditEntrySchema.Columns.DurationMs}`,
+                `{AuditEntrySchema.Columns.Result}`,
+                `{AuditEntrySchema.Columns.Payload}`,
+                `{AuditEntrySchema.Columns.ExceptionMessage}`
+            FROM {_table}
+            WHERE 1 = 1
+            """
+        );
+
+        if (filter.CommandType is not null)
+        {
+            _ = sql.Append(
+                CultureInfo.InvariantCulture,
+                $" AND `{AuditEntrySchema.Columns.CommandType}` = @commandType"
+            );
+        }
+
+        if (filter.UserId is not null)
+        {
+            _ = sql.Append(CultureInfo.InvariantCulture, $" AND `{AuditEntrySchema.Columns.UserId}` = @userId");
+        }
+
+        if (filter.From is not null)
+        {
+            _ = sql.Append(CultureInfo.InvariantCulture, $" AND `{AuditEntrySchema.Columns.OccurredAt}` >= @from");
+        }
+
+        if (filter.To is not null)
+        {
+            _ = sql.Append(CultureInfo.InvariantCulture, $" AND `{AuditEntrySchema.Columns.OccurredAt}` <= @to");
+        }
+
+        if (filter.Result is not null)
+        {
+            _ = sql.Append(CultureInfo.InvariantCulture, $" AND `{AuditEntrySchema.Columns.Result}` = @result");
+        }
+
+        _ = sql.Append(CultureInfo.InvariantCulture, $" ORDER BY `{AuditEntrySchema.Columns.OccurredAt}` DESC");
+        _ = sql.Append(" LIMIT @take OFFSET @skip");
+
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var command = new MySqlCommand(sql.ToString(), connection);
+            await using (command.ConfigureAwait(false))
+            {
+                if (filter.CommandType is not null)
+                {
+                    _ = command.Parameters.AddWithValue("@commandType", filter.CommandType);
+                }
+
+                if (filter.UserId is not null)
+                {
+                    _ = command.Parameters.AddWithValue("@userId", filter.UserId);
+                }
+
+                if (filter.From is not null)
+                {
+                    _ = command.Parameters.AddWithValue("@from", filter.From.Value.UtcTicks);
+                }
+
+                if (filter.To is not null)
+                {
+                    _ = command.Parameters.AddWithValue("@to", filter.To.Value.UtcTicks);
+                }
+
+                if (filter.Result is not null)
+                {
+                    _ = command.Parameters.AddWithValue("@result", (int)filter.Result.Value);
+                }
+
+                _ = command.Parameters.AddWithValue("@take", filter.Take);
+                _ = command.Parameters.AddWithValue("@skip", filter.Skip);
+
+                return await ReadRecordsAsync(command, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<AuditStatistics> GetStatisticsAsync(CancellationToken cancellationToken = default)
+    {
+        var successCount = 0;
+        var failureCount = 0;
+
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var command = new MySqlCommand(_getStatisticsSql, connection);
+            await using (command.ConfigureAwait(false))
+            {
+                var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                await using (reader.ConfigureAwait(false))
+                {
+                    while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                    {
+                        var result = (AuditResult)reader.GetInt32(0);
+                        var count = Convert.ToInt32(reader.GetValue(1), CultureInfo.InvariantCulture);
+
+                        switch (result)
+                        {
+                            case AuditResult.Success:
+                                successCount = count;
+                                break;
+                            case AuditResult.Failure:
+                                failureCount = count;
+                                break;
+                        }
+                    }
+                }
+            }
+        }
+
+        return new AuditStatistics(successCount, failureCount);
+    }
+
+    /// <summary>
+    /// Opens and returns a new <see cref="MySqlConnection"/> using the stored connection string.
+    /// The caller is responsible for disposing the connection.
+    /// </summary>
+    private async Task<MySqlConnection> CreateConnectionAsync(CancellationToken cancellationToken)
+    {
+        var connection = new MySqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        return connection;
+    }
+
+    /// <summary>
+    /// Executes <paramref name="command"/> and reads all rows into a list of <see cref="AuditRecord"/> instances.
+    /// </summary>
+    private static async Task<IReadOnlyList<AuditRecord>> ReadRecordsAsync(
+        MySqlCommand command,
+        CancellationToken cancellationToken
+    )
+    {
+        var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        await using (reader.ConfigureAwait(false))
+        {
+            if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                return [];
+            }
+
+            var ordId = reader.GetOrdinal(AuditEntrySchema.Columns.Id);
+            var ordCommandType = reader.GetOrdinal(AuditEntrySchema.Columns.CommandType);
+            var ordUserId = reader.GetOrdinal(AuditEntrySchema.Columns.UserId);
+            var ordCorrelationId = reader.GetOrdinal(AuditEntrySchema.Columns.CorrelationId);
+            var ordOccurredAt = reader.GetOrdinal(AuditEntrySchema.Columns.OccurredAt);
+            var ordDurationMs = reader.GetOrdinal(AuditEntrySchema.Columns.DurationMs);
+            var ordResult = reader.GetOrdinal(AuditEntrySchema.Columns.Result);
+            var ordPayload = reader.GetOrdinal(AuditEntrySchema.Columns.Payload);
+            var ordExceptionMessage = reader.GetOrdinal(AuditEntrySchema.Columns.ExceptionMessage);
+
+            var records = new List<AuditRecord>();
+            do
+            {
+                var idBytes = await reader.GetFieldValueAsync<byte[]>(ordId, cancellationToken).ConfigureAwait(false);
+                var userIdNull = await reader.IsDBNullAsync(ordUserId, cancellationToken).ConfigureAwait(false);
+                var correlationIdNull = await reader
+                    .IsDBNullAsync(ordCorrelationId, cancellationToken)
+                    .ConfigureAwait(false);
+                var payloadNull = await reader.IsDBNullAsync(ordPayload, cancellationToken).ConfigureAwait(false);
+                var exceptionMessageNull = await reader
+                    .IsDBNullAsync(ordExceptionMessage, cancellationToken)
+                    .ConfigureAwait(false);
+
+                records.Add(
+                    new AuditRecord
+                    {
+                        Id = new Guid(idBytes),
+                        CommandType = reader.GetString(ordCommandType),
+                        UserId = userIdNull ? null : reader.GetString(ordUserId),
+                        CorrelationId = correlationIdNull ? null : reader.GetString(ordCorrelationId),
+                        OccurredAt = new DateTimeOffset(reader.GetInt64(ordOccurredAt), TimeSpan.Zero),
+                        DurationMs = reader.GetDouble(ordDurationMs),
+                        Result = (AuditResult)reader.GetInt32(ordResult),
+                        Payload = payloadNull ? null : reader.GetString(ordPayload),
+                        ExceptionMessage = exceptionMessageNull ? null : reader.GetString(ordExceptionMessage),
+                    }
+                );
+            } while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false));
+
+            return records;
+        }
+    }
+}

--- a/src/NetEvolve.Pulse.MySql/Audit/MySqlAuditStore.cs
+++ b/src/NetEvolve.Pulse.MySql/Audit/MySqlAuditStore.cs
@@ -1,0 +1,118 @@
+namespace NetEvolve.Pulse.Audit;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using MySql.Data.MySqlClient;
+using NetEvolve.Pulse.Extensibility.Audit;
+using NetEvolve.Pulse.Extensibility.Outbox;
+
+/// <summary>
+/// MySQL implementation of <see cref="IAuditStore"/> using ADO.NET.
+/// Provides audit trail persistence optimized for MySQL.
+/// </summary>
+/// <remarks>
+/// <para><strong>Prerequisites:</strong></para>
+/// Execute the schema script from <c>Scripts/AuditEntry.sql</c> to create the required
+/// database objects before using this provider.
+/// <para><strong>Schema:</strong></para>
+/// MySQL does not use schema namespaces in the same way as SQL Server or PostgreSQL.
+/// All tables reside in the active database specified by the connection string.
+/// The <see cref="AuditStoreOptions.Schema"/> property is ignored for MySQL.
+/// <para><strong>Timestamps:</strong></para>
+/// Stores <see cref="DateTimeOffset"/> values as <c>BIGINT</c> (UTC ticks), matching the
+/// interoperability contract with the Entity Framework MySQL provider.
+/// </remarks>
+[SuppressMessage(
+    "Reliability",
+    "CA2007:Consider calling ConfigureAwait on the awaited task",
+    Justification = "await using statements in library code; ConfigureAwait applied to all Task-returning awaits."
+)]
+[SuppressMessage(
+    "Security",
+    "CA2100:Review SQL queries for security vulnerabilities",
+    Justification = "SQL is constructed from validated AuditStoreOptions.TableName property, not user input."
+)]
+internal sealed class MySqlAuditStore : IAuditStore
+{
+    /// <summary>The MySQL connection string used to open new connections for each store operation.</summary>
+    private readonly string _connectionString;
+
+    /// <summary>Cached SQL statement for inserting an audit record.</summary>
+    private readonly string _insertSql;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MySqlAuditStore"/> class.
+    /// </summary>
+    /// <param name="options">The audit trail store configuration options.</param>
+    public MySqlAuditStore(IOptions<AuditStoreOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrWhiteSpace(options.Value.ConnectionString);
+
+        var opts = options.Value;
+        _connectionString = opts.ConnectionString;
+
+        SqlIdentifier.Validate(opts.TableName, nameof(opts.TableName));
+        var table = $"`{opts.TableName}`";
+
+        _insertSql = $"""
+            INSERT INTO {table}
+                (`{AuditEntrySchema.Columns.Id}`,
+                 `{AuditEntrySchema.Columns.CommandType}`,
+                 `{AuditEntrySchema.Columns.UserId}`,
+                 `{AuditEntrySchema.Columns.CorrelationId}`,
+                 `{AuditEntrySchema.Columns.OccurredAt}`,
+                 `{AuditEntrySchema.Columns.DurationMs}`,
+                 `{AuditEntrySchema.Columns.Result}`,
+                 `{AuditEntrySchema.Columns.Payload}`,
+                 `{AuditEntrySchema.Columns.ExceptionMessage}`)
+            VALUES
+                (@id, @commandType, @userId, @correlationId, @occurredAtTicks, @durationMs, @result, @payload, @exceptionMessage)
+            """;
+    }
+
+    /// <inheritdoc />
+    public async Task RecordAsync(AuditRecord record, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var command = new MySqlCommand(_insertSql, connection);
+            await using (command.ConfigureAwait(false))
+            {
+                _ = command.Parameters.AddWithValue("@id", record.Id.ToByteArray());
+                _ = command.Parameters.AddWithValue("@commandType", record.CommandType);
+                _ = command.Parameters.AddWithValue("@userId", (object?)record.UserId ?? DBNull.Value);
+                _ = command.Parameters.AddWithValue("@correlationId", (object?)record.CorrelationId ?? DBNull.Value);
+                _ = command.Parameters.AddWithValue("@occurredAtTicks", record.OccurredAt.UtcTicks);
+                _ = command.Parameters.AddWithValue("@durationMs", record.DurationMs);
+                _ = command.Parameters.AddWithValue("@result", (int)record.Result);
+                _ = command.Parameters.AddWithValue("@payload", (object?)record.Payload ?? DBNull.Value);
+                _ = command.Parameters.AddWithValue(
+                    "@exceptionMessage",
+                    (object?)record.ExceptionMessage ?? DBNull.Value
+                );
+
+                _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Opens and returns a new <see cref="MySqlConnection"/> using the stored connection string.
+    /// The caller is responsible for disposing the connection.
+    /// </summary>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>An open <see cref="MySqlConnection"/>.</returns>
+    private async Task<MySqlConnection> CreateConnectionAsync(CancellationToken cancellationToken)
+    {
+        var connection = new MySqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        return connection;
+    }
+}

--- a/src/NetEvolve.Pulse.MySql/MySqlAuditMediatorBuilderExtensions.cs
+++ b/src/NetEvolve.Pulse.MySql/MySqlAuditMediatorBuilderExtensions.cs
@@ -1,0 +1,71 @@
+namespace NetEvolve.Pulse;
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using NetEvolve.Pulse.Audit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.Audit;
+
+/// <summary>
+/// Extension methods for configuring the MySQL audit trail store on <see cref="IMediatorBuilder"/>.
+/// </summary>
+public static class MySqlAuditMediatorBuilderExtensions
+{
+    /// <summary>
+    /// Adds MySQL audit trail persistence using ADO.NET.
+    /// </summary>
+    /// <param name="configurator">The mediator configurator.</param>
+    /// <param name="configureOptions">Action to configure <see cref="AuditStoreOptions"/>.</param>
+    /// <returns>The configurator for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configurator"/> or <paramref name="configureOptions"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para><strong>Prerequisites:</strong></para>
+    /// Execute the schema script from <c>Scripts/AuditEntry.sql</c> against the target MySQL
+    /// database to create the required table before using this provider.
+    /// <para><strong>Schema:</strong></para>
+    /// MySQL does not use schema namespaces. The <see cref="AuditStoreOptions.Schema"/> property is
+    /// ignored; tables are always created in the active database from the connection string.
+    /// <para><strong>Interoperability:</strong></para>
+    /// Stores <see cref="DateTimeOffset"/> values as <c>BIGINT</c> (UTC ticks), matching
+    /// the Entity Framework MySQL provider schema.
+    /// <para><strong>Registered Services:</strong></para>
+    /// <list type="bullet">
+    /// <item><description><see cref="IAuditStore"/> as <see cref="MySqlAuditStore"/> (Scoped)</description></item>
+    /// <item><description><see cref="IAuditManagement"/> as <see cref="MySqlAuditManagement"/> (Scoped)</description></item>
+    /// </list>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// services.AddPulse(config => config
+    ///     .AddMySqlAuditStore(opts =>
+    ///     {
+    ///         opts.ConnectionString = "Server=localhost;Database=mydb;User Id=root;Password=secret;";
+    ///     })
+    /// );
+    /// </code>
+    /// </example>
+    public static IMediatorBuilder AddMySqlAuditStore(
+        this IMediatorBuilder configurator,
+        Action<AuditStoreOptions> configureOptions
+    )
+    {
+        ArgumentNullException.ThrowIfNull(configurator);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+
+        _ = configurator.Services.Configure(configureOptions);
+
+        return configurator.RegisterMySqlAuditServices();
+    }
+
+    private static IMediatorBuilder RegisterMySqlAuditServices(this IMediatorBuilder configurator)
+    {
+        _ = configurator
+            .Services.RemoveAll<IAuditStore>()
+            .AddScoped<IAuditStore, MySqlAuditStore>()
+            .RemoveAll<IAuditManagement>()
+            .AddScoped<IAuditManagement, MySqlAuditManagement>();
+
+        return configurator;
+    }
+}

--- a/src/NetEvolve.Pulse.MySql/Scripts/AuditEntry.sql
+++ b/src/NetEvolve.Pulse.MySql/Scripts/AuditEntry.sql
@@ -1,0 +1,56 @@
+-- ============================================================================
+-- AuditEntry Table Schema (MySQL)
+-- ============================================================================
+--
+-- Purpose:   Stores audit trail records describing processed requests, so
+--            operators can inspect who did what, when, and with what outcome.
+-- Provider:  NetEvolve.Pulse.MySql (ADO.NET)
+--            NetEvolve.Pulse.EntityFramework with MySql.EntityFrameworkCore
+--
+-- Prerequisites:
+--   MySQL 8.0 or later
+--
+-- Column types:
+--   Id               BINARY(16)    -- Guid.ToByteArray(), primary key
+--   CommandType      VARCHAR(500)  -- runtime type name of the processed request
+--   UserId           VARCHAR(256)  -- identifier of the user who issued the request (nullable)
+--   CorrelationId    VARCHAR(100)  -- correlation identifier associated with the request (nullable)
+--   OccurredAt       BIGINT        -- UTC ticks (use dto.UtcTicks / new DateTimeOffset(ticks, TimeSpan.Zero))
+--   DurationMs       DOUBLE        -- elapsed time, in milliseconds, of the handler invocation
+--   Result           TINYINT       -- AuditResult enum value (0 = Success, 1 = Failure)
+--   Payload          LONGTEXT      -- JSON serialized request payload (nullable)
+--   ExceptionMessage LONGTEXT      -- message of the exception that caused the failure (nullable)
+--
+-- Usage:
+--   Run this script in the target MySQL database once before deploying the application:
+--     mysql -u <user> -p <database> < AuditEntry.sql
+--
+--   If you need a custom table name, replace all occurrences of `AuditEntry`
+--   and update AuditStoreOptions.TableName in your application configuration accordingly.
+--
+-- Note on schema:
+--   MySQL does not use schema namespaces in the same way as SQL Server or PostgreSQL.
+--   Tables are created in whichever database is active when this script runs.
+--   Pass the desired database in the connection string (Database=<dbname>).
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS `AuditEntry` (
+    `Id`               BINARY(16)   NOT NULL,
+    `CommandType`      VARCHAR(500) NOT NULL,
+    `UserId`           VARCHAR(256)     NULL,
+    `CorrelationId`    VARCHAR(100)     NULL,
+    `OccurredAt`       BIGINT       NOT NULL,
+    `DurationMs`       DOUBLE       NOT NULL,
+    `Result`           TINYINT      NOT NULL,
+    `Payload`          LONGTEXT         NULL,
+    `ExceptionMessage` LONGTEXT         NULL,
+    CONSTRAINT `PK_AuditEntry` PRIMARY KEY (`Id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Index to efficiently order and range-filter entries by occurrence time
+CREATE INDEX `IX_AuditEntry_OccurredAt`
+    ON `AuditEntry` (`OccurredAt`);
+
+-- Index to efficiently filter entries by request type
+CREATE INDEX `IX_AuditEntry_CommandType`
+    ON `AuditEntry` (`CommandType`);

--- a/src/NetEvolve.Pulse.PostgreSql/Audit/PostgreSqlAuditManagement.cs
+++ b/src/NetEvolve.Pulse.PostgreSql/Audit/PostgreSqlAuditManagement.cs
@@ -1,0 +1,262 @@
+namespace NetEvolve.Pulse.Audit;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.Extensibility.Audit;
+using NetEvolve.Pulse.Extensibility.Outbox;
+using Npgsql;
+
+/// <summary>
+/// PostgreSQL implementation of <see cref="IAuditManagement"/> using ADO.NET.
+/// Provides audit trail querying and statistics for PostgreSQL.
+/// </summary>
+/// <remarks>
+/// <para><strong>Prerequisites:</strong></para>
+/// Execute the schema script from <c>Scripts/AuditEntry.sql</c> to create the required
+/// database objects before using this provider.
+/// </remarks>
+[SuppressMessage(
+    "Reliability",
+    "CA2007:Consider calling ConfigureAwait on the awaited task",
+    Justification = "await using statements in library code; ConfigureAwait applied to all Task-returning awaits."
+)]
+[SuppressMessage(
+    "Security",
+    "CA2100:Review SQL queries for security vulnerabilities",
+    Justification = "The table name is constructed from validated AuditStoreOptions.Schema/TableName properties, not user input."
+)]
+internal sealed class PostgreSqlAuditManagement : IAuditManagement
+{
+    /// <summary>The PostgreSQL connection string used to open new connections for each operation.</summary>
+    private readonly string _connectionString;
+
+    /// <summary>The fully qualified table name (schema and table, quoted).</summary>
+    private readonly string _qualifiedTableName;
+
+    /// <summary>The comma-separated, quoted column list used by SELECT queries.</summary>
+    private readonly string _columns;
+
+    /// <summary>Cached SQL for aggregating record counts per result.</summary>
+    private readonly string _getStatisticsSql;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PostgreSqlAuditManagement"/> class.
+    /// </summary>
+    /// <param name="options">The audit trail store configuration options.</param>
+    public PostgreSqlAuditManagement(IOptions<AuditStoreOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrWhiteSpace(options.Value.ConnectionString);
+
+        _connectionString = options.Value.ConnectionString;
+
+        var schema = string.IsNullOrWhiteSpace(options.Value.Schema)
+            ? AuditEntrySchema.DefaultSchema
+            : options.Value.Schema;
+        SqlIdentifier.Validate(schema, nameof(options.Value.Schema));
+
+        var tableName = string.IsNullOrWhiteSpace(options.Value.TableName)
+            ? AuditEntrySchema.DefaultTableName
+            : options.Value.TableName;
+        SqlIdentifier.Validate(tableName, nameof(options.Value.TableName));
+
+        _qualifiedTableName = $"\"{schema}\".\"{tableName}\"";
+
+        _columns =
+            $"\"{AuditEntrySchema.Columns.Id}\", \"{AuditEntrySchema.Columns.CommandType}\", "
+            + $"\"{AuditEntrySchema.Columns.UserId}\", \"{AuditEntrySchema.Columns.CorrelationId}\", "
+            + $"\"{AuditEntrySchema.Columns.OccurredAt}\", \"{AuditEntrySchema.Columns.DurationMs}\", "
+            + $"\"{AuditEntrySchema.Columns.Result}\", \"{AuditEntrySchema.Columns.Payload}\", "
+            + $"\"{AuditEntrySchema.Columns.ExceptionMessage}\"";
+
+        _getStatisticsSql = $"""
+            SELECT "{AuditEntrySchema.Columns.Result}", COUNT(*)
+            FROM {_qualifiedTableName}
+            GROUP BY "{AuditEntrySchema.Columns.Result}"
+            """;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<AuditRecord>> QueryAsync(
+        AuditFilter filter,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+
+        var whereClause = new StringBuilder();
+        var conditions = new List<string>();
+
+        if (filter.CommandType is not null)
+        {
+            conditions.Add($"\"{AuditEntrySchema.Columns.CommandType}\" = @command_type");
+        }
+
+        if (filter.UserId is not null)
+        {
+            conditions.Add($"\"{AuditEntrySchema.Columns.UserId}\" = @user_id");
+        }
+
+        if (filter.From is not null)
+        {
+            conditions.Add($"\"{AuditEntrySchema.Columns.OccurredAt}\" >= @from");
+        }
+
+        if (filter.To is not null)
+        {
+            conditions.Add($"\"{AuditEntrySchema.Columns.OccurredAt}\" <= @to");
+        }
+
+        if (filter.Result is not null)
+        {
+            conditions.Add($"\"{AuditEntrySchema.Columns.Result}\" = @result");
+        }
+
+        if (conditions.Count > 0)
+        {
+            _ = whereClause.Append("WHERE ").Append(string.Join(" AND ", conditions));
+        }
+
+        var querySql = $"""
+            SELECT {_columns}
+            FROM {_qualifiedTableName}
+            {whereClause}
+            ORDER BY "{AuditEntrySchema.Columns.OccurredAt}" DESC
+            LIMIT @take
+            OFFSET @skip
+            """;
+
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var command = new NpgsqlCommand(querySql, connection);
+            await using (command.ConfigureAwait(false))
+            {
+                if (filter.CommandType is not null)
+                {
+                    _ = command.Parameters.AddWithValue("command_type", filter.CommandType);
+                }
+
+                if (filter.UserId is not null)
+                {
+                    _ = command.Parameters.AddWithValue("user_id", filter.UserId);
+                }
+
+                if (filter.From is not null)
+                {
+                    _ = command.Parameters.AddWithValue("from", filter.From.Value);
+                }
+
+                if (filter.To is not null)
+                {
+                    _ = command.Parameters.AddWithValue("to", filter.To.Value);
+                }
+
+                if (filter.Result is not null)
+                {
+                    _ = command.Parameters.AddWithValue("result", (short)filter.Result.Value);
+                }
+
+                _ = command.Parameters.AddWithValue("take", filter.Take);
+                _ = command.Parameters.AddWithValue("skip", filter.Skip);
+
+                var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                await using (reader.ConfigureAwait(false))
+                {
+                    var records = new List<AuditRecord>();
+                    while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                    {
+                        records.Add(MapToRecord(reader));
+                    }
+
+                    return records;
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<AuditStatistics> GetStatisticsAsync(CancellationToken cancellationToken = default)
+    {
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var command = new NpgsqlCommand(_getStatisticsSql, connection);
+            await using (command.ConfigureAwait(false))
+            {
+                var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                await using (reader.ConfigureAwait(false))
+                {
+                    var successCount = 0;
+                    var failureCount = 0;
+
+                    while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                    {
+                        var result = (AuditResult)reader.GetInt16(0);
+                        var groupCount = Convert.ToInt32(reader.GetInt64(1), CultureInfo.InvariantCulture);
+
+                        switch (result)
+                        {
+                            case AuditResult.Success:
+                                successCount = groupCount;
+                                break;
+                            case AuditResult.Failure:
+                                failureCount = groupCount;
+                                break;
+                        }
+                    }
+
+                    return new AuditStatistics(successCount, failureCount);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Opens and returns a new <see cref="NpgsqlConnection"/> using the stored connection string.
+    /// The caller is responsible for disposing the connection.
+    /// </summary>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>An open <see cref="NpgsqlConnection"/>.</returns>
+    private async Task<NpgsqlConnection> CreateConnectionAsync(CancellationToken cancellationToken)
+    {
+        var connection = new NpgsqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        return connection;
+    }
+
+    /// <summary>
+    /// Maps the current row of a <see cref="NpgsqlDataReader"/> to a new <see cref="AuditRecord"/> instance.
+    /// </summary>
+    private static AuditRecord MapToRecord(NpgsqlDataReader reader)
+    {
+        var ordId = reader.GetOrdinal(AuditEntrySchema.Columns.Id);
+        var ordCommandType = reader.GetOrdinal(AuditEntrySchema.Columns.CommandType);
+        var ordUserId = reader.GetOrdinal(AuditEntrySchema.Columns.UserId);
+        var ordCorrelationId = reader.GetOrdinal(AuditEntrySchema.Columns.CorrelationId);
+        var ordOccurredAt = reader.GetOrdinal(AuditEntrySchema.Columns.OccurredAt);
+        var ordDurationMs = reader.GetOrdinal(AuditEntrySchema.Columns.DurationMs);
+        var ordResult = reader.GetOrdinal(AuditEntrySchema.Columns.Result);
+        var ordPayload = reader.GetOrdinal(AuditEntrySchema.Columns.Payload);
+        var ordExceptionMessage = reader.GetOrdinal(AuditEntrySchema.Columns.ExceptionMessage);
+
+        return new AuditRecord
+        {
+            Id = reader.GetGuid(ordId),
+            CommandType = reader.GetString(ordCommandType),
+            UserId = reader.IsDBNull(ordUserId) ? null : reader.GetString(ordUserId),
+            CorrelationId = reader.IsDBNull(ordCorrelationId) ? null : reader.GetString(ordCorrelationId),
+            OccurredAt = reader.GetFieldValue<DateTimeOffset>(ordOccurredAt),
+            DurationMs = reader.GetDouble(ordDurationMs),
+            Result = (AuditResult)reader.GetInt16(ordResult),
+            Payload = reader.IsDBNull(ordPayload) ? null : reader.GetString(ordPayload),
+            ExceptionMessage = reader.IsDBNull(ordExceptionMessage) ? null : reader.GetString(ordExceptionMessage),
+        };
+    }
+}

--- a/src/NetEvolve.Pulse.PostgreSql/Audit/PostgreSqlAuditStore.cs
+++ b/src/NetEvolve.Pulse.PostgreSql/Audit/PostgreSqlAuditStore.cs
@@ -1,0 +1,111 @@
+namespace NetEvolve.Pulse.Audit;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.Extensibility.Audit;
+using NetEvolve.Pulse.Extensibility.Outbox;
+using Npgsql;
+
+/// <summary>
+/// PostgreSQL implementation of <see cref="IAuditStore"/> using ADO.NET.
+/// Provides audit trail persistence optimized for PostgreSQL.
+/// </summary>
+/// <remarks>
+/// <para><strong>Prerequisites:</strong></para>
+/// Execute the schema script from <c>Scripts/AuditEntry.sql</c> to create the required
+/// database objects before using this provider.
+/// </remarks>
+[SuppressMessage(
+    "Reliability",
+    "CA2007:Consider calling ConfigureAwait on the awaited task",
+    Justification = "await using statements in library code; ConfigureAwait applied to all Task-returning awaits."
+)]
+[SuppressMessage(
+    "Security",
+    "CA2100:Review SQL queries for security vulnerabilities",
+    Justification = "The table name is constructed from validated AuditStoreOptions.Schema/TableName properties, not user input."
+)]
+internal sealed class PostgreSqlAuditStore : IAuditStore
+{
+    /// <summary>The PostgreSQL connection string used to open new connections for each operation.</summary>
+    private readonly string _connectionString;
+
+    /// <summary>Cached SQL for inserting an audit record.</summary>
+    private readonly string _insertSql;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PostgreSqlAuditStore"/> class.
+    /// </summary>
+    /// <param name="options">The audit trail store configuration options.</param>
+    public PostgreSqlAuditStore(IOptions<AuditStoreOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrWhiteSpace(options.Value.ConnectionString);
+
+        _connectionString = options.Value.ConnectionString;
+
+        var schema = string.IsNullOrWhiteSpace(options.Value.Schema)
+            ? AuditEntrySchema.DefaultSchema
+            : options.Value.Schema;
+        SqlIdentifier.Validate(schema, nameof(options.Value.Schema));
+
+        var tableName = string.IsNullOrWhiteSpace(options.Value.TableName)
+            ? AuditEntrySchema.DefaultTableName
+            : options.Value.TableName;
+        SqlIdentifier.Validate(tableName, nameof(options.Value.TableName));
+
+        var qualifiedTableName = $"\"{schema}\".\"{tableName}\"";
+
+        _insertSql = $"""
+            INSERT INTO {qualifiedTableName}
+                ("{AuditEntrySchema.Columns.Id}", "{AuditEntrySchema.Columns.CommandType}", "{AuditEntrySchema.Columns.UserId}", "{AuditEntrySchema.Columns.CorrelationId}", "{AuditEntrySchema.Columns.OccurredAt}", "{AuditEntrySchema.Columns.DurationMs}", "{AuditEntrySchema.Columns.Result}", "{AuditEntrySchema.Columns.Payload}", "{AuditEntrySchema.Columns.ExceptionMessage}")
+            VALUES
+                (@id, @command_type, @user_id, @correlation_id, @occurred_at, @duration_ms, @result, @payload, @exception_message)
+            """;
+    }
+
+    /// <inheritdoc />
+    public async Task RecordAsync(AuditRecord record, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var command = new NpgsqlCommand(_insertSql, connection);
+            await using (command.ConfigureAwait(false))
+            {
+                _ = command.Parameters.AddWithValue("id", record.Id);
+                _ = command.Parameters.AddWithValue("command_type", record.CommandType);
+                _ = command.Parameters.AddWithValue("user_id", (object?)record.UserId ?? DBNull.Value);
+                _ = command.Parameters.AddWithValue("correlation_id", (object?)record.CorrelationId ?? DBNull.Value);
+                _ = command.Parameters.AddWithValue("occurred_at", record.OccurredAt);
+                _ = command.Parameters.AddWithValue("duration_ms", record.DurationMs);
+                _ = command.Parameters.AddWithValue("result", (short)record.Result);
+                _ = command.Parameters.AddWithValue("payload", (object?)record.Payload ?? DBNull.Value);
+                _ = command.Parameters.AddWithValue(
+                    "exception_message",
+                    (object?)record.ExceptionMessage ?? DBNull.Value
+                );
+
+                _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Opens and returns a new <see cref="NpgsqlConnection"/> using the stored connection string.
+    /// The caller is responsible for disposing the connection.
+    /// </summary>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>An open <see cref="NpgsqlConnection"/>.</returns>
+    private async Task<NpgsqlConnection> CreateConnectionAsync(CancellationToken cancellationToken)
+    {
+        var connection = new NpgsqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        return connection;
+    }
+}

--- a/src/NetEvolve.Pulse.PostgreSql/PostgreSqlAuditMediatorBuilderExtensions.cs
+++ b/src/NetEvolve.Pulse.PostgreSql/PostgreSqlAuditMediatorBuilderExtensions.cs
@@ -1,0 +1,66 @@
+namespace NetEvolve.Pulse;
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using NetEvolve.Pulse.Audit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.Audit;
+
+/// <summary>
+/// Extension methods for configuring PostgreSQL audit trail persistence on <see cref="IMediatorBuilder"/>.
+/// </summary>
+public static class PostgreSqlAuditMediatorBuilderExtensions
+{
+    /// <summary>
+    /// Adds PostgreSQL audit trail persistence using ADO.NET.
+    /// </summary>
+    /// <param name="configurator">The mediator configurator.</param>
+    /// <param name="configureOptions">Action to configure <see cref="AuditStoreOptions"/>.</param>
+    /// <returns>The configurator for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configurator"/> or <paramref name="configureOptions"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para><strong>Prerequisites:</strong></para>
+    /// Execute the schema script from <c>Scripts/AuditEntry.sql</c> to create the required
+    /// database objects before using this provider.
+    /// <para><strong>Registered Services:</strong></para>
+    /// <list type="bullet">
+    /// <item><description><see cref="IAuditStore"/> as <see cref="PostgreSqlAuditStore"/> (Scoped)</description></item>
+    /// <item><description><see cref="IAuditManagement"/> as <see cref="PostgreSqlAuditManagement"/> (Scoped)</description></item>
+    /// </list>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// services.AddPulse(config => config
+    ///     .AddPostgreSqlAuditStore(opts =>
+    ///     {
+    ///         opts.ConnectionString = "Host=localhost;Database=MyDb;Username=postgres;Password=secret;";
+    ///         opts.Schema = "myschema";
+    ///     })
+    /// );
+    /// </code>
+    /// </example>
+    public static IMediatorBuilder AddPostgreSqlAuditStore(
+        this IMediatorBuilder configurator,
+        Action<AuditStoreOptions> configureOptions
+    )
+    {
+        ArgumentNullException.ThrowIfNull(configurator);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+
+        _ = configurator.Services.Configure(configureOptions);
+
+        return configurator.RegisterPostgreSqlAuditStore();
+    }
+
+    private static IMediatorBuilder RegisterPostgreSqlAuditStore(this IMediatorBuilder configurator)
+    {
+        var services = configurator.Services;
+
+        _ = services.RemoveAll<IAuditStore>().AddScoped<IAuditStore, PostgreSqlAuditStore>();
+
+        _ = services.RemoveAll<IAuditManagement>().AddScoped<IAuditManagement, PostgreSqlAuditManagement>();
+
+        return configurator;
+    }
+}

--- a/src/NetEvolve.Pulse.PostgreSql/Scripts/AuditEntry.sql
+++ b/src/NetEvolve.Pulse.PostgreSql/Scripts/AuditEntry.sql
@@ -1,0 +1,46 @@
+-- ============================================================================
+-- AuditEntry Table Schema (PostgreSQL)
+-- ============================================================================
+-- Purpose: Stores audit trail records for processed requests, capturing the
+--          command type, user, correlation, timing, result, and optional
+--          payload/exception details.
+-- Compatible with: NetEvolve.Pulse.PostgreSql (ADO.NET)
+--
+-- Configuration:
+--   Adjust schema_name and table_name variables below before executing.
+--   Run this script using psql or any PostgreSQL-compatible client.
+--
+-- Usage:
+--   psql -h your-host -d your-database -f AuditEntry.sql
+-- ============================================================================
+
+-- ============================================================================
+-- Configuration
+-- ============================================================================
+\set schema_name 'pulse'
+\set table_name 'AuditEntry'
+
+-- Create schema if it doesn't exist
+CREATE SCHEMA IF NOT EXISTS :schema_name;
+
+-- Create table if it doesn't exist
+CREATE TABLE IF NOT EXISTS ":schema_name".":table_name" (
+    "Id"               UUID                      NOT NULL,
+    "CommandType"      VARCHAR(500)              NOT NULL,
+    "UserId"           VARCHAR(256)              NULL,
+    "CorrelationId"    VARCHAR(100)              NULL,
+    "OccurredAt"       TIMESTAMP WITH TIME ZONE  NOT NULL,
+    "DurationMs"       DOUBLE PRECISION          NOT NULL,
+    "Result"           SMALLINT                  NOT NULL,
+    "Payload"          TEXT                      NULL,
+    "ExceptionMessage" TEXT                      NULL,
+    CONSTRAINT "PK_:schema_name_:table_name" PRIMARY KEY ("Id")
+);
+
+-- Index for ordering/range-filtering entries by occurrence time
+CREATE INDEX IF NOT EXISTS "IX_:schema_name_:table_name_OccurredAt"
+ON ":schema_name".":table_name" ("OccurredAt");
+
+-- Index for efficient filtering by command type
+CREATE INDEX IF NOT EXISTS "IX_:schema_name_:table_name_CommandType"
+ON ":schema_name".":table_name" ("CommandType");

--- a/src/NetEvolve.Pulse.SQLite/Audit/SQLiteAuditManagement.cs
+++ b/src/NetEvolve.Pulse.SQLite/Audit/SQLiteAuditManagement.cs
@@ -1,0 +1,312 @@
+namespace NetEvolve.Pulse.Audit;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.Extensibility.Audit;
+using NetEvolve.Pulse.Extensibility.Outbox;
+
+/// <summary>
+/// SQLite implementation of <see cref="IAuditManagement"/> using ADO.NET.
+/// Provides audit trail querying and statistics.
+/// </summary>
+/// <remarks>
+/// <para><strong>Prerequisites:</strong></para>
+/// Execute the schema script from <c>Scripts/004_CreateAuditEntryTable.sql</c> to create the
+/// required database objects before using this provider.
+/// </remarks>
+[SuppressMessage(
+    "Reliability",
+    "CA2007:Consider calling ConfigureAwait on the awaited task",
+    Justification = "await using statements in library code; ConfigureAwait applied to all Task-returning awaits."
+)]
+[SuppressMessage(
+    "Security",
+    "CA2100:Review SQL queries for security vulnerabilities",
+    Justification = "SQL is constructed from validated AuditStoreOptions.TableName property, not user input."
+)]
+internal sealed class SQLiteAuditManagement : IAuditManagement
+{
+    /// <summary>The SQLite connection string resolved from <see cref="AuditStoreOptions"/>.</summary>
+    private readonly string _connectionString;
+
+    /// <summary>Whether to apply WAL journal mode to the database.</summary>
+    private readonly bool _enableWalMode;
+
+    /// <summary>Tracks whether the persistent WAL journal mode has already been applied to the database.</summary>
+    private int _walModeApplied;
+
+    /// <summary>The qualified table name used to build query statements.</summary>
+    private readonly string _table;
+
+    /// <summary>Cached SQL statement for retrieving audit statistics.</summary>
+    private readonly string _getStatisticsSql;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SQLiteAuditManagement"/> class.
+    /// </summary>
+    /// <param name="options">The audit trail configuration options.</param>
+    public SQLiteAuditManagement(IOptions<AuditStoreOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrWhiteSpace(options.Value.ConnectionString);
+
+        var opts = options.Value;
+        _connectionString = opts.ConnectionString;
+        _enableWalMode = opts.EnableWalMode;
+
+        SqlIdentifier.Validate(opts.TableName, nameof(opts.TableName));
+        _table = $"\"{opts.TableName}\"";
+
+        _getStatisticsSql = $"""
+            SELECT "{AuditEntrySchema.Columns.Result}", COUNT(*)
+            FROM {_table}
+            GROUP BY "{AuditEntrySchema.Columns.Result}";
+            """;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<AuditRecord>> QueryAsync(
+        AuditFilter filter,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+
+        var whereClause = new StringBuilder();
+
+        if (filter.CommandType is not null)
+        {
+            var keyword = whereClause.Length == 0 ? "WHERE " : "AND ";
+            _ = whereClause
+                .Append(keyword)
+                .Append('"')
+                .Append(AuditEntrySchema.Columns.CommandType)
+                .Append("\" = @commandType ");
+        }
+
+        if (filter.UserId is not null)
+        {
+            var keyword = whereClause.Length == 0 ? "WHERE " : "AND ";
+            _ = whereClause.Append(keyword).Append('"').Append(AuditEntrySchema.Columns.UserId).Append("\" = @userId ");
+        }
+
+        if (filter.From is not null)
+        {
+            var keyword = whereClause.Length == 0 ? "WHERE " : "AND ";
+            _ = whereClause
+                .Append(keyword)
+                .Append('"')
+                .Append(AuditEntrySchema.Columns.OccurredAt)
+                .Append("\" >= @from ");
+        }
+
+        if (filter.To is not null)
+        {
+            var keyword = whereClause.Length == 0 ? "WHERE " : "AND ";
+            _ = whereClause
+                .Append(keyword)
+                .Append('"')
+                .Append(AuditEntrySchema.Columns.OccurredAt)
+                .Append("\" <= @to ");
+        }
+
+        if (filter.Result is not null)
+        {
+            var keyword = whereClause.Length == 0 ? "WHERE " : "AND ";
+            _ = whereClause.Append(keyword).Append('"').Append(AuditEntrySchema.Columns.Result).Append("\" = @result ");
+        }
+
+        var querySql = $"""
+            SELECT
+                "{AuditEntrySchema.Columns.Id}",
+                "{AuditEntrySchema.Columns.CommandType}",
+                "{AuditEntrySchema.Columns.UserId}",
+                "{AuditEntrySchema.Columns.CorrelationId}",
+                "{AuditEntrySchema.Columns.OccurredAt}",
+                "{AuditEntrySchema.Columns.DurationMs}",
+                "{AuditEntrySchema.Columns.Result}",
+                "{AuditEntrySchema.Columns.Payload}",
+                "{AuditEntrySchema.Columns.ExceptionMessage}"
+            FROM {_table}
+            {whereClause}
+            ORDER BY "{AuditEntrySchema.Columns.OccurredAt}" DESC
+            LIMIT @take OFFSET @skip;
+            """;
+
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+#pragma warning disable S2077 // querySql is built exclusively from the fixed column list, validated table name, and static WHERE keywords; all filter values are bound as parameters
+            var command = new SqliteCommand(querySql, connection);
+#pragma warning restore S2077
+            await using (command.ConfigureAwait(false))
+            {
+                if (filter.CommandType is not null)
+                {
+                    _ = command.Parameters.AddWithValue("@commandType", filter.CommandType);
+                }
+
+                if (filter.UserId is not null)
+                {
+                    _ = command.Parameters.AddWithValue("@userId", filter.UserId);
+                }
+
+                if (filter.From is not null)
+                {
+                    _ = command.Parameters.AddWithValue("@from", filter.From.Value);
+                }
+
+                if (filter.To is not null)
+                {
+                    _ = command.Parameters.AddWithValue("@to", filter.To.Value);
+                }
+
+                if (filter.Result is not null)
+                {
+                    _ = command.Parameters.AddWithValue("@result", (int)filter.Result.Value);
+                }
+
+                _ = command.Parameters.AddWithValue("@take", filter.Take);
+                _ = command.Parameters.AddWithValue("@skip", filter.Skip);
+
+                return await ReadRecordsAsync(command, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<AuditStatistics> GetStatisticsAsync(CancellationToken cancellationToken = default)
+    {
+        var successCount = 0;
+        var failureCount = 0;
+
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var command = new SqliteCommand(_getStatisticsSql, connection);
+            await using (command.ConfigureAwait(false))
+            {
+                var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                await using (reader.ConfigureAwait(false))
+                {
+                    while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                    {
+                        var result = (AuditResult)reader.GetInt64(0);
+                        var count = (int)reader.GetInt64(1);
+
+                        switch (result)
+                        {
+                            case AuditResult.Success:
+                                successCount = count;
+                                break;
+                            case AuditResult.Failure:
+                                failureCount = count;
+                                break;
+                        }
+                    }
+                }
+            }
+        }
+
+        return new AuditStatistics(successCount, failureCount);
+    }
+
+    /// <summary>
+    /// Opens and returns a new <see cref="SqliteConnection"/> using the stored connection string.
+    /// Applies WAL mode once per instance when <see cref="AuditStoreOptions.EnableWalMode"/> is
+    /// <see langword="true"/>; the journal mode is a persistent database property and does not need
+    /// to be re-applied on subsequent connections.
+    /// The caller is responsible for disposing the connection.
+    /// </summary>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>An open <see cref="SqliteConnection"/>.</returns>
+    private async Task<SqliteConnection> CreateConnectionAsync(CancellationToken cancellationToken)
+    {
+        var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        if (_enableWalMode && Volatile.Read(ref _walModeApplied) == 0)
+        {
+            var walCmd = new SqliteCommand("PRAGMA journal_mode=WAL;", connection);
+            await using (walCmd.ConfigureAwait(false))
+            {
+                _ = await walCmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            Volatile.Write(ref _walModeApplied, 1);
+        }
+
+        return connection;
+    }
+
+    /// <summary>
+    /// Executes <paramref name="command"/> and reads all rows into a list of <see cref="AuditRecord"/> instances.
+    /// </summary>
+    /// <param name="command">The <see cref="SqliteCommand"/> to execute.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A read-only list of <see cref="AuditRecord"/> instances.</returns>
+    private static async Task<IReadOnlyList<AuditRecord>> ReadRecordsAsync(
+        SqliteCommand command,
+        CancellationToken cancellationToken
+    )
+    {
+        var records = new List<AuditRecord>();
+
+        var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        await using (reader.ConfigureAwait(false))
+        {
+            if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                return records;
+            }
+
+            var ordId = reader.GetOrdinal(AuditEntrySchema.Columns.Id);
+            var ordCommandType = reader.GetOrdinal(AuditEntrySchema.Columns.CommandType);
+            var ordUserId = reader.GetOrdinal(AuditEntrySchema.Columns.UserId);
+            var ordCorrelationId = reader.GetOrdinal(AuditEntrySchema.Columns.CorrelationId);
+            var ordOccurredAt = reader.GetOrdinal(AuditEntrySchema.Columns.OccurredAt);
+            var ordDurationMs = reader.GetOrdinal(AuditEntrySchema.Columns.DurationMs);
+            var ordResult = reader.GetOrdinal(AuditEntrySchema.Columns.Result);
+            var ordPayload = reader.GetOrdinal(AuditEntrySchema.Columns.Payload);
+            var ordExceptionMessage = reader.GetOrdinal(AuditEntrySchema.Columns.ExceptionMessage);
+
+            do
+            {
+                var userIdNull = await reader.IsDBNullAsync(ordUserId, cancellationToken).ConfigureAwait(false);
+                var correlationIdNull = await reader
+                    .IsDBNullAsync(ordCorrelationId, cancellationToken)
+                    .ConfigureAwait(false);
+                var payloadNull = await reader.IsDBNullAsync(ordPayload, cancellationToken).ConfigureAwait(false);
+                var exceptionMessageNull = await reader
+                    .IsDBNullAsync(ordExceptionMessage, cancellationToken)
+                    .ConfigureAwait(false);
+                var occurredAt = await reader
+                    .GetFieldValueAsync<DateTimeOffset>(ordOccurredAt, cancellationToken)
+                    .ConfigureAwait(false);
+
+                records.Add(
+                    new AuditRecord
+                    {
+                        Id = Guid.Parse(reader.GetString(ordId)),
+                        CommandType = reader.GetString(ordCommandType),
+                        UserId = userIdNull ? null : reader.GetString(ordUserId),
+                        CorrelationId = correlationIdNull ? null : reader.GetString(ordCorrelationId),
+                        OccurredAt = occurredAt,
+                        DurationMs = reader.GetDouble(ordDurationMs),
+                        Result = (AuditResult)reader.GetInt64(ordResult),
+                        Payload = payloadNull ? null : reader.GetString(ordPayload),
+                        ExceptionMessage = exceptionMessageNull ? null : reader.GetString(ordExceptionMessage),
+                    }
+                );
+            } while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false));
+
+            return records;
+        }
+    }
+}

--- a/src/NetEvolve.Pulse.SQLite/Audit/SQLiteAuditStore.cs
+++ b/src/NetEvolve.Pulse.SQLite/Audit/SQLiteAuditStore.cs
@@ -1,0 +1,132 @@
+namespace NetEvolve.Pulse.Audit;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.Extensibility.Audit;
+using NetEvolve.Pulse.Extensibility.Outbox;
+
+/// <summary>
+/// SQLite implementation of <see cref="IAuditStore"/> using ADO.NET.
+/// Provides audit trail persistence optimized for SQLite.
+/// </summary>
+/// <remarks>
+/// <para><strong>Prerequisites:</strong></para>
+/// Execute the schema script from <c>Scripts/004_CreateAuditEntryTable.sql</c> to create the
+/// required database objects before using this provider.
+/// </remarks>
+[SuppressMessage(
+    "Reliability",
+    "CA2007:Consider calling ConfigureAwait on the awaited task",
+    Justification = "await using statements in library code; ConfigureAwait applied to all Task-returning awaits."
+)]
+[SuppressMessage(
+    "Security",
+    "CA2100:Review SQL queries for security vulnerabilities",
+    Justification = "SQL is constructed from validated AuditStoreOptions.TableName property, not user input."
+)]
+internal sealed class SQLiteAuditStore : IAuditStore
+{
+    /// <summary>The SQLite connection string used to open new connections for each store operation.</summary>
+    private readonly string _connectionString;
+
+    /// <summary>Whether to apply WAL journal mode to the database.</summary>
+    private readonly bool _enableWalMode;
+
+    /// <summary>Tracks whether the persistent WAL journal mode has already been applied to the database.</summary>
+    private int _walModeApplied;
+
+    /// <summary>Cached SQL statement for inserting an audit record.</summary>
+    private readonly string _insertSql;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SQLiteAuditStore"/> class.
+    /// </summary>
+    /// <param name="options">The audit trail configuration options.</param>
+    public SQLiteAuditStore(IOptions<AuditStoreOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrWhiteSpace(options.Value.ConnectionString);
+
+        var opts = options.Value;
+        _connectionString = opts.ConnectionString;
+        _enableWalMode = opts.EnableWalMode;
+
+        SqlIdentifier.Validate(opts.TableName, nameof(opts.TableName));
+        var table = $"\"{opts.TableName}\"";
+
+        _insertSql = $"""
+            INSERT INTO {table}
+            ("{AuditEntrySchema.Columns.Id}",
+             "{AuditEntrySchema.Columns.CommandType}",
+             "{AuditEntrySchema.Columns.UserId}",
+             "{AuditEntrySchema.Columns.CorrelationId}",
+             "{AuditEntrySchema.Columns.OccurredAt}",
+             "{AuditEntrySchema.Columns.DurationMs}",
+             "{AuditEntrySchema.Columns.Result}",
+             "{AuditEntrySchema.Columns.Payload}",
+             "{AuditEntrySchema.Columns.ExceptionMessage}")
+            VALUES (@id, @commandType, @userId, @correlationId, @occurredAt, @durationMs, @result, @payload, @exceptionMessage);
+            """;
+    }
+
+    /// <inheritdoc />
+    public async Task RecordAsync(AuditRecord record, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var command = new SqliteCommand(_insertSql, connection);
+            await using (command.ConfigureAwait(false))
+            {
+                _ = command.Parameters.AddWithValue("@id", record.Id.ToString());
+                _ = command.Parameters.AddWithValue("@commandType", record.CommandType);
+                _ = command.Parameters.AddWithValue("@userId", (object?)record.UserId ?? DBNull.Value);
+                _ = command.Parameters.AddWithValue("@correlationId", (object?)record.CorrelationId ?? DBNull.Value);
+                _ = command.Parameters.AddWithValue("@occurredAt", record.OccurredAt);
+                _ = command.Parameters.AddWithValue("@durationMs", record.DurationMs);
+                _ = command.Parameters.AddWithValue("@result", (int)record.Result);
+                _ = command.Parameters.AddWithValue("@payload", (object?)record.Payload ?? DBNull.Value);
+                _ = command.Parameters.AddWithValue(
+                    "@exceptionMessage",
+                    (object?)record.ExceptionMessage ?? DBNull.Value
+                );
+
+                _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Opens and returns a new <see cref="SqliteConnection"/> using the stored connection string.
+    /// Applies WAL mode once per store instance when <see cref="AuditStoreOptions.EnableWalMode"/> is
+    /// <see langword="true"/>; the journal mode is a persistent database property and does not need
+    /// to be re-applied on subsequent connections.
+    /// The caller is responsible for disposing the connection.
+    /// </summary>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>An open <see cref="SqliteConnection"/>.</returns>
+    private async Task<SqliteConnection> CreateConnectionAsync(CancellationToken cancellationToken)
+    {
+        var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        if (_enableWalMode && Volatile.Read(ref _walModeApplied) == 0)
+        {
+            var walCmd = new SqliteCommand("PRAGMA journal_mode=WAL;", connection);
+            await using (walCmd.ConfigureAwait(false))
+            {
+                _ = await walCmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            Volatile.Write(ref _walModeApplied, 1);
+        }
+
+        return connection;
+    }
+}

--- a/src/NetEvolve.Pulse.SQLite/SQLiteAuditMediatorBuilderExtensions.cs
+++ b/src/NetEvolve.Pulse.SQLite/SQLiteAuditMediatorBuilderExtensions.cs
@@ -1,0 +1,61 @@
+namespace NetEvolve.Pulse;
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using NetEvolve.Pulse.Audit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.Audit;
+
+/// <summary>
+/// Extension methods for configuring the SQLite audit trail store on <see cref="IMediatorBuilder"/>.
+/// </summary>
+public static class SQLiteAuditMediatorBuilderExtensions
+{
+    /// <summary>
+    /// Adds SQLite audit trail persistence using ADO.NET with a full options configuration action.
+    /// </summary>
+    /// <param name="configurator">The mediator configurator.</param>
+    /// <param name="configureOptions">Action to configure <see cref="AuditStoreOptions"/>.</param>
+    /// <returns>The configurator for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configurator"/> or <paramref name="configureOptions"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para><strong>Prerequisites:</strong></para>
+    /// Execute the schema script from <c>Scripts/004_CreateAuditEntryTable.sql</c> to create the required
+    /// database objects before using this provider.
+    /// <para><strong>Registered Services:</strong></para>
+    /// <list type="bullet">
+    /// <item><description><see cref="IAuditStore"/> as <see cref="SQLiteAuditStore"/> (Scoped)</description></item>
+    /// <item><description><see cref="IAuditManagement"/> as <see cref="SQLiteAuditManagement"/> (Scoped)</description></item>
+    /// </list>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// services.AddPulse(config => config
+    ///     .AddSQLiteAuditStore(opts =>
+    ///     {
+    ///         opts.ConnectionString = "Data Source=audit.db";
+    ///         opts.TableName = "MyAuditEntry";
+    ///     })
+    /// );
+    /// </code>
+    /// </example>
+    public static IMediatorBuilder AddSQLiteAuditStore(
+        this IMediatorBuilder configurator,
+        Action<AuditStoreOptions> configureOptions
+    )
+    {
+        ArgumentNullException.ThrowIfNull(configurator);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+
+        var services = configurator.Services;
+
+        _ = services.Configure(configureOptions);
+
+        _ = services.RemoveAll<IAuditStore>().AddScoped<IAuditStore, SQLiteAuditStore>();
+
+        _ = services.RemoveAll<IAuditManagement>().AddScoped<IAuditManagement, SQLiteAuditManagement>();
+
+        return configurator;
+    }
+}

--- a/src/NetEvolve.Pulse.SQLite/Scripts/004_CreateAuditEntryTable.sql
+++ b/src/NetEvolve.Pulse.SQLite/Scripts/004_CreateAuditEntryTable.sql
@@ -1,0 +1,54 @@
+-- ============================================================================
+-- 004_CreateAuditEntryTable.sql
+-- ============================================================================
+-- Purpose: Creates the AuditEntry table for the SQLite audit trail store.
+-- Compatible with: NetEvolve.Pulse.SQLite (ADO.NET)
+--
+-- Configuration:
+--   This script uses SQLite CLI .parameter to emulate SQLCMD-style variables.
+--   Set values before running (the defaults below are used when not provided):
+--     @table_name   (default: AuditEntry)
+--     @journal_mode (default: wal)
+--
+-- Usage:
+--   sqlite3 audit.db -cmd ".parameter set @table_name AuditEntry" \
+--                     -cmd ".parameter set @journal_mode wal" \
+--                     ".read 004_CreateAuditEntryTable.sql"
+-- ============================================================================
+
+.bail on
+.mode list
+.headers off
+.separator ''
+
+.output audit.schema.tmp.sql
+SELECT 'PRAGMA journal_mode=' || lower(coalesce(@journal_mode, 'wal')) || ';';
+SELECT 'CREATE TABLE IF NOT EXISTS '
+       || printf('"%w"', coalesce(@table_name, 'AuditEntry'))
+       || ' ('
+       || '"Id"               TEXT        NOT NULL,'
+       || '"CommandType"      TEXT        NOT NULL,'
+       || '"UserId"           TEXT        NULL,'
+       || '"CorrelationId"    TEXT        NULL,'
+       || '"OccurredAt"       TEXT        NOT NULL,'
+       || '"DurationMs"       REAL        NOT NULL,'
+       || '"Result"           INTEGER     NOT NULL,'
+       || '"Payload"          TEXT        NULL,'
+       || '"ExceptionMessage" TEXT        NULL,'
+       || 'CONSTRAINT '
+       || printf('"PK_%w"', coalesce(@table_name, 'AuditEntry'))
+       || ' PRIMARY KEY ("Id")'
+       || ');';
+SELECT 'CREATE INDEX IF NOT EXISTS '
+       || printf('"IX_%w_OccurredAt"', coalesce(@table_name, 'AuditEntry'))
+       || ' ON '
+       || printf('"%w"', coalesce(@table_name, 'AuditEntry'))
+       || ' ("OccurredAt");';
+SELECT 'CREATE INDEX IF NOT EXISTS '
+       || printf('"IX_%w_CommandType"', coalesce(@table_name, 'AuditEntry'))
+       || ' ON '
+       || printf('"%w"', coalesce(@table_name, 'AuditEntry'))
+       || ' ("CommandType");';
+.output stdout
+
+.read audit.schema.tmp.sql

--- a/src/NetEvolve.Pulse.SqlServer/Audit/SqlServerAuditManagement.cs
+++ b/src/NetEvolve.Pulse.SqlServer/Audit/SqlServerAuditManagement.cs
@@ -1,0 +1,268 @@
+﻿namespace NetEvolve.Pulse.Audit;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.Extensibility.Audit;
+using NetEvolve.Pulse.Extensibility.Outbox;
+
+/// <summary>
+/// SQL Server implementation of <see cref="IAuditManagement"/> using ADO.NET.
+/// Provides filtered querying and statistics for the audit trail store.
+/// </summary>
+/// <remarks>
+/// <para><strong>Prerequisites:</strong></para>
+/// Execute the schema script from <c>Scripts/AuditEntry.sql</c> to create the required
+/// database objects before using this provider.
+/// </remarks>
+[SuppressMessage(
+    "Reliability",
+    "CA2007:Consider calling ConfigureAwait on the awaited task",
+    Justification = "await using statements in library code; ConfigureAwait applied to all Task-returning awaits."
+)]
+[SuppressMessage(
+    "Security",
+    "CA2100:Review SQL queries for security vulnerabilities",
+    Justification = "The SQL command text is constructed from validated AuditStoreOptions.Schema/TableName properties and static filter clauses parameterized via SqlParameter, not user input."
+)]
+internal sealed class SqlServerAuditManagement : IAuditManagement
+{
+    /// <summary>The SQL Server connection string used to open new connections for each management operation.</summary>
+    private readonly string _connectionString;
+
+    /// <summary>The fully qualified, bracket-quoted table name used to build query SQL.</summary>
+    private readonly string _fullTableName;
+
+    /// <summary>Cached SQL command text for retrieving aggregate result counts.</summary>
+    private readonly string _getStatisticsSql;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SqlServerAuditManagement"/> class.
+    /// </summary>
+    /// <param name="options">The audit store configuration options.</param>
+    public SqlServerAuditManagement(IOptions<AuditStoreOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrWhiteSpace(options.Value.ConnectionString);
+
+        _connectionString = options.Value.ConnectionString;
+
+        var schema = string.IsNullOrWhiteSpace(options.Value.Schema)
+            ? AuditEntrySchema.DefaultSchema
+            : options.Value.Schema;
+        SqlIdentifier.Validate(schema, nameof(options.Value.Schema));
+        SqlIdentifier.Validate(options.Value.TableName, nameof(options.Value.TableName));
+
+        _fullTableName = $"[{schema}].[{options.Value.TableName}]";
+
+        _getStatisticsSql = $"""
+            SELECT [{AuditEntrySchema.Columns.Result}], COUNT(*) AS [Count]
+            FROM {_fullTableName}
+            GROUP BY [{AuditEntrySchema.Columns.Result}]
+            """;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<AuditRecord>> QueryAsync(
+        AuditFilter filter,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var sql = BuildQuerySql(filter, out var parameters);
+
+            var command = new SqlCommand(sql, connection);
+            await using (command.ConfigureAwait(false))
+            {
+                foreach (var (name, value) in parameters)
+                {
+                    _ = command.Parameters.AddWithValue(name, value);
+                }
+
+                var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                await using (reader.ConfigureAwait(false))
+                {
+                    var records = new List<AuditRecord>();
+                    while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                    {
+                        records.Add(MapToRecord(reader));
+                    }
+
+                    return records;
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<AuditStatistics> GetStatisticsAsync(CancellationToken cancellationToken = default)
+    {
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var command = new SqlCommand(_getStatisticsSql, connection);
+            await using (command.ConfigureAwait(false))
+            {
+                var successCount = 0;
+                var failureCount = 0;
+
+                var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                await using (reader.ConfigureAwait(false))
+                {
+                    var ordResult = reader.GetOrdinal(AuditEntrySchema.Columns.Result);
+                    var ordCount = reader.GetOrdinal("Count");
+
+                    while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                    {
+                        var result = (AuditResult)reader.GetInt16(ordResult);
+                        var count = reader.GetInt32(ordCount);
+
+                        switch (result)
+                        {
+                            case AuditResult.Success:
+                                successCount = count;
+                                break;
+                            case AuditResult.Failure:
+                                failureCount = count;
+                                break;
+                        }
+                    }
+                }
+
+                return new AuditStatistics(successCount, failureCount);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Builds the parameterized SQL SELECT statement for the given <paramref name="filter"/>.
+    /// </summary>
+    /// <param name="filter">The filter conditions to translate into a dynamic WHERE clause.</param>
+    /// <param name="parameters">The parameters to apply to the returned SQL text.</param>
+    /// <returns>The parameterized SQL SELECT statement text.</returns>
+    private string BuildQuerySql(AuditFilter filter, out List<(string Name, object Value)> parameters)
+    {
+        parameters = [];
+
+        var sql = new StringBuilder();
+        _ = sql.Append("SELECT [")
+            .Append(AuditEntrySchema.Columns.Id)
+            .Append("], [")
+            .Append(AuditEntrySchema.Columns.CommandType)
+            .Append("], [")
+            .Append(AuditEntrySchema.Columns.UserId)
+            .Append("], [")
+            .Append(AuditEntrySchema.Columns.CorrelationId)
+            .Append("], [")
+            .Append(AuditEntrySchema.Columns.OccurredAt)
+            .Append("], [")
+            .Append(AuditEntrySchema.Columns.DurationMs)
+            .Append("], [")
+            .Append(AuditEntrySchema.Columns.Result)
+            .Append("], [")
+            .Append(AuditEntrySchema.Columns.Payload)
+            .Append("], [")
+            .Append(AuditEntrySchema.Columns.ExceptionMessage)
+            .Append("]\nFROM ")
+            .Append(_fullTableName);
+
+        var conditions = new List<string>();
+
+        if (filter.CommandType is not null)
+        {
+            conditions.Add($"[{AuditEntrySchema.Columns.CommandType}] = @CommandType");
+            parameters.Add(("@CommandType", filter.CommandType));
+        }
+
+        if (filter.UserId is not null)
+        {
+            conditions.Add($"[{AuditEntrySchema.Columns.UserId}] = @UserId");
+            parameters.Add(("@UserId", filter.UserId));
+        }
+
+        if (filter.From is not null)
+        {
+            conditions.Add($"[{AuditEntrySchema.Columns.OccurredAt}] >= @From");
+            parameters.Add(("@From", filter.From.Value));
+        }
+
+        if (filter.To is not null)
+        {
+            conditions.Add($"[{AuditEntrySchema.Columns.OccurredAt}] <= @To");
+            parameters.Add(("@To", filter.To.Value));
+        }
+
+        if (filter.Result is not null)
+        {
+            conditions.Add($"[{AuditEntrySchema.Columns.Result}] = @Result");
+            parameters.Add(("@Result", (short)filter.Result.Value));
+        }
+
+        if (conditions.Count > 0)
+        {
+            _ = sql.Append("\nWHERE ").Append(string.Join(" AND ", conditions));
+        }
+
+        _ = sql.Append("\nORDER BY [")
+            .Append(AuditEntrySchema.Columns.OccurredAt)
+            .Append("] DESC")
+            .Append("\nOFFSET @Skip ROWS FETCH NEXT @Take ROWS ONLY");
+
+        parameters.Add(("@Skip", filter.Skip));
+        parameters.Add(("@Take", filter.Take));
+
+        return sql.ToString();
+    }
+
+    /// <summary>
+    /// Creates and opens a new SQL Server connection.
+    /// </summary>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>An open <see cref="SqlConnection"/>.</returns>
+    private async Task<SqlConnection> CreateConnectionAsync(CancellationToken cancellationToken)
+    {
+        var connection = new SqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        return connection;
+    }
+
+    /// <summary>
+    /// Maps the current row of a <see cref="SqlDataReader"/> to a new <see cref="AuditRecord"/> instance.
+    /// </summary>
+    /// <param name="reader">The reader positioned on the row to map.</param>
+    /// <returns>A populated <see cref="AuditRecord"/>.</returns>
+    private static AuditRecord MapToRecord(SqlDataReader reader)
+    {
+        var ordId = reader.GetOrdinal(AuditEntrySchema.Columns.Id);
+        var ordCommandType = reader.GetOrdinal(AuditEntrySchema.Columns.CommandType);
+        var ordUserId = reader.GetOrdinal(AuditEntrySchema.Columns.UserId);
+        var ordCorrelationId = reader.GetOrdinal(AuditEntrySchema.Columns.CorrelationId);
+        var ordOccurredAt = reader.GetOrdinal(AuditEntrySchema.Columns.OccurredAt);
+        var ordDurationMs = reader.GetOrdinal(AuditEntrySchema.Columns.DurationMs);
+        var ordResult = reader.GetOrdinal(AuditEntrySchema.Columns.Result);
+        var ordPayload = reader.GetOrdinal(AuditEntrySchema.Columns.Payload);
+        var ordExceptionMessage = reader.GetOrdinal(AuditEntrySchema.Columns.ExceptionMessage);
+
+        return new AuditRecord
+        {
+            Id = reader.GetGuid(ordId),
+            CommandType = reader.GetString(ordCommandType),
+            UserId = reader.IsDBNull(ordUserId) ? null : reader.GetString(ordUserId),
+            CorrelationId = reader.IsDBNull(ordCorrelationId) ? null : reader.GetString(ordCorrelationId),
+            OccurredAt = reader.GetDateTimeOffset(ordOccurredAt),
+            DurationMs = reader.GetDouble(ordDurationMs),
+            Result = (AuditResult)reader.GetInt16(ordResult),
+            Payload = reader.IsDBNull(ordPayload) ? null : reader.GetString(ordPayload),
+            ExceptionMessage = reader.IsDBNull(ordExceptionMessage) ? null : reader.GetString(ordExceptionMessage),
+        };
+    }
+}

--- a/src/NetEvolve.Pulse.SqlServer/Audit/SqlServerAuditStore.cs
+++ b/src/NetEvolve.Pulse.SqlServer/Audit/SqlServerAuditStore.cs
@@ -1,0 +1,114 @@
+﻿namespace NetEvolve.Pulse.Audit;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.Extensibility.Audit;
+using NetEvolve.Pulse.Extensibility.Outbox;
+
+/// <summary>
+/// SQL Server implementation of <see cref="IAuditStore"/> using ADO.NET.
+/// Provides audit trail persistence optimized for SQL Server.
+/// </summary>
+/// <remarks>
+/// <para><strong>Prerequisites:</strong></para>
+/// Execute the schema script from <c>Scripts/AuditEntry.sql</c> to create the required
+/// database objects before using this provider.
+/// </remarks>
+[SuppressMessage(
+    "Reliability",
+    "CA2007:Consider calling ConfigureAwait on the awaited task",
+    Justification = "await using statements in library code; ConfigureAwait applied to all Task-returning awaits."
+)]
+[SuppressMessage(
+    "Security",
+    "CA2100:Review SQL queries for security vulnerabilities",
+    Justification = "The SQL command text is constructed from validated AuditStoreOptions.Schema/TableName properties, not user input."
+)]
+internal sealed class SqlServerAuditStore : IAuditStore
+{
+    /// <summary>The SQL Server connection string used to open new connections for each store operation.</summary>
+    private readonly string _connectionString;
+
+    /// <summary>Cached SQL command text for inserting a new audit record.</summary>
+    private readonly string _insertSql;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SqlServerAuditStore"/> class.
+    /// </summary>
+    /// <param name="options">The audit store configuration options.</param>
+    public SqlServerAuditStore(IOptions<AuditStoreOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrWhiteSpace(options.Value.ConnectionString);
+
+        _connectionString = options.Value.ConnectionString;
+
+        var schema = string.IsNullOrWhiteSpace(options.Value.Schema)
+            ? AuditEntrySchema.DefaultSchema
+            : options.Value.Schema;
+        SqlIdentifier.Validate(schema, nameof(options.Value.Schema));
+        SqlIdentifier.Validate(options.Value.TableName, nameof(options.Value.TableName));
+
+        var fullTableName = $"[{schema}].[{options.Value.TableName}]";
+
+        _insertSql = $"""
+            INSERT INTO {fullTableName}
+                ([{AuditEntrySchema.Columns.Id}],
+                 [{AuditEntrySchema.Columns.CommandType}],
+                 [{AuditEntrySchema.Columns.UserId}],
+                 [{AuditEntrySchema.Columns.CorrelationId}],
+                 [{AuditEntrySchema.Columns.OccurredAt}],
+                 [{AuditEntrySchema.Columns.DurationMs}],
+                 [{AuditEntrySchema.Columns.Result}],
+                 [{AuditEntrySchema.Columns.Payload}],
+                 [{AuditEntrySchema.Columns.ExceptionMessage}])
+            VALUES
+                (@Id, @CommandType, @UserId, @CorrelationId, @OccurredAt, @DurationMs, @Result, @Payload, @ExceptionMessage)
+            """;
+    }
+
+    /// <inheritdoc />
+    public async Task RecordAsync(AuditRecord record, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        var connection = await CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var command = new SqlCommand(_insertSql, connection);
+            await using (command.ConfigureAwait(false))
+            {
+                _ = command.Parameters.AddWithValue("@Id", record.Id);
+                _ = command.Parameters.AddWithValue("@CommandType", record.CommandType);
+                _ = command.Parameters.AddWithValue("@UserId", (object?)record.UserId ?? DBNull.Value);
+                _ = command.Parameters.AddWithValue("@CorrelationId", (object?)record.CorrelationId ?? DBNull.Value);
+                _ = command.Parameters.AddWithValue("@OccurredAt", record.OccurredAt);
+                _ = command.Parameters.AddWithValue("@DurationMs", record.DurationMs);
+                _ = command.Parameters.AddWithValue("@Result", (short)record.Result);
+                _ = command.Parameters.AddWithValue("@Payload", (object?)record.Payload ?? DBNull.Value);
+                _ = command.Parameters.AddWithValue(
+                    "@ExceptionMessage",
+                    (object?)record.ExceptionMessage ?? DBNull.Value
+                );
+
+                _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Creates and opens a new SQL Server connection.
+    /// </summary>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>An open <see cref="SqlConnection"/>.</returns>
+    private async Task<SqlConnection> CreateConnectionAsync(CancellationToken cancellationToken)
+    {
+        var connection = new SqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        return connection;
+    }
+}

--- a/src/NetEvolve.Pulse.SqlServer/Scripts/AuditEntry.sql
+++ b/src/NetEvolve.Pulse.SqlServer/Scripts/AuditEntry.sql
@@ -1,0 +1,54 @@
+-- ============================================================================
+-- AuditEntry Table Schema
+-- ============================================================================
+-- Purpose: Stores audit trail records for processed requests (commands and,
+--          optionally, queries), for later inspection and statistics reporting.
+-- Compatible with: NetEvolve.Pulse.SqlServer (ADO.NET)
+--
+-- Configuration:
+--   Adjust SchemaName and TableName below before executing.
+--   This script requires SQLCMD mode:
+--     - sqlcmd utility:    sqlcmd -i AuditEntry.sql
+--     - SSMS:              Query > SQLCMD Mode (Ctrl+Shift+Q)
+--     - Azure Data Studio: Enable SQLCMD in the query toolbar
+-- ============================================================================
+
+-- ============================================================================
+-- Configuration
+-- ============================================================================
+:setvar SchemaName "pulse"
+:setvar TableName "AuditEntry"
+
+-- Create schema if it doesn't exist
+IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE [name] = N'$(SchemaName)')
+BEGIN
+    EXEC('CREATE SCHEMA [$(SchemaName)]');
+END
+GO
+
+-- Create table if it doesn't exist
+IF NOT EXISTS (SELECT 1 FROM sys.objects WHERE [object_id] = OBJECT_ID(N'[$(SchemaName)].[$(TableName)]') AND [type] = N'U')
+BEGIN
+    CREATE TABLE [$(SchemaName)].[$(TableName)]
+    (
+        [Id] UNIQUEIDENTIFIER NOT NULL,
+        [CommandType] NVARCHAR(500) NOT NULL,
+        [UserId] NVARCHAR(256) NULL,
+        [CorrelationId] NVARCHAR(100) NULL,
+        [OccurredAt] DATETIMEOFFSET(7) NOT NULL,
+        [DurationMs] FLOAT NOT NULL,
+        [Result] SMALLINT NOT NULL,
+        [Payload] NVARCHAR(MAX) NULL,
+        [ExceptionMessage] NVARCHAR(MAX) NULL,
+        CONSTRAINT [PK_$(TableName)] PRIMARY KEY CLUSTERED ([Id])
+    );
+
+    -- Index for ordering/range-filtering entries by occurrence time (most recent first)
+    CREATE NONCLUSTERED INDEX [IX_$(TableName)_OccurredAt]
+        ON [$(SchemaName)].[$(TableName)] ([OccurredAt]);
+
+    -- Index for efficient filtering by request type
+    CREATE NONCLUSTERED INDEX [IX_$(TableName)_CommandType]
+        ON [$(SchemaName)].[$(TableName)] ([CommandType]);
+END
+GO

--- a/src/NetEvolve.Pulse.SqlServer/SqlServerAuditMediatorBuilderExtensions.cs
+++ b/src/NetEvolve.Pulse.SqlServer/SqlServerAuditMediatorBuilderExtensions.cs
@@ -1,0 +1,61 @@
+﻿namespace NetEvolve.Pulse;
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using NetEvolve.Pulse.Audit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.Audit;
+
+/// <summary>
+/// Extension methods for configuring the SQL Server audit trail store on <see cref="IMediatorBuilder"/>.
+/// </summary>
+public static class SqlServerAuditMediatorBuilderExtensions
+{
+    /// <summary>
+    /// Adds SQL Server audit trail persistence using ADO.NET.
+    /// </summary>
+    /// <param name="configurator">The mediator configurator.</param>
+    /// <param name="configureOptions">Action to configure <see cref="AuditStoreOptions"/>.</param>
+    /// <returns>The configurator for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configurator"/> or <paramref name="configureOptions"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para><strong>Prerequisites:</strong></para>
+    /// Execute the schema script from <c>Scripts/AuditEntry.sql</c> to create the required
+    /// database objects before using this provider.
+    /// <para><strong>Registered Services:</strong></para>
+    /// <list type="bullet">
+    /// <item><description><see cref="IAuditStore"/> as <see cref="SqlServerAuditStore"/> (Scoped)</description></item>
+    /// <item><description><see cref="IAuditManagement"/> as <see cref="SqlServerAuditManagement"/> (Scoped)</description></item>
+    /// </list>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// services.AddPulse(config => config
+    ///     .AddSqlServerAuditStore(opts =>
+    ///     {
+    ///         opts.ConnectionString = "Server=.;Database=MyDb;Integrated Security=true;";
+    ///         opts.Schema = "myschema";
+    ///     })
+    /// );
+    /// </code>
+    /// </example>
+    public static IMediatorBuilder AddSqlServerAuditStore(
+        this IMediatorBuilder configurator,
+        Action<AuditStoreOptions> configureOptions
+    )
+    {
+        ArgumentNullException.ThrowIfNull(configurator);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+
+        var services = configurator.Services;
+
+        _ = services.Configure(configureOptions);
+
+        _ = services.RemoveAll<IAuditStore>().AddScoped<IAuditStore, SqlServerAuditStore>();
+
+        _ = services.RemoveAll<IAuditManagement>().AddScoped<IAuditManagement, SqlServerAuditManagement>();
+
+        return configurator;
+    }
+}

--- a/src/NetEvolve.Pulse/Audit/AuditOptions.cs
+++ b/src/NetEvolve.Pulse/Audit/AuditOptions.cs
@@ -1,0 +1,34 @@
+namespace NetEvolve.Pulse.Audit;
+
+using System;
+using System.Collections.Generic;
+
+/// <summary>
+/// Configuration options for the audit trail.
+/// </summary>
+public sealed class AuditOptions
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the serialized request payload is stored
+    /// on the recorded <c>AuditRecord</c>.
+    /// </summary>
+    /// <remarks>
+    /// When enabled, the payload is serialized via the registered <c>IPayloadSerializer</c>
+    /// by the audit request interceptor. Default: <see langword="false"/>.
+    /// </remarks>
+    public bool CapturePayload { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether queries, in addition to commands, are recorded
+    /// to the audit trail.
+    /// </summary>
+    /// <remarks>
+    /// Default: <see langword="false"/>, meaning only commands are audited.
+    /// </remarks>
+    public bool AuditQueries { get; set; }
+
+    /// <summary>
+    /// Gets the set of request types that are excluded from auditing entirely.
+    /// </summary>
+    public ISet<Type> ExcludedCommandTypes { get; } = new HashSet<Type>();
+}

--- a/src/NetEvolve.Pulse/Audit/AuditStoreOptions.cs
+++ b/src/NetEvolve.Pulse/Audit/AuditStoreOptions.cs
@@ -1,0 +1,43 @@
+namespace NetEvolve.Pulse.Audit;
+
+using NetEvolve.Pulse.Extensibility.Audit;
+
+/// <summary>
+/// Configuration options for the audit trail store.
+/// </summary>
+public sealed class AuditStoreOptions
+{
+    /// <summary>
+    /// Gets or sets the connection string used by the audit trail store provider.
+    /// </summary>
+    /// <remarks>
+    /// Required for database-backed providers. Leave <see langword="null"/> when the provider
+    /// obtains its connection through other means (e.g., a registered <c>DbContext</c>).
+    /// </remarks>
+    public string? ConnectionString { get; set; }
+
+    /// <summary>
+    /// Gets or sets the database schema name for the audit entry table.
+    /// Default: <c>"pulse"</c>.
+    /// </summary>
+    /// <remarks>
+    /// Set to <c>null</c> or empty string to use the default schema (e.g., "dbo" for SQL Server).
+    /// Some database providers may not support schemas.
+    /// </remarks>
+    public string? Schema { get; set; } = AuditEntrySchema.DefaultSchema;
+
+    /// <summary>
+    /// Gets or sets the table name for audit entries.
+    /// Default: <c>"AuditEntry"</c>.
+    /// </summary>
+    public string TableName { get; set; } = AuditEntrySchema.DefaultTableName;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether WAL (Write-Ahead Logging) mode is enabled.
+    /// </summary>
+    /// <remarks>
+    /// This setting is used by SQLite-based providers.
+    /// Default: <see langword="true"/>.
+    /// </remarks>
+    public bool EnableWalMode { get; set; } = true;
+}

--- a/src/NetEvolve.Pulse/Audit/NullAuditUserAccessor.cs
+++ b/src/NetEvolve.Pulse/Audit/NullAuditUserAccessor.cs
@@ -1,0 +1,18 @@
+namespace NetEvolve.Pulse.Audit;
+
+using NetEvolve.Pulse.Extensibility.Audit;
+
+/// <summary>
+/// A no-op <see cref="IAuditUserAccessor"/> implementation that never resolves a user.
+/// </summary>
+/// <remarks>
+/// <para><strong>Use Case:</strong></para>
+/// Registered as the default accessor by <c>AddAudit()</c> when no other
+/// <see cref="IAuditUserAccessor"/> is registered, e.g. by
+/// <c>NetEvolve.Pulse.AspNetCore</c>'s <c>HttpContextAuditUserAccessor</c>.
+/// </remarks>
+internal sealed class NullAuditUserAccessor : IAuditUserAccessor
+{
+    /// <inheritdoc/>
+    public string? GetCurrentUser() => null;
+}

--- a/src/NetEvolve.Pulse/AuditMediatorBuilderExtensions.cs
+++ b/src/NetEvolve.Pulse/AuditMediatorBuilderExtensions.cs
@@ -1,0 +1,70 @@
+namespace NetEvolve.Pulse;
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using NetEvolve.Pulse.Audit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.Audit;
+using NetEvolve.Pulse.Interceptors;
+
+/// <summary>
+/// Provides extension methods for registering the audit trail interceptor with the Pulse mediator.
+/// </summary>
+/// <seealso cref="AuditOptions"/>
+/// <seealso cref="IAuditStore"/>
+/// <seealso cref="IAuditUserAccessor"/>
+public static class AuditMediatorBuilderExtensions
+{
+    /// <summary>
+    /// Registers the audit trail interceptor. Commands, and optionally queries, are recorded to
+    /// <see cref="IAuditStore"/> as they are processed by the mediator.
+    /// </summary>
+    /// <param name="builder">The mediator builder.</param>
+    /// <param name="configure">
+    /// An optional delegate that configures <see cref="AuditOptions"/>.
+    /// When <see langword="null"/>, default options are used.
+    /// </param>
+    /// <returns>The builder for method chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// This method only registers the interceptor - it does not register an <see cref="IAuditStore"/>.
+    /// Callers must also register a store, e.g. via one of the provider-specific
+    /// <c>Add*AuditStore()</c> extensions (EF Core or an ADO.NET provider), for audit records to actually
+    /// be persisted. Without a registered store, the interceptor is a harmless no-op.
+    /// <para>
+    /// By default, the current user is resolved via a no-op <see cref="IAuditUserAccessor"/> that always
+    /// returns <see langword="null"/>. In an ASP.NET Core host, call
+    /// <c>NetEvolve.Pulse.AspNetCore</c>'s <c>AddHttpContextAuditUserAccessor()</c> to replace it with an
+    /// accessor that reads the current user from the ambient <c>HttpContext</c>.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// services.AddPulse(builder =>
+    /// {
+    ///     builder.AddAudit(options => options.CapturePayload = true);
+    ///     // builder.AddSqlServerAuditStore(...); // registers the store
+    /// });
+    /// </code>
+    /// </example>
+    public static IMediatorBuilder AddAudit(this IMediatorBuilder builder, Action<AuditOptions>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        _ = builder.Services.AddOptions<AuditOptions>();
+
+        if (configure is not null)
+        {
+            _ = builder.Services.Configure(configure);
+        }
+
+        builder.Services.TryAddSingleton<IAuditUserAccessor, NullAuditUserAccessor>();
+
+        builder.Services.TryAddEnumerable(
+            ServiceDescriptor.Scoped(typeof(IRequestInterceptor<,>), typeof(AuditRequestInterceptor<,>))
+        );
+
+        return builder;
+    }
+}

--- a/src/NetEvolve.Pulse/Interceptors/AuditRequestInterceptor.cs
+++ b/src/NetEvolve.Pulse/Interceptors/AuditRequestInterceptor.cs
@@ -1,0 +1,147 @@
+namespace NetEvolve.Pulse.Interceptors;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.Audit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.Audit;
+
+/// <summary>
+/// Request interceptor that records commands, and optionally queries, to an <see cref="IAuditStore"/>
+/// for audit trail purposes.
+/// </summary>
+/// <typeparam name="TRequest">The type of request being intercepted.</typeparam>
+/// <typeparam name="TResponse">The type of response produced by the request.</typeparam>
+/// <remarks>
+/// <para><strong>Behavior:</strong></para>
+/// <list type="number">
+/// <item><description>If <typeparamref name="TRequest"/> is listed in <see cref="AuditOptions.ExcludedCommandTypes"/>, the interceptor passes through without any try/catch overhead - the request is never audited.</description></item>
+/// <item><description>If the request implements <see cref="IQuery{TResponse}"/> and <see cref="AuditOptions.AuditQueries"/> is <see langword="false"/>, the interceptor passes through unchanged - queries are not audited by default.</description></item>
+/// <item><description>If <see cref="IAuditStore"/> is not registered in the DI container, the interceptor is a no-op - auditing is not possible without a store.</description></item>
+/// <item><description>Otherwise, the handler is invoked and an <see cref="AuditRecord"/> is recorded before returning, with <see cref="AuditResult.Success"/> on success or <see cref="AuditResult.Failure"/> when the handler throws.</description></item>
+/// <item><description>The serialized request payload is only captured when <see cref="AuditOptions.CapturePayload"/> is <see langword="true"/>.</description></item>
+/// <item><description>The original exception always propagates unchanged - this interceptor never swallows a failure, it only optionally records it first.</description></item>
+/// </list>
+/// <para><strong>Registration:</strong></para>
+/// Use <c>AddAudit()</c> on the <see cref="IMediatorBuilder"/> to register this interceptor.
+/// </remarks>
+/// <seealso cref="IAuditStore"/>
+/// <seealso cref="IAuditUserAccessor"/>
+/// <seealso cref="AuditOptions"/>
+internal sealed class AuditRequestInterceptor<TRequest, TResponse> : IRequestInterceptor<TRequest, TResponse>
+    where TRequest : IRequest<TResponse>
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly AuditOptions _options;
+    private readonly IPayloadSerializer _payloadSerializer;
+    private readonly IAuditUserAccessor _auditUserAccessor;
+    private readonly TimeProvider _timeProvider;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AuditRequestInterceptor{TRequest, TResponse}"/> class.
+    /// </summary>
+    /// <param name="serviceProvider">The service provider used to resolve the optional <see cref="IAuditStore"/>.</param>
+    /// <param name="options">The options that control audit trail behavior.</param>
+    /// <param name="payloadSerializer">The serializer used to serialize the request payload.</param>
+    /// <param name="auditUserAccessor">The accessor used to resolve the current user.</param>
+    /// <param name="timeProvider">The time provider used to measure elapsed time.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="serviceProvider"/>, <paramref name="options"/>, <paramref name="payloadSerializer"/>,
+    /// <paramref name="auditUserAccessor"/> or <paramref name="timeProvider"/> is <see langword="null"/>.
+    /// </exception>
+    public AuditRequestInterceptor(
+        IServiceProvider serviceProvider,
+        IOptions<AuditOptions> options,
+        IPayloadSerializer payloadSerializer,
+        IAuditUserAccessor auditUserAccessor,
+        TimeProvider timeProvider
+    )
+    {
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(payloadSerializer);
+        ArgumentNullException.ThrowIfNull(auditUserAccessor);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        _serviceProvider = serviceProvider;
+        _options = options.Value;
+        _payloadSerializer = payloadSerializer;
+        _auditUserAccessor = auditUserAccessor;
+        _timeProvider = timeProvider;
+    }
+
+    /// <inheritdoc />
+    public async Task<TResponse> HandleAsync(
+        TRequest request,
+        Func<TRequest, CancellationToken, Task<TResponse>> handler,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+
+        if (_options.ExcludedCommandTypes.Contains(typeof(TRequest)))
+        {
+            return await handler(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (request is IQuery<TResponse> && !_options.AuditQueries)
+        {
+            return await handler(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        var store = _serviceProvider.GetService<IAuditStore>();
+        if (store is null)
+        {
+            return await handler(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        var startTime = _timeProvider.GetUtcNow();
+
+        try
+        {
+            var response = await handler(request, cancellationToken).ConfigureAwait(false);
+
+            var elapsedMs = (_timeProvider.GetUtcNow() - startTime).TotalMilliseconds;
+
+            var record = new AuditRecord
+            {
+                Id = Guid.NewGuid(),
+                CommandType = typeof(TRequest).AssemblyQualifiedName!,
+                UserId = _auditUserAccessor.GetCurrentUser(),
+                CorrelationId = request.CorrelationId,
+                OccurredAt = _timeProvider.GetUtcNow(),
+                DurationMs = elapsedMs,
+                Result = AuditResult.Success,
+                Payload = _options.CapturePayload ? _payloadSerializer.Serialize(request) : null,
+            };
+
+            await store.RecordAsync(record, cancellationToken).ConfigureAwait(false);
+
+            return response;
+        }
+        catch (Exception ex)
+        {
+            var elapsedMs = (_timeProvider.GetUtcNow() - startTime).TotalMilliseconds;
+
+            var record = new AuditRecord
+            {
+                Id = Guid.NewGuid(),
+                CommandType = typeof(TRequest).AssemblyQualifiedName!,
+                UserId = _auditUserAccessor.GetCurrentUser(),
+                CorrelationId = request.CorrelationId,
+                OccurredAt = _timeProvider.GetUtcNow(),
+                DurationMs = elapsedMs,
+                Result = AuditResult.Failure,
+                Payload = _options.CapturePayload ? _payloadSerializer.Serialize(request) : null,
+                ExceptionMessage = ex.Message,
+            };
+
+            await store.RecordAsync(record, cancellationToken).ConfigureAwait(false);
+
+            throw;
+        }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Integration/Audit/AuditTestsBase.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Audit/AuditTestsBase.cs
@@ -1,0 +1,279 @@
+namespace NetEvolve.Pulse.Tests.Integration.Audit;
+
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Audit;
+using NetEvolve.Pulse.Extensibility.Audit;
+using NetEvolve.Pulse.Tests.Integration.Internals;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
+
+[TestGroup("Audit")]
+[Timeout(300_000)] // Increased timeout to accommodate potential delays in CI environments.
+public abstract class AuditTestsBase(IServiceFixture databaseServiceFixture, IServiceInitializer databaseInitializer)
+{
+    protected IServiceFixture DatabaseServiceFixture { get; } = databaseServiceFixture;
+    protected IServiceInitializer DatabaseInitializer { get; } = databaseInitializer;
+
+    protected async ValueTask RunAndVerify(
+        Func<IServiceProvider, CancellationToken, Task> testableCode,
+        CancellationToken cancellationToken,
+        Action<IServiceCollection>? configureServices = null,
+        [CallerMemberName] string tableName = null!
+    )
+    {
+        ArgumentNullException.ThrowIfNull(testableCode);
+
+        using var host = new HostBuilder()
+            .ConfigureAppConfiguration((hostContext, configBuilder) => { })
+            .ConfigureServices(services =>
+            {
+                DatabaseInitializer.Initialize(services, DatabaseServiceFixture);
+                configureServices?.Invoke(services);
+                _ = services
+                    .AddPulse(mediatorBuilder => DatabaseInitializer.Configure(mediatorBuilder, DatabaseServiceFixture))
+                    .Configure<AuditStoreOptions>(options =>
+                    {
+                        options.TableName = tableName;
+                        options.Schema = TestHelper.TargetFramework;
+                    });
+            })
+            .ConfigureWebHost(webBuilder => _ = webBuilder.UseTestServer().Configure(applicationBuilder => { }))
+            .Build();
+
+        await DatabaseInitializer.CreateDatabaseAsync(host.Services, cancellationToken).ConfigureAwait(false);
+        await host.StartAsync(cancellationToken).ConfigureAwait(false);
+
+        using var server = host.GetTestServer();
+
+        using (Assert.Multiple())
+        {
+            var scope = server.Services.CreateAsyncScope();
+            await using (scope.ConfigureAwait(false))
+            {
+                await testableCode.Invoke(scope.ServiceProvider, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        await host.StopAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static AuditRecord CreateRecord(
+        string commandType = "Test.Command",
+        string? userId = "user-1",
+        string? correlationId = "corr-1",
+        DateTimeOffset? occurredAt = null,
+        double durationMs = 12.5,
+        AuditResult result = AuditResult.Success,
+        string? payload = null,
+        string? exceptionMessage = null
+    ) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            CommandType = commandType,
+            UserId = userId,
+            CorrelationId = correlationId,
+            OccurredAt = occurredAt ?? DateTimeOffset.UtcNow,
+            DurationMs = durationMs,
+            Result = result,
+            Payload = payload,
+            ExceptionMessage = exceptionMessage,
+        };
+
+    [Test]
+    public async Task RecordAsync_Then_QueryAsync_Returns_record(CancellationToken cancellationToken) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var store = services.GetRequiredService<IAuditStore>();
+                    var management = services.GetRequiredService<IAuditManagement>();
+
+                    var record = CreateRecord(
+                        commandType: "Test.CreateOrderCommand",
+                        userId: "alice",
+                        correlationId: "corr-xyz",
+                        payload: """{"orderId":1}"""
+                    );
+                    await store.RecordAsync(record, token).ConfigureAwait(false);
+
+                    var results = await management.QueryAsync(new AuditFilter(), token).ConfigureAwait(false);
+
+                    _ = await Assert.That(results).HasSingleItem();
+                    var stored = results[0];
+
+                    using (Assert.Multiple())
+                    {
+                        _ = await Assert.That(stored.CommandType).IsEqualTo(record.CommandType);
+                        _ = await Assert.That(stored.UserId).IsEqualTo(record.UserId);
+                        _ = await Assert.That(stored.CorrelationId).IsEqualTo(record.CorrelationId);
+                        _ = await Assert.That(stored.Result).IsEqualTo(AuditResult.Success);
+                        _ = await Assert.That(stored.Payload).IsEqualTo(record.Payload);
+                    }
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+    [Test]
+    public async Task QueryAsync_Filters_by_CommandType(CancellationToken cancellationToken) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var store = services.GetRequiredService<IAuditStore>();
+                    var management = services.GetRequiredService<IAuditManagement>();
+
+                    await store.RecordAsync(CreateRecord(commandType: "Test.CommandA"), token).ConfigureAwait(false);
+                    await store.RecordAsync(CreateRecord(commandType: "Test.CommandB"), token).ConfigureAwait(false);
+
+                    var results = await management
+                        .QueryAsync(new AuditFilter { CommandType = "Test.CommandA" }, token)
+                        .ConfigureAwait(false);
+
+                    _ = await Assert.That(results).HasSingleItem();
+                    _ = await Assert.That(results[0].CommandType).IsEqualTo("Test.CommandA");
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+    [Test]
+    public async Task QueryAsync_Filters_by_UserId(CancellationToken cancellationToken) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var store = services.GetRequiredService<IAuditStore>();
+                    var management = services.GetRequiredService<IAuditManagement>();
+
+                    await store.RecordAsync(CreateRecord(userId: "alice"), token).ConfigureAwait(false);
+                    await store.RecordAsync(CreateRecord(userId: "bob"), token).ConfigureAwait(false);
+
+                    var results = await management
+                        .QueryAsync(new AuditFilter { UserId = "bob" }, token)
+                        .ConfigureAwait(false);
+
+                    _ = await Assert.That(results).HasSingleItem();
+                    _ = await Assert.That(results[0].UserId).IsEqualTo("bob");
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+    [Test]
+    public async Task QueryAsync_Filters_by_Result(CancellationToken cancellationToken) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var store = services.GetRequiredService<IAuditStore>();
+                    var management = services.GetRequiredService<IAuditManagement>();
+
+                    await store.RecordAsync(CreateRecord(result: AuditResult.Success), token).ConfigureAwait(false);
+                    await store
+                        .RecordAsync(CreateRecord(result: AuditResult.Failure, exceptionMessage: "boom"), token)
+                        .ConfigureAwait(false);
+
+                    var results = await management
+                        .QueryAsync(new AuditFilter { Result = AuditResult.Failure }, token)
+                        .ConfigureAwait(false);
+
+                    _ = await Assert.That(results).HasSingleItem();
+                    _ = await Assert.That(results[0].Result).IsEqualTo(AuditResult.Failure);
+                    _ = await Assert.That(results[0].ExceptionMessage).IsEqualTo("boom");
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+    [Test]
+    public async Task QueryAsync_Filters_by_From_and_To(CancellationToken cancellationToken) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var store = services.GetRequiredService<IAuditStore>();
+                    var management = services.GetRequiredService<IAuditManagement>();
+
+                    var old = DateTimeOffset.UtcNow.AddDays(-10);
+                    var recent = DateTimeOffset.UtcNow;
+
+                    await store
+                        .RecordAsync(CreateRecord(commandType: "Test.Old", occurredAt: old), token)
+                        .ConfigureAwait(false);
+                    await store
+                        .RecordAsync(CreateRecord(commandType: "Test.Recent", occurredAt: recent), token)
+                        .ConfigureAwait(false);
+
+                    var results = await management
+                        .QueryAsync(new AuditFilter { From = DateTimeOffset.UtcNow.AddDays(-1) }, token)
+                        .ConfigureAwait(false);
+
+                    _ = await Assert.That(results).HasSingleItem();
+                    _ = await Assert.That(results[0].CommandType).IsEqualTo("Test.Recent");
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+    [Test]
+    public async Task QueryAsync_Respects_Take_and_orders_by_OccurredAt_descending(
+        CancellationToken cancellationToken
+    ) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var store = services.GetRequiredService<IAuditStore>();
+                    var management = services.GetRequiredService<IAuditManagement>();
+
+                    var baseline = DateTimeOffset.UtcNow.AddMinutes(-10);
+                    for (var i = 0; i < 3; i++)
+                    {
+                        await store
+                            .RecordAsync(
+                                CreateRecord(commandType: $"Test.Command{i}", occurredAt: baseline.AddMinutes(i)),
+                                token
+                            )
+                            .ConfigureAwait(false);
+                    }
+
+                    var results = await management
+                        .QueryAsync(new AuditFilter { Take = 2 }, token)
+                        .ConfigureAwait(false);
+
+                    _ = await Assert.That(results.Count).IsEqualTo(2);
+                    // Most recent (Command2) first, then Command1.
+                    _ = await Assert.That(results[0].CommandType).IsEqualTo("Test.Command2");
+                    _ = await Assert.That(results[1].CommandType).IsEqualTo("Test.Command1");
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+    [Test]
+    public async Task GetStatisticsAsync_Returns_correct_counts(CancellationToken cancellationToken) =>
+        await RunAndVerify(
+                async (services, token) =>
+                {
+                    var store = services.GetRequiredService<IAuditStore>();
+                    var management = services.GetRequiredService<IAuditManagement>();
+
+                    await store.RecordAsync(CreateRecord(result: AuditResult.Success), token).ConfigureAwait(false);
+                    await store.RecordAsync(CreateRecord(result: AuditResult.Success), token).ConfigureAwait(false);
+                    await store.RecordAsync(CreateRecord(result: AuditResult.Failure), token).ConfigureAwait(false);
+
+                    var stats = await management.GetStatisticsAsync(token).ConfigureAwait(false);
+
+                    using (Assert.Multiple())
+                    {
+                        _ = await Assert.That(stats.SuccessCount).IsEqualTo(2);
+                        _ = await Assert.That(stats.FailureCount).IsEqualTo(1);
+                        _ = await Assert.That(stats.TotalCount).IsEqualTo(3);
+                    }
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+}

--- a/tests/NetEvolve.Pulse.Tests.Integration/Audit/MySqlAdoNetAuditTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Audit/MySqlAdoNetAuditTests.cs
@@ -1,0 +1,12 @@
+namespace NetEvolve.Pulse.Tests.Integration.Audit;
+
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Tests.Integration.Internals;
+using NetEvolve.Pulse.Tests.Integration.Internals.Audit;
+
+[ClassDataSource<MySqlDatabaseServiceFixture, MySqlAdoNetAuditInitializer>(Shared = [SharedType.None, SharedType.None])]
+[TestGroup("MySql")]
+[TestGroup("AdoNet")]
+[InheritsTests]
+public class MySqlAdoNetAuditTests(IServiceFixture databaseServiceFixture, IServiceInitializer databaseInitializer)
+    : AuditTestsBase(databaseServiceFixture, databaseInitializer);

--- a/tests/NetEvolve.Pulse.Tests.Integration/Audit/MySqlEntityFrameworkAuditTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Audit/MySqlEntityFrameworkAuditTests.cs
@@ -1,0 +1,16 @@
+namespace NetEvolve.Pulse.Tests.Integration.Audit;
+
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Tests.Integration.Internals;
+using NetEvolve.Pulse.Tests.Integration.Internals.Audit;
+
+[ClassDataSource<MySqlDatabaseServiceFixture, EntityFrameworkAuditInitializer>(
+    Shared = [SharedType.None, SharedType.None]
+)]
+[TestGroup("MySql")]
+[TestGroup("EntityFramework")]
+[InheritsTests]
+public class MySqlEntityFrameworkAuditTests(
+    IServiceFixture databaseServiceFixture,
+    IServiceInitializer databaseInitializer
+) : AuditTestsBase(databaseServiceFixture, databaseInitializer);

--- a/tests/NetEvolve.Pulse.Tests.Integration/Audit/PostgreSqlAdoNetAuditTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Audit/PostgreSqlAdoNetAuditTests.cs
@@ -1,0 +1,14 @@
+namespace NetEvolve.Pulse.Tests.Integration.Audit;
+
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Tests.Integration.Internals;
+using NetEvolve.Pulse.Tests.Integration.Internals.Audit;
+
+[ClassDataSource<PostgreSqlDatabaseServiceFixture, PostgreSqlAdoNetAuditInitializer>(
+    Shared = [SharedType.None, SharedType.None]
+)]
+[TestGroup("PostgreSql")]
+[TestGroup("AdoNet")]
+[InheritsTests]
+public class PostgreSqlAdoNetAuditTests(IServiceFixture databaseServiceFixture, IServiceInitializer databaseInitializer)
+    : AuditTestsBase(databaseServiceFixture, databaseInitializer);

--- a/tests/NetEvolve.Pulse.Tests.Integration/Audit/SQLiteAdoNetAuditTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Audit/SQLiteAdoNetAuditTests.cs
@@ -1,0 +1,14 @@
+namespace NetEvolve.Pulse.Tests.Integration.Audit;
+
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Tests.Integration.Internals;
+using NetEvolve.Pulse.Tests.Integration.Internals.Audit;
+
+[ClassDataSource<SQLiteDatabaseServiceFixture, SQLiteAdoNetAuditInitializer>(
+    Shared = [SharedType.None, SharedType.None]
+)]
+[TestGroup("SQLite")]
+[TestGroup("AdoNet")]
+[InheritsTests]
+public class SQLiteAdoNetAuditTests(IServiceFixture databaseServiceFixture, IServiceInitializer databaseInitializer)
+    : AuditTestsBase(databaseServiceFixture, databaseInitializer);

--- a/tests/NetEvolve.Pulse.Tests.Integration/Audit/SQLiteEntityFrameworkAuditTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Audit/SQLiteEntityFrameworkAuditTests.cs
@@ -1,0 +1,16 @@
+namespace NetEvolve.Pulse.Tests.Integration.Audit;
+
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Tests.Integration.Internals;
+using NetEvolve.Pulse.Tests.Integration.Internals.Audit;
+
+[ClassDataSource<SQLiteDatabaseServiceFixture, EntityFrameworkAuditInitializer>(
+    Shared = [SharedType.None, SharedType.None]
+)]
+[TestGroup("SQLite")]
+[TestGroup("EntityFramework")]
+[InheritsTests]
+public class SQLiteEntityFrameworkAuditTests(
+    IServiceFixture databaseServiceFixture,
+    IServiceInitializer databaseInitializer
+) : AuditTestsBase(databaseServiceFixture, databaseInitializer);

--- a/tests/NetEvolve.Pulse.Tests.Integration/Audit/SqlServerAdoNetAuditTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Audit/SqlServerAdoNetAuditTests.cs
@@ -1,0 +1,14 @@
+namespace NetEvolve.Pulse.Tests.Integration.Audit;
+
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Tests.Integration.Internals;
+using NetEvolve.Pulse.Tests.Integration.Internals.Audit;
+
+[ClassDataSource<SqlServerDatabaseServiceFixture, SqlServerAdoNetAuditInitializer>(
+    Shared = [SharedType.None, SharedType.None]
+)]
+[TestGroup("SqlServer")]
+[TestGroup("AdoNet")]
+[InheritsTests]
+public class SqlServerAdoNetAuditTests(IServiceFixture databaseServiceFixture, IServiceInitializer databaseInitializer)
+    : AuditTestsBase(databaseServiceFixture, databaseInitializer);

--- a/tests/NetEvolve.Pulse.Tests.Integration/Internals/Audit/EntityFrameworkAuditInitializer.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Internals/Audit/EntityFrameworkAuditInitializer.cs
@@ -1,0 +1,164 @@
+namespace NetEvolve.Pulse.Tests.Integration.Internals.Audit;
+
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.Audit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.Audit;
+
+public sealed class EntityFrameworkAuditInitializer : IServiceInitializer
+{
+    public void Configure(IMediatorBuilder mediatorBuilder, IServiceFixture serviceFixture) =>
+        mediatorBuilder.AddEntityFrameworkAuditStore<TestAuditStoreDbContext>();
+
+    private static readonly SemaphoreSlim _gate = new(1, 1);
+
+    public async ValueTask CreateDatabaseAsync(IServiceProvider serviceProvider, CancellationToken cancellationToken)
+    {
+        using (var scope = serviceProvider.CreateScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<TestAuditStoreDbContext>();
+            var databaseCreator = context.GetService<IDatabaseCreator>();
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (databaseCreator is IRelationalDatabaseCreator relationalDatabaseCreator)
+            {
+                if (!await relationalDatabaseCreator.CanConnectAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    await relationalDatabaseCreator.CreateAsync(cancellationToken).ConfigureAwait(false);
+                }
+            }
+            else
+            {
+                if (await databaseCreator.CanConnectAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    return;
+                }
+
+                await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+                try
+                {
+                    _ = await databaseCreator.EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+                    return;
+                }
+                finally
+                {
+                    _ = _gate.Release();
+                }
+            }
+
+            if (databaseCreator is IRelationalDatabaseCreator relationalTableCreator)
+            {
+                await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    await relationalTableCreator.CreateTablesAsync(cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    _ = _gate.Release();
+                }
+            }
+        }
+    }
+
+    public void Initialize(IServiceCollection services, IServiceFixture serviceFixture) =>
+        _ = services.AddDbContextFactory<TestAuditStoreDbContext>(options =>
+        {
+            var connectionString = serviceFixture.ConnectionString;
+
+            // Register a custom model-cache key factory that includes the per-test table name.
+            _ = options.ReplaceService<IModelCacheKeyFactory, TestTableModelCacheKeyFactory>();
+
+            _ = serviceFixture.ServiceType switch
+            {
+                ServiceType.InMemory => options.UseInMemoryDatabase(connectionString),
+                ServiceType.MySql => options.UseMySQL(connectionString),
+                ServiceType.PostgreSQL => options.UseNpgsql(connectionString),
+                // Add a busy-timeout interceptor so that concurrent SaveChangesAsync calls from
+                // parallel tests wait and retry instead of failing with SQLITE_BUSY.
+                ServiceType.SQLite => options
+                    .UseSqlite(connectionString)
+                    .AddInterceptors(new SQLiteBusyTimeoutInterceptor()),
+                ServiceType.SqlServer => options.UseSqlServer(
+                    connectionString,
+                    sqlOptions => sqlOptions.EnableRetryOnFailure(maxRetryCount: 5)
+                ),
+                _ => throw new NotSupportedException($"Database type {serviceFixture.ServiceType} is not supported."),
+            };
+        });
+
+    /// <summary>
+    /// Sets <c>PRAGMA busy_timeout</c> on every SQLite connection when it is opened so that
+    /// concurrent write operations wait and retry rather than immediately failing with SQLITE_BUSY.
+    /// </summary>
+    private sealed class SQLiteBusyTimeoutInterceptor : DbConnectionInterceptor
+    {
+        private const string Pragmas = "PRAGMA busy_timeout = 60000; PRAGMA journal_mode = WAL;";
+
+        public override void ConnectionOpened(DbConnection connection, ConnectionEndEventData eventData)
+        {
+            using var command = connection.CreateCommand();
+            command.CommandText = Pragmas;
+            _ = command.ExecuteNonQuery();
+        }
+
+        public override async Task ConnectionOpenedAsync(
+            DbConnection connection,
+            ConnectionEndEventData eventData,
+            CancellationToken cancellationToken = default
+        )
+        {
+            var command = connection.CreateCommand();
+            await using (command.ConfigureAwait(false))
+            {
+                command.CommandText = Pragmas;
+                _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Custom EF Core model-cache key factory that incorporates <see cref="AuditStoreOptions.TableName"/>
+    /// into the cache key to prevent model sharing between tests that use different table names.
+    /// </summary>
+    private sealed class TestTableModelCacheKeyFactory : IModelCacheKeyFactory
+    {
+        /// <inheritdoc />
+        public object Create(DbContext context, bool designTime)
+        {
+            string tableName;
+            try
+            {
+                tableName = context.GetService<IOptions<AuditStoreOptions>>()?.Value?.TableName ?? string.Empty;
+            }
+            catch (InvalidOperationException)
+            {
+                tableName = string.Empty;
+            }
+
+            return (context.GetType(), tableName, designTime);
+        }
+    }
+
+    internal sealed class TestAuditStoreDbContext : DbContext, IAuditStoreDbContext
+    {
+        public DbSet<AuditRecord> AuditEntries => Set<AuditRecord>();
+
+        public TestAuditStoreDbContext(DbContextOptions<TestAuditStoreDbContext> configuration)
+            : base(configuration) { }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            _ = modelBuilder.ApplyPulseConfiguration(this);
+        }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Integration/Internals/Audit/MySqlAdoNetAuditInitializer.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Internals/Audit/MySqlAdoNetAuditInitializer.cs
@@ -1,0 +1,115 @@
+namespace NetEvolve.Pulse.Tests.Integration.Internals.Audit;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using MySql.Data.MySqlClient;
+using NetEvolve.Pulse.Audit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.Audit;
+
+/// <summary>
+/// Configures the MySQL ADO.NET audit trail store provider for integration tests.
+/// Executes <c>Scripts/MySql/AuditEntry.sql</c> to create the required table before each test.
+/// </summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Security",
+    "CA2100:Review SQL queries for security vulnerabilities",
+    Justification = "SQL is read from a script file with table name substituted from validated AuditStoreOptions properties."
+)]
+public sealed class MySqlAdoNetAuditInitializer : IServiceInitializer
+{
+    private static readonly string _scriptPath = Path.Combine(
+        AppContext.BaseDirectory,
+        "Scripts",
+        "MySql",
+        "AuditEntry.sql"
+    );
+
+    /// <inheritdoc />
+    public void Configure(IMediatorBuilder mediatorBuilder, IServiceFixture serviceFixture)
+    {
+        ArgumentNullException.ThrowIfNull(serviceFixture);
+        _ = mediatorBuilder.AddMySqlAuditStore(options => options.ConnectionString = serviceFixture.ConnectionString);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask CreateDatabaseAsync(IServiceProvider serviceProvider, CancellationToken cancellationToken)
+    {
+        var options = serviceProvider.GetRequiredService<IOptions<AuditStoreOptions>>().Value;
+
+        var connectionString =
+            options.ConnectionString
+            ?? throw new InvalidOperationException("AuditStoreOptions.ConnectionString is not configured.");
+
+        var tableName = string.IsNullOrWhiteSpace(options.TableName)
+            ? AuditEntrySchema.DefaultTableName
+            : options.TableName;
+
+        var script = await File.ReadAllTextAsync(_scriptPath, cancellationToken).ConfigureAwait(false);
+
+        // Replace only the table name occurrences (CREATE TABLE and ON clauses),
+        // not the identically-named column definition.
+        script = script
+            .Replace(
+                $"TABLE IF NOT EXISTS `{AuditEntrySchema.DefaultTableName}`",
+                $"TABLE IF NOT EXISTS `{tableName}`",
+                StringComparison.Ordinal
+            )
+            .Replace(
+                $"\n    ON `{AuditEntrySchema.DefaultTableName}`",
+                $"\n    ON `{tableName}`",
+                StringComparison.Ordinal
+            )
+            .Replace(
+                $"CONSTRAINT `PK_{AuditEntrySchema.DefaultTableName}`",
+                $"CONSTRAINT `PK_{tableName}`",
+                StringComparison.Ordinal
+            );
+
+        var connection = new MySqlConnection(connectionString);
+        await using (connection.ConfigureAwait(false))
+        {
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            // Execute each SQL statement individually (CREATE TABLE, CREATE INDEX)
+            foreach (
+                var statement in script.Split(
+                    ';',
+                    StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
+                )
+            )
+            {
+                if (IsCommentOrEmpty(statement))
+                {
+                    continue;
+                }
+
+                var command = new MySqlCommand(statement, connection);
+                await using (command.ConfigureAwait(false))
+                {
+                    _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public void Initialize(IServiceCollection services, IServiceFixture serviceFixture)
+    {
+        // No additional service initialization required for ADO.NET audit trail tests.
+    }
+
+    private static bool IsCommentOrEmpty(string statement)
+    {
+        foreach (var line in statement.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var trimmed = line.Trim();
+            if (trimmed.Length > 0 && !trimmed.StartsWith("--", StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Integration/Internals/Audit/PostgreSqlAdoNetAuditInitializer.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Internals/Audit/PostgreSqlAdoNetAuditInitializer.cs
@@ -1,0 +1,79 @@
+namespace NetEvolve.Pulse.Tests.Integration.Internals.Audit;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.Audit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.Audit;
+using Npgsql;
+
+[SuppressMessage(
+    "Security",
+    "CA2100:Review SQL queries for security vulnerabilities",
+    Justification = "SQL is read from a script file with schema and table names substituted from validated AuditStoreOptions properties."
+)]
+public sealed partial class PostgreSqlAdoNetAuditInitializer : IServiceInitializer
+{
+    private static readonly string _scriptPath = Path.Combine(
+        AppContext.BaseDirectory,
+        "Scripts",
+        "PostgreSql",
+        "AuditEntry.sql"
+    );
+
+    public void Configure(IMediatorBuilder mediatorBuilder, IServiceFixture serviceFixture)
+    {
+        ArgumentNullException.ThrowIfNull(serviceFixture);
+        _ = mediatorBuilder.AddPostgreSqlAuditStore(options =>
+            options.ConnectionString = serviceFixture.ConnectionString
+        );
+    }
+
+    public async ValueTask CreateDatabaseAsync(IServiceProvider serviceProvider, CancellationToken cancellationToken)
+    {
+        var options = serviceProvider.GetRequiredService<IOptions<AuditStoreOptions>>().Value;
+
+        var connectionString =
+            options.ConnectionString
+            ?? throw new InvalidOperationException("AuditStoreOptions.ConnectionString is not configured.");
+
+        var schema = string.IsNullOrWhiteSpace(options.Schema) ? AuditEntrySchema.DefaultSchema : options.Schema;
+
+        var tableName = string.IsNullOrWhiteSpace(options.TableName)
+            ? AuditEntrySchema.DefaultTableName
+            : options.TableName;
+
+        var script = await File.ReadAllTextAsync(_scriptPath, cancellationToken).ConfigureAwait(false);
+
+        // Remove psql-specific variable declarations (not valid SQL)
+        script = SearchSetVar().Replace(script, string.Empty);
+
+        // Substitute psql variables with actual values.
+        script = script
+            .Replace(":schema_name", schema, StringComparison.Ordinal)
+            .Replace(":table_name", tableName, StringComparison.Ordinal);
+
+        var connection = new NpgsqlConnection(connectionString);
+        await using (connection.ConfigureAwait(false))
+        {
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            var command = new NpgsqlCommand(script, connection);
+            await using (command.ConfigureAwait(false))
+            {
+                _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    public void Initialize(IServiceCollection services, IServiceFixture serviceFixture)
+    {
+        // No additional service initialization required for ADO.NET audit trail tests.
+        // The Configure method handles all necessary service registrations.
+    }
+
+    [GeneratedRegex(@"^\\set\s+\w+\s+.*$", RegexOptions.Multiline, 10000)]
+    private static partial Regex SearchSetVar();
+}

--- a/tests/NetEvolve.Pulse.Tests.Integration/Internals/Audit/SQLiteAdoNetAuditInitializer.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Internals/Audit/SQLiteAdoNetAuditInitializer.cs
@@ -1,0 +1,79 @@
+namespace NetEvolve.Pulse.Tests.Integration.Internals.Audit;
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.Audit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.Audit;
+
+[SuppressMessage(
+    "Security",
+    "CA2100:Review SQL queries for security vulnerabilities",
+    Justification = "SQL is constructed from validated AuditStoreOptions.TableName property, not user input."
+)]
+public sealed class SQLiteAdoNetAuditInitializer : IServiceInitializer
+{
+    public void Configure(IMediatorBuilder mediatorBuilder, IServiceFixture serviceFixture)
+    {
+        ArgumentNullException.ThrowIfNull(mediatorBuilder);
+        ArgumentNullException.ThrowIfNull(serviceFixture);
+        _ = mediatorBuilder.AddSQLiteAuditStore(options => options.ConnectionString = serviceFixture.ConnectionString);
+    }
+
+    public async ValueTask CreateDatabaseAsync(IServiceProvider serviceProvider, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+        var options = serviceProvider.GetRequiredService<IOptions<AuditStoreOptions>>().Value;
+
+        var connectionString =
+            options.ConnectionString
+            ?? throw new InvalidOperationException("AuditStoreOptions.ConnectionString is not configured.");
+
+        var tableName = string.IsNullOrWhiteSpace(options.TableName)
+            ? AuditEntrySchema.DefaultTableName
+            : options.TableName;
+
+        var quotedTable = $"\"{tableName}\"";
+        var quotedPk = $"\"PK_{tableName}\"";
+        var quotedIdxOccurredAt = $"\"IX_{tableName}_OccurredAt\"";
+        var quotedIdxCommandType = $"\"IX_{tableName}_CommandType\"";
+
+        var createTableSql = $"""
+            PRAGMA journal_mode=WAL;
+            CREATE TABLE IF NOT EXISTS {quotedTable} (
+                "{AuditEntrySchema.Columns.Id}"               TEXT NOT NULL,
+                "{AuditEntrySchema.Columns.CommandType}"      TEXT NOT NULL,
+                "{AuditEntrySchema.Columns.UserId}"           TEXT NULL,
+                "{AuditEntrySchema.Columns.CorrelationId}"    TEXT NULL,
+                "{AuditEntrySchema.Columns.OccurredAt}"       TEXT NOT NULL,
+                "{AuditEntrySchema.Columns.DurationMs}"       REAL NOT NULL,
+                "{AuditEntrySchema.Columns.Result}"           INTEGER NOT NULL,
+                "{AuditEntrySchema.Columns.Payload}"          TEXT NULL,
+                "{AuditEntrySchema.Columns.ExceptionMessage}" TEXT NULL,
+                CONSTRAINT {quotedPk} PRIMARY KEY ("{AuditEntrySchema.Columns.Id}")
+            );
+            CREATE INDEX IF NOT EXISTS {quotedIdxOccurredAt}
+                ON {quotedTable} ("{AuditEntrySchema.Columns.OccurredAt}");
+            CREATE INDEX IF NOT EXISTS {quotedIdxCommandType}
+                ON {quotedTable} ("{AuditEntrySchema.Columns.CommandType}");
+            """;
+
+        var connection = new SqliteConnection(connectionString);
+        await using (connection.ConfigureAwait(false))
+        {
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+#pragma warning disable S2077 // SQL is constructed from validated AuditStoreOptions.TableName property, not user input.
+            var command = new SqliteCommand(createTableSql, connection);
+#pragma warning restore S2077
+            await using (command.ConfigureAwait(false))
+            {
+                _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    public void Initialize(IServiceCollection services, IServiceFixture serviceFixture) { }
+}

--- a/tests/NetEvolve.Pulse.Tests.Integration/Internals/Audit/SqlServerAdoNetAuditInitializer.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Internals/Audit/SqlServerAdoNetAuditInitializer.cs
@@ -1,0 +1,90 @@
+namespace NetEvolve.Pulse.Tests.Integration.Internals.Audit;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NetEvolve.Pulse.Audit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.Audit;
+
+[SuppressMessage(
+    "Security",
+    "CA2100:Review SQL queries for security vulnerabilities",
+    Justification = "SQL is read from a script file with schema and table names substituted from validated AuditStoreOptions properties."
+)]
+public sealed partial class SqlServerAdoNetAuditInitializer : IServiceInitializer
+{
+    private static readonly string _scriptPath = Path.Combine(
+        AppContext.BaseDirectory,
+        "Scripts",
+        "SqlServer",
+        "AuditEntry.sql"
+    );
+
+    public void Configure(IMediatorBuilder mediatorBuilder, IServiceFixture serviceFixture)
+    {
+        ArgumentNullException.ThrowIfNull(serviceFixture);
+        _ = mediatorBuilder.AddSqlServerAuditStore(options =>
+            options.ConnectionString = serviceFixture.ConnectionString
+        );
+    }
+
+    public async ValueTask CreateDatabaseAsync(IServiceProvider serviceProvider, CancellationToken cancellationToken)
+    {
+        var options = serviceProvider.GetRequiredService<IOptions<AuditStoreOptions>>().Value;
+
+        var connectionString =
+            options.ConnectionString
+            ?? throw new InvalidOperationException("AuditStoreOptions.ConnectionString is not configured.");
+
+        var schema = string.IsNullOrWhiteSpace(options.Schema) ? AuditEntrySchema.DefaultSchema : options.Schema;
+
+        var tableName = string.IsNullOrWhiteSpace(options.TableName)
+            ? AuditEntrySchema.DefaultTableName
+            : options.TableName;
+
+        var script = await File.ReadAllTextAsync(_scriptPath, cancellationToken).ConfigureAwait(false);
+
+        // Remove SQLCMD-specific variable declarations (not valid T-SQL)
+        script = SearchSetVar().Replace(script, string.Empty);
+
+        // Substitute SQLCMD variables with actual values
+        script = script
+            .Replace("$(SchemaName)", schema, StringComparison.Ordinal)
+            .Replace("$(TableName)", tableName, StringComparison.Ordinal);
+
+        // Split on GO (on its own line) and execute each batch independently
+        var batches = SearchGoStatements().Split(script);
+
+        var connection = new SqlConnection(connectionString);
+        await using (connection.ConfigureAwait(false))
+        {
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            foreach (var batch in batches)
+            {
+                var trimmed = batch.Trim();
+                if (string.IsNullOrWhiteSpace(trimmed))
+                {
+                    continue;
+                }
+
+                var command = new SqlCommand(trimmed, connection);
+                await using (command.ConfigureAwait(false))
+                {
+                    _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+    }
+
+    public void Initialize(IServiceCollection services, IServiceFixture serviceFixture) { }
+
+    [GeneratedRegex(@"^:setvar\s+\w+\s+.*$", RegexOptions.Multiline, 10000)]
+    private static partial Regex SearchSetVar();
+
+    [GeneratedRegex(@"^\s*GO\s*$", RegexOptions.IgnoreCase | RegexOptions.Multiline, 10000)]
+    private static partial Regex SearchGoStatements();
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/AspNetCore/HttpContextAuditUserAccessorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/AspNetCore/HttpContextAuditUserAccessorTests.cs
@@ -1,0 +1,121 @@
+namespace NetEvolve.Pulse.Tests.Unit.AspNetCore;
+
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.AspNetCore;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.Audit;
+using NetEvolve.Pulse.Internals;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
+
+[TestGroup("AspNetCore")]
+public sealed class HttpContextAuditUserAccessorTests
+{
+    [Test]
+    public async Task Constructor_NullHttpContextAccessor_ThrowsArgumentNullException() =>
+        _ = await Assert.That(() => new HttpContextAuditUserAccessor(null!)).Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task GetCurrentUser_AuthenticatedUser_ReturnsIdentityName()
+    {
+        var identity = new ClaimsIdentity(authenticationType: "Test");
+        identity.AddClaim(new Claim(ClaimTypes.Name, "jane.doe"));
+        var context = new DefaultHttpContext { User = new ClaimsPrincipal(identity) };
+        var accessor = new FakeHttpContextAccessor(context);
+        var sut = new HttpContextAuditUserAccessor(accessor);
+
+        var result = sut.GetCurrentUser();
+
+        _ = await Assert.That(result).IsEqualTo("jane.doe");
+    }
+
+    [Test]
+    public async Task GetCurrentUser_UnauthenticatedUser_ReturnsNull()
+    {
+        var context = new DefaultHttpContext { User = new ClaimsPrincipal(new ClaimsIdentity()) };
+        var accessor = new FakeHttpContextAccessor(context);
+        var sut = new HttpContextAuditUserAccessor(accessor);
+
+        var result = sut.GetCurrentUser();
+
+        _ = await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task GetCurrentUser_NoAmbientHttpContext_ReturnsNull()
+    {
+        var accessor = new FakeHttpContextAccessor(null);
+        var sut = new HttpContextAuditUserAccessor(accessor);
+
+        var result = sut.GetCurrentUser();
+
+        _ = await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task AddHttpContextAuditUserAccessor_NullBuilder_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() => AuditExtensions.AddHttpContextAuditUserAccessor(null!))
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task AddHttpContextAuditUserAccessor_RegistersHttpContextAccessor()
+    {
+        var services = new ServiceCollection();
+        var builder = new MediatorBuilder(services);
+
+        _ = builder.AddHttpContextAuditUserAccessor();
+
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IHttpContextAccessor));
+
+        _ = await Assert.That(descriptor).IsNotNull();
+    }
+
+    [Test]
+    public async Task AddHttpContextAuditUserAccessor_ReplacesPreviouslyRegisteredAuditUserAccessor()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddSingleton<IAuditUserAccessor, PreExistingAuditUserAccessor>();
+        var builder = new MediatorBuilder(services);
+
+        _ = builder.AddHttpContextAuditUserAccessor();
+
+        var descriptors = services.Where(d => d.ServiceType == typeof(IAuditUserAccessor)).ToList();
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptors).HasSingleItem();
+            _ = await Assert.That(descriptors[0].ImplementationType).IsEqualTo(typeof(HttpContextAuditUserAccessor));
+        }
+    }
+
+    [Test]
+    public async Task AddHttpContextAuditUserAccessor_ReturnsSameBuilder()
+    {
+        var services = new ServiceCollection();
+        var builder = new MediatorBuilder(services);
+
+        var result = builder.AddHttpContextAuditUserAccessor();
+
+        _ = await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    private sealed class FakeHttpContextAccessor : IHttpContextAccessor
+    {
+        public FakeHttpContextAccessor(HttpContext? httpContext) => HttpContext = httpContext;
+
+        public HttpContext? HttpContext { get; set; }
+    }
+
+    private sealed class PreExistingAuditUserAccessor : IAuditUserAccessor
+    {
+        public string? GetCurrentUser() => "pre-existing";
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/AuditMediatorBuilderExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/AuditMediatorBuilderExtensionsTests.cs
@@ -1,0 +1,143 @@
+namespace NetEvolve.Pulse.Tests.Unit;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Audit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.Audit;
+using NetEvolve.Pulse.Interceptors;
+using NetEvolve.Pulse.Internals;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
+
+[TestGroup("Audit")]
+public sealed class AuditMediatorBuilderExtensionsTests
+{
+    [Test]
+    public async Task AddAudit_NullBuilder_ThrowsArgumentNullException() =>
+        _ = await Assert.That(() => AuditMediatorBuilderExtensions.AddAudit(null!)).Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task AddAudit_RegistersRequestInterceptorAsScoped()
+    {
+        var services = new ServiceCollection();
+        var builder = new MediatorBuilder(services);
+
+        var result = builder.AddAudit();
+
+        _ = await Assert.That(result).IsSameReferenceAs(builder);
+
+        var descriptor = services.FirstOrDefault(d =>
+            d.ServiceType == typeof(IRequestInterceptor<,>)
+            && d.ImplementationType == typeof(AuditRequestInterceptor<,>)
+        );
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor).IsNotNull();
+            _ = await Assert.That(descriptor!.Lifetime).IsEqualTo(ServiceLifetime.Scoped);
+        }
+    }
+
+    [Test]
+    public async Task AddAudit_RegistersNullAuditUserAccessorAsSingleton()
+    {
+        var services = new ServiceCollection();
+        var builder = new MediatorBuilder(services);
+
+        _ = builder.AddAudit();
+
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IAuditUserAccessor));
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor).IsNotNull();
+            _ = await Assert.That(descriptor!.ImplementationType).IsEqualTo(typeof(NullAuditUserAccessor));
+            _ = await Assert.That(descriptor.Lifetime).IsEqualTo(ServiceLifetime.Singleton);
+        }
+    }
+
+    [Test]
+    public async Task AddAudit_PreviouslyRegisteredAuditUserAccessor_IsNotOverwritten()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddSingleton<IAuditUserAccessor, CustomAuditUserAccessor>();
+        var builder = new MediatorBuilder(services);
+
+        _ = builder.AddAudit();
+
+        var descriptors = services.Where(d => d.ServiceType == typeof(IAuditUserAccessor)).ToList();
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptors).HasSingleItem();
+            _ = await Assert.That(descriptors[0].ImplementationType).IsEqualTo(typeof(CustomAuditUserAccessor));
+        }
+    }
+
+    [Test]
+    public async Task AddAudit_CalledMultipleTimes_DoesNotDuplicateInterceptor()
+    {
+        var services = new ServiceCollection();
+        var builder = new MediatorBuilder(services);
+
+        _ = builder.AddAudit();
+        _ = builder.AddAudit();
+
+        var descriptors = services
+            .Where(d =>
+                d.ServiceType == typeof(IRequestInterceptor<,>)
+                && d.ImplementationType == typeof(AuditRequestInterceptor<,>)
+            )
+            .ToList();
+
+        _ = await Assert.That(descriptors).HasSingleItem();
+    }
+
+    [Test]
+    public async Task AddAudit_ConfigureDelegate_IsApplied()
+    {
+        var services = new ServiceCollection();
+        var builder = new MediatorBuilder(services);
+
+        _ = builder.AddAudit(options =>
+        {
+            options.CapturePayload = true;
+            options.AuditQueries = true;
+        });
+
+        var provider = services.BuildServiceProvider();
+        var configured = provider.GetRequiredService<IOptions<AuditOptions>>().Value;
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(configured.CapturePayload).IsTrue();
+            _ = await Assert.That(configured.AuditQueries).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task AddAudit_ReturnsSameBuilder()
+    {
+        var services = new ServiceCollection();
+        var builder = new MediatorBuilder(services);
+
+        var result = builder.AddAudit();
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(result).IsSameReferenceAs(builder);
+            _ = await Assert.That(result).IsTypeOf<IMediatorBuilder>();
+        }
+    }
+
+    private sealed class CustomAuditUserAccessor : IAuditUserAccessor
+    {
+        public string? GetCurrentUser() => "custom-user";
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/EntityFrameworkAuditManagementTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/EntityFrameworkAuditManagementTests.cs
@@ -1,0 +1,347 @@
+namespace NetEvolve.Pulse.Tests.Unit.EntityFramework;
+
+using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Audit;
+using NetEvolve.Pulse.Extensibility.Audit;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
+
+[TestGroup("EntityFramework")]
+public sealed class EntityFrameworkAuditManagementTests
+{
+    private static TestAuditStoreDbContext CreateContext(string databaseName)
+    {
+        var options = new DbContextOptionsBuilder<TestAuditStoreDbContext>().UseInMemoryDatabase(databaseName).Options;
+        return new TestAuditStoreDbContext(options);
+    }
+
+    private static AuditRecord CreateRecord(
+        DateTimeOffset occurredAt,
+        string commandType = "Some.Command",
+        string? userId = null,
+        AuditResult result = AuditResult.Success
+    ) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            CommandType = commandType,
+            UserId = userId,
+            OccurredAt = occurredAt,
+            Result = result,
+        };
+
+    [Test]
+    public async Task Constructor_WithNullContext_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() => new EntityFrameworkAuditManagement<TestAuditStoreDbContext>(null!))
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Constructor_WithValidContext_CreatesInstance()
+    {
+        var context = CreateContext(nameof(Constructor_WithValidContext_CreatesInstance));
+        await using (context.ConfigureAwait(false))
+        {
+            var management = new EntityFrameworkAuditManagement<TestAuditStoreDbContext>(context);
+
+            _ = await Assert.That(management).IsNotNull();
+        }
+    }
+
+    [Test]
+    public async Task QueryAsync_WithNullFilter_ThrowsArgumentNullException(CancellationToken cancellationToken)
+    {
+        var context = CreateContext(nameof(QueryAsync_WithNullFilter_ThrowsArgumentNullException));
+        await using (context.ConfigureAwait(false))
+        {
+            var management = new EntityFrameworkAuditManagement<TestAuditStoreDbContext>(context);
+
+            _ = await Assert
+                .That(async () => await management.QueryAsync(null!, cancellationToken).ConfigureAwait(false))
+                .Throws<ArgumentNullException>();
+        }
+    }
+
+    [Test]
+    public async Task QueryAsync_FiltersByCommandType(CancellationToken cancellationToken)
+    {
+        var context = CreateContext(nameof(QueryAsync_FiltersByCommandType));
+        await using (context.ConfigureAwait(false))
+        {
+            var now = DateTimeOffset.UtcNow;
+            var match = CreateRecord(now, commandType: "Match.Command");
+            var noMatch = CreateRecord(now, commandType: "Other.Command");
+
+            await context.AuditEntries.AddRangeAsync([match, noMatch], cancellationToken).ConfigureAwait(false);
+            _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            var management = new EntityFrameworkAuditManagement<TestAuditStoreDbContext>(context);
+
+            var result = await management
+                .QueryAsync(new AuditFilter { CommandType = "Match.Command" }, cancellationToken)
+                .ConfigureAwait(false);
+
+            _ = await Assert.That(result).HasSingleItem();
+            _ = await Assert.That(result[0].Id).IsEqualTo(match.Id);
+        }
+    }
+
+    [Test]
+    public async Task QueryAsync_FiltersByUserId(CancellationToken cancellationToken)
+    {
+        var context = CreateContext(nameof(QueryAsync_FiltersByUserId));
+        await using (context.ConfigureAwait(false))
+        {
+            var now = DateTimeOffset.UtcNow;
+            var match = CreateRecord(now, userId: "user-1");
+            var noMatch = CreateRecord(now, userId: "user-2");
+
+            await context.AuditEntries.AddRangeAsync([match, noMatch], cancellationToken).ConfigureAwait(false);
+            _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            var management = new EntityFrameworkAuditManagement<TestAuditStoreDbContext>(context);
+
+            var result = await management
+                .QueryAsync(new AuditFilter { UserId = "user-1" }, cancellationToken)
+                .ConfigureAwait(false);
+
+            _ = await Assert.That(result).HasSingleItem();
+            _ = await Assert.That(result[0].Id).IsEqualTo(match.Id);
+        }
+    }
+
+    [Test]
+    public async Task QueryAsync_FiltersByFrom(CancellationToken cancellationToken)
+    {
+        var context = CreateContext(nameof(QueryAsync_FiltersByFrom));
+        await using (context.ConfigureAwait(false))
+        {
+            var now = DateTimeOffset.UtcNow;
+            var older = CreateRecord(now.AddMinutes(-10));
+            var newer = CreateRecord(now);
+
+            await context.AuditEntries.AddRangeAsync([older, newer], cancellationToken).ConfigureAwait(false);
+            _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            var management = new EntityFrameworkAuditManagement<TestAuditStoreDbContext>(context);
+
+            var result = await management
+                .QueryAsync(new AuditFilter { From = now.AddMinutes(-1) }, cancellationToken)
+                .ConfigureAwait(false);
+
+            _ = await Assert.That(result).HasSingleItem();
+            _ = await Assert.That(result[0].Id).IsEqualTo(newer.Id);
+        }
+    }
+
+    [Test]
+    public async Task QueryAsync_FiltersByTo(CancellationToken cancellationToken)
+    {
+        var context = CreateContext(nameof(QueryAsync_FiltersByTo));
+        await using (context.ConfigureAwait(false))
+        {
+            var now = DateTimeOffset.UtcNow;
+            var older = CreateRecord(now.AddMinutes(-10));
+            var newer = CreateRecord(now);
+
+            await context.AuditEntries.AddRangeAsync([older, newer], cancellationToken).ConfigureAwait(false);
+            _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            var management = new EntityFrameworkAuditManagement<TestAuditStoreDbContext>(context);
+
+            var result = await management
+                .QueryAsync(new AuditFilter { To = now.AddMinutes(-1) }, cancellationToken)
+                .ConfigureAwait(false);
+
+            _ = await Assert.That(result).HasSingleItem();
+            _ = await Assert.That(result[0].Id).IsEqualTo(older.Id);
+        }
+    }
+
+    [Test]
+    public async Task QueryAsync_FiltersByResult(CancellationToken cancellationToken)
+    {
+        var context = CreateContext(nameof(QueryAsync_FiltersByResult));
+        await using (context.ConfigureAwait(false))
+        {
+            var now = DateTimeOffset.UtcNow;
+            var success = CreateRecord(now, result: AuditResult.Success);
+            var failure = CreateRecord(now, result: AuditResult.Failure);
+
+            await context.AuditEntries.AddRangeAsync([success, failure], cancellationToken).ConfigureAwait(false);
+            _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            var management = new EntityFrameworkAuditManagement<TestAuditStoreDbContext>(context);
+
+            var result = await management
+                .QueryAsync(new AuditFilter { Result = AuditResult.Failure }, cancellationToken)
+                .ConfigureAwait(false);
+
+            _ = await Assert.That(result).HasSingleItem();
+            _ = await Assert.That(result[0].Id).IsEqualTo(failure.Id);
+        }
+    }
+
+    [Test]
+    public async Task QueryAsync_CombinesMultipleFilterConditions(CancellationToken cancellationToken)
+    {
+        var context = CreateContext(nameof(QueryAsync_CombinesMultipleFilterConditions));
+        await using (context.ConfigureAwait(false))
+        {
+            var now = DateTimeOffset.UtcNow;
+            var match = CreateRecord(now, commandType: "Match.Command", userId: "user-1", result: AuditResult.Failure);
+            var wrongCommandType = CreateRecord(
+                now,
+                commandType: "Other.Command",
+                userId: "user-1",
+                result: AuditResult.Failure
+            );
+            var wrongUserId = CreateRecord(
+                now,
+                commandType: "Match.Command",
+                userId: "user-2",
+                result: AuditResult.Failure
+            );
+            var wrongResult = CreateRecord(
+                now,
+                commandType: "Match.Command",
+                userId: "user-1",
+                result: AuditResult.Success
+            );
+
+            await context
+                .AuditEntries.AddRangeAsync([match, wrongCommandType, wrongUserId, wrongResult], cancellationToken)
+                .ConfigureAwait(false);
+            _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            var management = new EntityFrameworkAuditManagement<TestAuditStoreDbContext>(context);
+
+            var result = await management
+                .QueryAsync(
+                    new AuditFilter
+                    {
+                        CommandType = "Match.Command",
+                        UserId = "user-1",
+                        Result = AuditResult.Failure,
+                    },
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+
+            _ = await Assert.That(result).HasSingleItem();
+            _ = await Assert.That(result[0].Id).IsEqualTo(match.Id);
+        }
+    }
+
+    [Test]
+    public async Task QueryAsync_OrdersByOccurredAtDescending_AndRespectsSkipAndTake(
+        CancellationToken cancellationToken
+    )
+    {
+        var context = CreateContext(nameof(QueryAsync_OrdersByOccurredAtDescending_AndRespectsSkipAndTake));
+        await using (context.ConfigureAwait(false))
+        {
+            var now = DateTimeOffset.UtcNow;
+            var records = new List<AuditRecord>();
+            for (var i = 0; i < 5; i++)
+            {
+                records.Add(CreateRecord(now.AddMinutes(-i)));
+            }
+
+            await context.AuditEntries.AddRangeAsync(records, cancellationToken).ConfigureAwait(false);
+            _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            var management = new EntityFrameworkAuditManagement<TestAuditStoreDbContext>(context);
+
+            var result = await management
+                .QueryAsync(new AuditFilter { Skip = 1, Take = 2 }, cancellationToken)
+                .ConfigureAwait(false);
+
+            using (Assert.Multiple())
+            {
+                _ = await Assert.That(result).HasCount(2);
+                _ = await Assert.That(result[0].Id).IsEqualTo(records[1].Id);
+                _ = await Assert.That(result[1].Id).IsEqualTo(records[2].Id);
+            }
+        }
+    }
+
+    [Test]
+    public async Task GetStatisticsAsync_ReturnsCorrectSuccessAndFailureCounts(CancellationToken cancellationToken)
+    {
+        var context = CreateContext(nameof(GetStatisticsAsync_ReturnsCorrectSuccessAndFailureCounts));
+        await using (context.ConfigureAwait(false))
+        {
+            var now = DateTimeOffset.UtcNow;
+            var records = new[]
+            {
+                CreateRecord(now, result: AuditResult.Success),
+                CreateRecord(now, result: AuditResult.Success),
+                CreateRecord(now, result: AuditResult.Success),
+                CreateRecord(now, result: AuditResult.Failure),
+            };
+
+            await context.AuditEntries.AddRangeAsync(records, cancellationToken).ConfigureAwait(false);
+            _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            var management = new EntityFrameworkAuditManagement<TestAuditStoreDbContext>(context);
+
+            var statistics = await management.GetStatisticsAsync(cancellationToken).ConfigureAwait(false);
+
+            using (Assert.Multiple())
+            {
+                _ = await Assert.That(statistics.SuccessCount).IsEqualTo(3);
+                _ = await Assert.That(statistics.FailureCount).IsEqualTo(1);
+                _ = await Assert.That(statistics.TotalCount).IsEqualTo(4);
+            }
+        }
+    }
+
+    [Test]
+    public async Task GetStatisticsAsync_WithNoFailureRecords_ReturnsZeroFailureCount(
+        CancellationToken cancellationToken
+    )
+    {
+        var context = CreateContext(nameof(GetStatisticsAsync_WithNoFailureRecords_ReturnsZeroFailureCount));
+        await using (context.ConfigureAwait(false))
+        {
+            var now = DateTimeOffset.UtcNow;
+            var records = new[]
+            {
+                CreateRecord(now, result: AuditResult.Success),
+                CreateRecord(now, result: AuditResult.Success),
+            };
+
+            await context.AuditEntries.AddRangeAsync(records, cancellationToken).ConfigureAwait(false);
+            _ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            var management = new EntityFrameworkAuditManagement<TestAuditStoreDbContext>(context);
+
+            var statistics = await management.GetStatisticsAsync(cancellationToken).ConfigureAwait(false);
+
+            using (Assert.Multiple())
+            {
+                _ = await Assert.That(statistics.SuccessCount).IsEqualTo(2);
+                _ = await Assert.That(statistics.FailureCount).IsEqualTo(0);
+            }
+        }
+    }
+
+    [Test]
+    public async Task GetStatisticsAsync_EmptyDatabase_ReturnsAllZero(CancellationToken cancellationToken)
+    {
+        var context = CreateContext(nameof(GetStatisticsAsync_EmptyDatabase_ReturnsAllZero));
+        await using (context.ConfigureAwait(false))
+        {
+            var management = new EntityFrameworkAuditManagement<TestAuditStoreDbContext>(context);
+
+            var statistics = await management.GetStatisticsAsync(cancellationToken).ConfigureAwait(false);
+
+            _ = await Assert.That(statistics.TotalCount).IsEqualTo(0);
+        }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/EntityFrameworkAuditStoreTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/EntityFrameworkAuditStoreTests.cs
@@ -1,0 +1,131 @@
+namespace NetEvolve.Pulse.Tests.Unit.EntityFramework;
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Audit;
+using NetEvolve.Pulse.Extensibility.Audit;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
+
+[TestGroup("EntityFramework")]
+public sealed class EntityFrameworkAuditStoreTests
+{
+    private static TestAuditStoreDbContext CreateContext(string databaseName)
+    {
+        var options = new DbContextOptionsBuilder<TestAuditStoreDbContext>().UseInMemoryDatabase(databaseName).Options;
+        return new TestAuditStoreDbContext(options);
+    }
+
+    private static EntityFrameworkAuditStore<TestAuditStoreDbContext> CreateStore(TestAuditStoreDbContext context) =>
+        new(context);
+
+    [Test]
+    public async Task Constructor_WithNullContext_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() => new EntityFrameworkAuditStore<TestAuditStoreDbContext>(null!))
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Constructor_WithValidContext_CreatesInstance()
+    {
+        var context = CreateContext(nameof(Constructor_WithValidContext_CreatesInstance));
+        await using (context.ConfigureAwait(false))
+        {
+            var store = CreateStore(context);
+
+            _ = await Assert.That(store).IsNotNull();
+        }
+    }
+
+    [Test]
+    public async Task RecordAsync_WithNullRecord_ThrowsArgumentNullException(CancellationToken cancellationToken)
+    {
+        var context = CreateContext(nameof(RecordAsync_WithNullRecord_ThrowsArgumentNullException));
+        await using (context.ConfigureAwait(false))
+        {
+            var store = CreateStore(context);
+
+            _ = await Assert
+                .That(async () => await store.RecordAsync(null!, cancellationToken).ConfigureAwait(false))
+                .Throws<ArgumentNullException>();
+        }
+    }
+
+    [Test]
+    public async Task RecordAsync_WithValidRecord_InsertsNewRow(CancellationToken cancellationToken)
+    {
+        var context = CreateContext(nameof(RecordAsync_WithValidRecord_InsertsNewRow));
+        await using (context.ConfigureAwait(false))
+        {
+            var store = CreateStore(context);
+            var record = new AuditRecord
+            {
+                Id = Guid.NewGuid(),
+                CommandType = "MyApp.Commands.CreateOrderCommand",
+                UserId = "user-42",
+                CorrelationId = "correlation-1",
+                OccurredAt = DateTimeOffset.UtcNow,
+                DurationMs = 12.5,
+                Result = AuditResult.Success,
+                Payload = "{\"orderId\":42}",
+            };
+
+            await store.RecordAsync(record, cancellationToken).ConfigureAwait(false);
+
+            var entry = await context.AuditEntries.SingleAsync(cancellationToken).ConfigureAwait(false);
+
+            using (Assert.Multiple())
+            {
+                _ = await Assert.That(entry.Id).IsEqualTo(record.Id);
+                _ = await Assert.That(entry.CommandType).IsEqualTo("MyApp.Commands.CreateOrderCommand");
+                _ = await Assert.That(entry.UserId).IsEqualTo("user-42");
+                _ = await Assert.That(entry.CorrelationId).IsEqualTo("correlation-1");
+                _ = await Assert.That(entry.DurationMs).IsEqualTo(12.5);
+                _ = await Assert.That(entry.Result).IsEqualTo(AuditResult.Success);
+                _ = await Assert.That(entry.Payload).IsEqualTo("{\"orderId\":42}");
+            }
+        }
+    }
+
+    [Test]
+    public async Task RecordAsync_CalledTwice_StoresTwoDistinctEntries(CancellationToken cancellationToken)
+    {
+        var context = CreateContext(nameof(RecordAsync_CalledTwice_StoresTwoDistinctEntries));
+        await using (context.ConfigureAwait(false))
+        {
+            var store = CreateStore(context);
+
+            await store
+                .RecordAsync(
+                    new AuditRecord
+                    {
+                        Id = Guid.NewGuid(),
+                        CommandType = "Some.Command",
+                        OccurredAt = DateTimeOffset.UtcNow,
+                        Result = AuditResult.Success,
+                    },
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+
+            await store
+                .RecordAsync(
+                    new AuditRecord
+                    {
+                        Id = Guid.NewGuid(),
+                        CommandType = "Some.Command",
+                        OccurredAt = DateTimeOffset.UtcNow,
+                        Result = AuditResult.Failure,
+                    },
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+
+            var count = await context.AuditEntries.CountAsync(cancellationToken).ConfigureAwait(false);
+            _ = await Assert.That(count).IsEqualTo(2);
+        }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/TestAuditStoreDbContext.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/EntityFramework/TestAuditStoreDbContext.cs
@@ -1,0 +1,29 @@
+namespace NetEvolve.Pulse.Tests.Unit.EntityFramework;
+
+using Microsoft.EntityFrameworkCore;
+using NetEvolve.Pulse.Audit;
+using NetEvolve.Pulse.Extensibility.Audit;
+
+/// <summary>
+/// Minimal <see cref="DbContext"/> used in unit tests to verify Entity Framework audit trail
+/// behaviour without requiring a real database provider.
+/// </summary>
+internal sealed class TestAuditStoreDbContext : DbContext, IAuditStoreDbContext
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TestAuditStoreDbContext"/> class.
+    /// </summary>
+    /// <param name="options">The options for this context.</param>
+    public TestAuditStoreDbContext(DbContextOptions<TestAuditStoreDbContext> options)
+        : base(options) { }
+
+    /// <inheritdoc />
+    public DbSet<AuditRecord> AuditEntries => Set<AuditRecord>();
+
+    /// <inheritdoc />
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        _ = modelBuilder.ApplyPulseConfiguration(this);
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/AuditRequestInterceptorTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Interceptors/AuditRequestInterceptorTests.cs
@@ -1,0 +1,413 @@
+namespace NetEvolve.Pulse.Tests.Unit.Interceptors;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Audit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.Audit;
+using NetEvolve.Pulse.Interceptors;
+using NetEvolve.Pulse.Serialization;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
+
+[SuppressMessage(
+    "IDisposableAnalyzers.Correctness",
+    "CA2000:Dispose objects before losing scope",
+    Justification = "ServiceProvider instances are short-lived within test methods"
+)]
+[TestGroup("Interceptors")]
+public sealed class AuditRequestInterceptorTests
+{
+    private static IPayloadSerializer DefaultSerializer =>
+        new SystemTextJsonPayloadSerializer(Options.Create(JsonSerializerOptions.Default));
+
+    [Test]
+    public async Task Constructor_NullServiceProvider_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() =>
+                new AuditRequestInterceptor<TestCommand, string>(
+                    null!,
+                    Options.Create(new AuditOptions()),
+                    DefaultSerializer,
+                    new FakeAuditUserAccessor(),
+                    new FakeTimeProvider()
+                )
+            )
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Constructor_NullOptions_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() =>
+                new AuditRequestInterceptor<TestCommand, string>(
+                    new ServiceCollection().BuildServiceProvider(),
+                    null!,
+                    DefaultSerializer,
+                    new FakeAuditUserAccessor(),
+                    new FakeTimeProvider()
+                )
+            )
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Constructor_NullPayloadSerializer_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() =>
+                new AuditRequestInterceptor<TestCommand, string>(
+                    new ServiceCollection().BuildServiceProvider(),
+                    Options.Create(new AuditOptions()),
+                    null!,
+                    new FakeAuditUserAccessor(),
+                    new FakeTimeProvider()
+                )
+            )
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Constructor_NullAuditUserAccessor_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() =>
+                new AuditRequestInterceptor<TestCommand, string>(
+                    new ServiceCollection().BuildServiceProvider(),
+                    Options.Create(new AuditOptions()),
+                    DefaultSerializer,
+                    null!,
+                    new FakeTimeProvider()
+                )
+            )
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Constructor_NullTimeProvider_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() =>
+                new AuditRequestInterceptor<TestCommand, string>(
+                    new ServiceCollection().BuildServiceProvider(),
+                    Options.Create(new AuditOptions()),
+                    DefaultSerializer,
+                    new FakeAuditUserAccessor(),
+                    null!
+                )
+            )
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task HandleAsync_ExcludedCommandType_SuccessfulCommand_NeverCallsStoreAsync(
+        CancellationToken cancellationToken
+    )
+    {
+        var options = new AuditOptions();
+        _ = options.ExcludedCommandTypes.Add(typeof(TestCommand));
+        var (interceptor, store) = CreateInterceptor(options);
+        var command = new TestCommand { Value = "excluded" };
+
+        var result = await interceptor
+            .HandleAsync(command, (_, _) => Task.FromResult("response"), cancellationToken)
+            .ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(result).IsEqualTo("response");
+            _ = await Assert.That(store.RecordCallCount).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task HandleAsync_ExcludedCommandType_FailingCommand_NeverCallsStoreAsyncAndRethrows(
+        CancellationToken cancellationToken
+    )
+    {
+        var options = new AuditOptions();
+        _ = options.ExcludedCommandTypes.Add(typeof(TestCommand));
+        var (interceptor, store) = CreateInterceptor(options);
+        var command = new TestCommand { Value = "excluded" };
+        var thrown = new InvalidOperationException("handler failed");
+
+        _ = await Assert
+            .That(async () =>
+                await interceptor
+                    .HandleAsync(command, (_, _) => Task.FromException<string>(thrown), cancellationToken)
+                    .ConfigureAwait(false)
+            )
+            .Throws<InvalidOperationException>();
+
+        _ = await Assert.That(store.RecordCallCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task HandleAsync_SuccessfulCommand_RecordsSuccessWithExpectedValues(
+        CancellationToken cancellationToken
+    )
+    {
+        var timeProvider = new FakeTimeProvider();
+        var userAccessor = new FakeAuditUserAccessor { CurrentUser = "user-42" };
+        var (interceptor, store) = CreateInterceptor(new AuditOptions(), timeProvider, userAccessor);
+        var command = new TestCommand { Value = "ok", CorrelationId = "corr-1" };
+
+        timeProvider.SetUtcNow(DateTimeOffset.UtcNow);
+        var result = await interceptor
+            .HandleAsync(
+                command,
+                async (_, _) =>
+                {
+                    timeProvider.Advance(TimeSpan.FromMilliseconds(5));
+                    return await Task.FromResult("response").ConfigureAwait(false);
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(result).IsEqualTo("response");
+            _ = await Assert.That(store.RecordCallCount).IsEqualTo(1);
+            _ = await Assert.That(store.LastRecord!.Result).IsEqualTo(AuditResult.Success);
+            _ = await Assert.That(store.LastRecord.DurationMs).IsGreaterThanOrEqualTo(0);
+            _ = await Assert.That(store.LastRecord.UserId).IsEqualTo("user-42");
+            _ = await Assert.That(store.LastRecord.CorrelationId).IsEqualTo("corr-1");
+            _ = await Assert.That(store.LastRecord.CommandType).IsEqualTo(typeof(TestCommand).AssemblyQualifiedName);
+        }
+    }
+
+    [Test]
+    public async Task HandleAsync_FailingCommand_RecordsFailureAndRethrows(CancellationToken cancellationToken)
+    {
+        var (interceptor, store) = CreateInterceptor(new AuditOptions());
+        var command = new TestCommand { Value = "fail" };
+        var thrown = new InvalidOperationException("handler failed");
+
+        _ = await Assert
+            .That(async () =>
+                await interceptor
+                    .HandleAsync(command, (_, _) => Task.FromException<string>(thrown), cancellationToken)
+                    .ConfigureAwait(false)
+            )
+            .Throws<InvalidOperationException>();
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(store.RecordCallCount).IsEqualTo(1);
+            _ = await Assert.That(store.LastRecord!.Result).IsEqualTo(AuditResult.Failure);
+            _ = await Assert.That(store.LastRecord.ExceptionMessage).IsEqualTo("handler failed");
+        }
+    }
+
+    [Test]
+    public async Task HandleAsync_QueryWithAuditQueriesDisabled_SuccessfulQuery_NeverCallsStoreAsync(
+        CancellationToken cancellationToken
+    )
+    {
+        var (interceptor, store) = CreateInterceptorForQuery(new AuditOptions { AuditQueries = false });
+        var query = new TestQuery();
+
+        var result = await interceptor
+            .HandleAsync(query, (_, _) => Task.FromResult("response"), cancellationToken)
+            .ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(result).IsEqualTo("response");
+            _ = await Assert.That(store.RecordCallCount).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task HandleAsync_QueryWithAuditQueriesDisabled_FailingQuery_NeverCallsStoreAsync(
+        CancellationToken cancellationToken
+    )
+    {
+        var (interceptor, store) = CreateInterceptorForQuery(new AuditOptions { AuditQueries = false });
+        var query = new TestQuery();
+        var thrown = new InvalidOperationException("query handler failed");
+
+        _ = await Assert
+            .That(async () =>
+                await interceptor
+                    .HandleAsync(query, (_, _) => Task.FromException<string>(thrown), cancellationToken)
+                    .ConfigureAwait(false)
+            )
+            .Throws<InvalidOperationException>();
+
+        _ = await Assert.That(store.RecordCallCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task HandleAsync_QueryWithAuditQueriesEnabled_SuccessfulQuery_CallsStoreAsync(
+        CancellationToken cancellationToken
+    )
+    {
+        var (interceptor, store) = CreateInterceptorForQuery(new AuditOptions { AuditQueries = true });
+        var query = new TestQuery();
+
+        var result = await interceptor
+            .HandleAsync(query, (_, _) => Task.FromResult("response"), cancellationToken)
+            .ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(result).IsEqualTo("response");
+            _ = await Assert.That(store.RecordCallCount).IsEqualTo(1);
+            _ = await Assert.That(store.LastRecord!.Result).IsEqualTo(AuditResult.Success);
+        }
+    }
+
+    [Test]
+    public async Task HandleAsync_NoStoreRegistered_SuccessfulCommand_CompletesWithoutError(
+        CancellationToken cancellationToken
+    )
+    {
+        var provider = new ServiceCollection().BuildServiceProvider();
+        var interceptor = new AuditRequestInterceptor<TestCommand, string>(
+            provider,
+            Options.Create(new AuditOptions()),
+            DefaultSerializer,
+            new FakeAuditUserAccessor(),
+            new FakeTimeProvider()
+        );
+        var command = new TestCommand { Value = "no-store" };
+
+        var result = await interceptor
+            .HandleAsync(command, (_, _) => Task.FromResult("response"), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(result).IsEqualTo("response");
+    }
+
+    [Test]
+    public async Task HandleAsync_NoStoreRegistered_FailingCommand_StillRethrowsWithoutError(
+        CancellationToken cancellationToken
+    )
+    {
+        var provider = new ServiceCollection().BuildServiceProvider();
+        var interceptor = new AuditRequestInterceptor<TestCommand, string>(
+            provider,
+            Options.Create(new AuditOptions()),
+            DefaultSerializer,
+            new FakeAuditUserAccessor(),
+            new FakeTimeProvider()
+        );
+        var command = new TestCommand { Value = "no-store" };
+        var thrown = new InvalidOperationException("handler failed without store");
+
+        _ = await Assert
+            .That(async () =>
+                await interceptor
+                    .HandleAsync(command, (_, _) => Task.FromException<string>(thrown), cancellationToken)
+                    .ConfigureAwait(false)
+            )
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task HandleAsync_CapturePayloadEnabled_PopulatesPayload(CancellationToken cancellationToken)
+    {
+        var (interceptor, store) = CreateInterceptor(new AuditOptions { CapturePayload = true });
+        var command = new TestCommand { Value = "captured-value" };
+
+        _ = await interceptor
+            .HandleAsync(command, (_, _) => Task.FromResult("response"), cancellationToken)
+            .ConfigureAwait(false);
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(store.LastRecord!.Payload).IsNotNull();
+            _ = await Assert.That(store.LastRecord.Payload).Contains("captured-value");
+        }
+    }
+
+    [Test]
+    public async Task HandleAsync_CapturePayloadDisabled_LeavesPayloadNull(CancellationToken cancellationToken)
+    {
+        var (interceptor, store) = CreateInterceptor(new AuditOptions { CapturePayload = false });
+        var command = new TestCommand { Value = "not-captured" };
+
+        _ = await interceptor
+            .HandleAsync(command, (_, _) => Task.FromResult("response"), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(store.LastRecord!.Payload).IsNull();
+    }
+
+    private static (AuditRequestInterceptor<TestCommand, string> Interceptor, FakeAuditStore Store) CreateInterceptor(
+        AuditOptions options,
+        TimeProvider? timeProvider = null,
+        IAuditUserAccessor? userAccessor = null
+    )
+    {
+        var store = new FakeAuditStore();
+        var services = new ServiceCollection();
+        _ = services.AddSingleton<IAuditStore>(store);
+        var provider = services.BuildServiceProvider();
+
+        var interceptor = new AuditRequestInterceptor<TestCommand, string>(
+            provider,
+            Options.Create(options),
+            DefaultSerializer,
+            userAccessor ?? new FakeAuditUserAccessor(),
+            timeProvider ?? new FakeTimeProvider()
+        );
+
+        return (interceptor, store);
+    }
+
+    private static (
+        AuditRequestInterceptor<TestQuery, string> Interceptor,
+        FakeAuditStore Store
+    ) CreateInterceptorForQuery(AuditOptions options)
+    {
+        var store = new FakeAuditStore();
+        var services = new ServiceCollection();
+        _ = services.AddSingleton<IAuditStore>(store);
+        var provider = services.BuildServiceProvider();
+
+        var interceptor = new AuditRequestInterceptor<TestQuery, string>(
+            provider,
+            Options.Create(options),
+            DefaultSerializer,
+            new FakeAuditUserAccessor(),
+            new FakeTimeProvider()
+        );
+
+        return (interceptor, store);
+    }
+
+    private sealed record TestCommand : ICommand<string>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+        public string Value { get; init; } = string.Empty;
+    }
+
+    private sealed record TestQuery : IQuery<string>
+    {
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+    }
+
+    private sealed class FakeAuditUserAccessor : IAuditUserAccessor
+    {
+        public string? CurrentUser { get; set; }
+
+        public string? GetCurrentUser() => CurrentUser;
+    }
+
+    private sealed class FakeAuditStore : IAuditStore
+    {
+        public int RecordCallCount { get; private set; }
+        public AuditRecord? LastRecord { get; private set; }
+
+        public Task RecordAsync(AuditRecord record, CancellationToken cancellationToken = default)
+        {
+            RecordCallCount++;
+            LastRecord = record;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/MySql/MySqlAuditTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/MySql/MySqlAuditTests.cs
@@ -1,0 +1,190 @@
+namespace NetEvolve.Pulse.Tests.Unit.MySql;
+
+using System;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Audit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.Audit;
+using TUnit.Core;
+using TUnit.Mocks;
+
+[TestGroup("MySql")]
+public sealed class MySqlAuditTests
+{
+    private const string ValidConnectionString = "Server=localhost;Database=Test;Uid=root;Pwd=secret;";
+
+    [Test]
+    public async Task Store_Constructor_WithNullOptions_ThrowsArgumentNullException() =>
+        _ = await Assert.That(() => new MySqlAuditStore(null!)).Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Store_Constructor_WithNullConnectionString_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() => new MySqlAuditStore(Options.Create(new AuditStoreOptions { ConnectionString = null })))
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Store_Constructor_WithEmptyConnectionString_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() => new MySqlAuditStore(Options.Create(new AuditStoreOptions { ConnectionString = string.Empty })))
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task Store_Constructor_WithWhitespaceConnectionString_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() => new MySqlAuditStore(Options.Create(new AuditStoreOptions { ConnectionString = "   " })))
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task Store_Constructor_WithValidConnectionString_CreatesInstance()
+    {
+        var store = new MySqlAuditStore(
+            Options.Create(new AuditStoreOptions { ConnectionString = ValidConnectionString })
+        );
+
+        _ = await Assert.That(store).IsNotNull();
+    }
+
+    [Test]
+    public async Task Store_Constructor_WithCustomTableName_CreatesInstance()
+    {
+        var options = new AuditStoreOptions
+        {
+            ConnectionString = ValidConnectionString,
+            TableName = "CustomAuditEntry",
+        };
+
+        var store = new MySqlAuditStore(Options.Create(options));
+
+        _ = await Assert.That(store).IsNotNull();
+    }
+
+    [Test]
+    public async Task Management_Constructor_WithNullOptions_ThrowsArgumentNullException() =>
+        _ = await Assert.That(() => new MySqlAuditManagement(null!)).Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Management_Constructor_WithNullConnectionString_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() => new MySqlAuditManagement(Options.Create(new AuditStoreOptions { ConnectionString = null })))
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Management_Constructor_WithEmptyConnectionString_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() =>
+                new MySqlAuditManagement(Options.Create(new AuditStoreOptions { ConnectionString = string.Empty }))
+            )
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task Management_Constructor_WithWhitespaceConnectionString_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() => new MySqlAuditManagement(Options.Create(new AuditStoreOptions { ConnectionString = "   " })))
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task Management_Constructor_WithValidArguments_CreatesInstance()
+    {
+        var management = new MySqlAuditManagement(
+            Options.Create(new AuditStoreOptions { ConnectionString = ValidConnectionString })
+        );
+
+        _ = await Assert.That(management).IsNotNull();
+    }
+
+    [Test]
+    public async Task AddMySqlAuditStore_WithNullConfigurator_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() =>
+                MySqlAuditMediatorBuilderExtensions.AddMySqlAuditStore(
+                    null!,
+                    opts => opts.ConnectionString = ValidConnectionString
+                )
+            )
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task AddMySqlAuditStore_WithNullConfigureOptions_ThrowsArgumentNullException()
+    {
+        var mock = Mock.Of<IMediatorBuilder>();
+        _ = mock.Services.Returns(new ServiceCollection());
+
+        _ = await Assert.That(() => mock.Object.AddMySqlAuditStore(null!)).Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task AddMySqlAuditStore_WithValidOptions_ReturnsConfiguratorForChaining()
+    {
+        var mock = Mock.Of<IMediatorBuilder>();
+        _ = mock.Services.Returns(new ServiceCollection());
+
+        var result = mock.Object.AddMySqlAuditStore(opts => opts.ConnectionString = ValidConnectionString);
+
+        _ = await Assert.That(result).IsSameReferenceAs(mock.Object);
+    }
+
+    [Test]
+    public async Task AddMySqlAuditStore_RegistersAuditStoreAsScoped()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddPulse(config =>
+            config.AddMySqlAuditStore(opts => opts.ConnectionString = ValidConnectionString)
+        );
+
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IAuditStore));
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor).IsNotNull();
+            _ = await Assert.That(descriptor!.Lifetime).IsEqualTo(ServiceLifetime.Scoped);
+            _ = await Assert.That(descriptor.ImplementationType).IsEqualTo(typeof(MySqlAuditStore));
+        }
+    }
+
+    [Test]
+    public async Task AddMySqlAuditStore_RegistersAuditManagementAsScoped()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddPulse(config =>
+            config.AddMySqlAuditStore(opts => opts.ConnectionString = ValidConnectionString)
+        );
+
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IAuditManagement));
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor).IsNotNull();
+            _ = await Assert.That(descriptor!.Lifetime).IsEqualTo(ServiceLifetime.Scoped);
+            _ = await Assert.That(descriptor.ImplementationType).IsEqualTo(typeof(MySqlAuditManagement));
+        }
+    }
+
+    [Test]
+    public async Task AddMySqlAuditStore_WithConfigureOptions_AppliesOptions()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddPulse(config =>
+            config.AddMySqlAuditStore(opts =>
+            {
+                opts.ConnectionString = ValidConnectionString;
+                opts.TableName = "CustomAuditEntry";
+            })
+        );
+
+        var provider = services.BuildServiceProvider();
+        await using (provider.ConfigureAwait(false))
+        {
+            var options = provider.GetRequiredService<IOptions<AuditStoreOptions>>();
+
+            using (Assert.Multiple())
+            {
+                _ = await Assert.That(options.Value.ConnectionString).IsEqualTo(ValidConnectionString);
+                _ = await Assert.That(options.Value.TableName).IsEqualTo("CustomAuditEntry");
+            }
+        }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/PostgreSql/PostgreSqlAuditTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/PostgreSql/PostgreSqlAuditTests.cs
@@ -1,0 +1,213 @@
+﻿namespace NetEvolve.Pulse.Tests.Unit.PostgreSql;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Audit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.Audit;
+using TUnit.Core;
+using TUnit.Mocks;
+
+[TestGroup("PostgreSql")]
+public sealed class PostgreSqlAuditTests
+{
+    private const string ValidConnectionString = "Host=localhost;Database=Test;Username=postgres;Password=secret;";
+
+    [Test]
+    public async Task Store_Constructor_WithNullOptions_ThrowsArgumentNullException() =>
+        _ = await Assert.That(() => new PostgreSqlAuditStore(null!)).Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Store_Constructor_WithNullConnectionString_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() => new PostgreSqlAuditStore(Options.Create(new AuditStoreOptions { ConnectionString = null })))
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Store_Constructor_WithEmptyConnectionString_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() =>
+                new PostgreSqlAuditStore(Options.Create(new AuditStoreOptions { ConnectionString = string.Empty }))
+            )
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task Store_Constructor_WithWhitespaceConnectionString_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() => new PostgreSqlAuditStore(Options.Create(new AuditStoreOptions { ConnectionString = "   " })))
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task Store_Constructor_WithValidConnectionString_CreatesInstance()
+    {
+        var options = new AuditStoreOptions { ConnectionString = ValidConnectionString };
+
+        var store = new PostgreSqlAuditStore(Options.Create(options));
+
+        _ = await Assert.That(store).IsNotNull();
+    }
+
+    [Test]
+    public async Task Store_Constructor_WithCustomSchemaAndTableName_CreatesInstance()
+    {
+        var options = new AuditStoreOptions
+        {
+            ConnectionString = ValidConnectionString,
+            Schema = "custom",
+            TableName = "CustomAuditEntry",
+        };
+
+        var store = new PostgreSqlAuditStore(Options.Create(options));
+
+        _ = await Assert.That(store).IsNotNull();
+    }
+
+    [Test]
+    public async Task Store_Constructor_WithNullSchema_CreatesInstance()
+    {
+        var options = new AuditStoreOptions { ConnectionString = ValidConnectionString, Schema = null };
+
+        var store = new PostgreSqlAuditStore(Options.Create(options));
+
+        _ = await Assert.That(store).IsNotNull();
+    }
+
+    [Test]
+    public async Task Management_Constructor_WithNullOptions_ThrowsArgumentNullException() =>
+        _ = await Assert.That(() => new PostgreSqlAuditManagement(null!)).Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Management_Constructor_WithNullConnectionString_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() =>
+                new PostgreSqlAuditManagement(Options.Create(new AuditStoreOptions { ConnectionString = null }))
+            )
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Management_Constructor_WithEmptyConnectionString_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() =>
+                new PostgreSqlAuditManagement(Options.Create(new AuditStoreOptions { ConnectionString = string.Empty }))
+            )
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task Management_Constructor_WithWhitespaceConnectionString_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() =>
+                new PostgreSqlAuditManagement(Options.Create(new AuditStoreOptions { ConnectionString = "   " }))
+            )
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task Management_Constructor_WithValidArguments_CreatesInstance()
+    {
+        var options = Options.Create(new AuditStoreOptions { ConnectionString = ValidConnectionString });
+
+        var management = new PostgreSqlAuditManagement(options);
+
+        _ = await Assert.That(management).IsNotNull();
+    }
+
+    [Test]
+    public async Task AddPostgreSqlAuditStore_WithNullConfigurator_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() =>
+                PostgreSqlAuditMediatorBuilderExtensions.AddPostgreSqlAuditStore(
+                    null!,
+                    opts => opts.ConnectionString = ValidConnectionString
+                )
+            )
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task AddPostgreSqlAuditStore_WithNullConfigureOptions_ThrowsArgumentNullException()
+    {
+        var mock = Mock.Of<IMediatorBuilder>();
+        _ = mock.Services.Returns(new ServiceCollection());
+
+        _ = await Assert.That(() => mock.Object.AddPostgreSqlAuditStore(null!)).Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task AddPostgreSqlAuditStore_WithValidOptions_ReturnsConfiguratorForChaining()
+    {
+        var mock = Mock.Of<IMediatorBuilder>();
+        _ = mock.Services.Returns(new ServiceCollection());
+
+        var result = mock.Object.AddPostgreSqlAuditStore(opts => opts.ConnectionString = ValidConnectionString);
+
+        _ = await Assert.That(result).IsSameReferenceAs(mock.Object);
+    }
+
+    [Test]
+    public async Task AddPostgreSqlAuditStore_RegistersAuditStoreAsScoped()
+    {
+        var mock = Mock.Of<IMediatorBuilder>();
+        var services = new ServiceCollection();
+        _ = mock.Services.Returns(services);
+
+        _ = mock.Object.AddPostgreSqlAuditStore(opts => opts.ConnectionString = ValidConnectionString);
+
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IAuditStore));
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor).IsNotNull();
+            _ = await Assert.That(descriptor!.Lifetime).IsEqualTo(ServiceLifetime.Scoped);
+            _ = await Assert.That(descriptor.ImplementationType).IsEqualTo(typeof(PostgreSqlAuditStore));
+        }
+    }
+
+    [Test]
+    public async Task AddPostgreSqlAuditStore_RegistersAuditManagementAsScoped()
+    {
+        var mock = Mock.Of<IMediatorBuilder>();
+        var services = new ServiceCollection();
+        _ = mock.Services.Returns(services);
+
+        _ = mock.Object.AddPostgreSqlAuditStore(opts => opts.ConnectionString = ValidConnectionString);
+
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IAuditManagement));
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor).IsNotNull();
+            _ = await Assert.That(descriptor!.Lifetime).IsEqualTo(ServiceLifetime.Scoped);
+            _ = await Assert.That(descriptor.ImplementationType).IsEqualTo(typeof(PostgreSqlAuditManagement));
+        }
+    }
+
+    [Test]
+    public async Task AddPostgreSqlAuditStore_AppliesOptions()
+    {
+        var mock = Mock.Of<IMediatorBuilder>();
+        var services = new ServiceCollection();
+        _ = mock.Services.Returns(services);
+
+        _ = mock.Object.AddPostgreSqlAuditStore(opts =>
+        {
+            opts.ConnectionString = ValidConnectionString;
+            opts.Schema = "custom";
+            opts.TableName = "CustomAuditEntry";
+        });
+
+        var provider = services.BuildServiceProvider();
+        await using (provider.ConfigureAwait(false))
+        {
+            var options = provider.GetRequiredService<IOptions<AuditStoreOptions>>();
+
+            using (Assert.Multiple())
+            {
+                _ = await Assert.That(options.Value.ConnectionString).IsEqualTo(ValidConnectionString);
+                _ = await Assert.That(options.Value.Schema).IsEqualTo("custom");
+                _ = await Assert.That(options.Value.TableName).IsEqualTo("CustomAuditEntry");
+            }
+        }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/SQLite/SQLiteAuditTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/SQLite/SQLiteAuditTests.cs
@@ -1,0 +1,231 @@
+namespace NetEvolve.Pulse.Tests.Unit.SQLite;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse;
+using NetEvolve.Pulse.Audit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.Audit;
+using TUnit.Core;
+using TUnit.Mocks;
+
+[TestGroup("SQLite")]
+public sealed class SQLiteAuditTests
+{
+    private const string ValidConnectionString = "Data Source=:memory:";
+
+    [Test]
+    public async Task Store_Constructor_WithNullOptions_ThrowsArgumentNullException() =>
+        _ = await Assert.That(() => new SQLiteAuditStore(null!)).Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Store_Constructor_WithNullConnectionString_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() => new SQLiteAuditStore(Options.Create(new AuditStoreOptions { ConnectionString = null })))
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Store_Constructor_WithEmptyConnectionString_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() => new SQLiteAuditStore(Options.Create(new AuditStoreOptions { ConnectionString = string.Empty })))
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task Store_Constructor_WithWhitespaceConnectionString_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() => new SQLiteAuditStore(Options.Create(new AuditStoreOptions { ConnectionString = "   " })))
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task Store_Constructor_WithValidConnectionString_CreatesInstance()
+    {
+        var options = new AuditStoreOptions { ConnectionString = ValidConnectionString };
+
+        var store = new SQLiteAuditStore(Options.Create(options));
+
+        _ = await Assert.That(store).IsNotNull();
+    }
+
+    [Test]
+    public async Task Store_Constructor_WithCustomTableName_CreatesInstance()
+    {
+        var options = new AuditStoreOptions
+        {
+            ConnectionString = ValidConnectionString,
+            TableName = "CustomAuditEntry",
+        };
+
+        var store = new SQLiteAuditStore(Options.Create(options));
+
+        _ = await Assert.That(store).IsNotNull();
+    }
+
+    [Test]
+    public async Task Store_Constructor_WithWalModeDisabled_CreatesInstance()
+    {
+        var options = new AuditStoreOptions { ConnectionString = ValidConnectionString, EnableWalMode = false };
+
+        var store = new SQLiteAuditStore(Options.Create(options));
+
+        _ = await Assert.That(store).IsNotNull();
+    }
+
+    [Test]
+    public async Task Store_Constructor_WithInvalidTableName_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() =>
+                new SQLiteAuditStore(
+                    Options.Create(
+                        new AuditStoreOptions { ConnectionString = ValidConnectionString, TableName = "1invalid" }
+                    )
+                )
+            )
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task Management_Constructor_WithNullOptions_ThrowsArgumentNullException() =>
+        _ = await Assert.That(() => new SQLiteAuditManagement(null!)).Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Management_Constructor_WithNullConnectionString_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() => new SQLiteAuditManagement(Options.Create(new AuditStoreOptions { ConnectionString = null })))
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Management_Constructor_WithEmptyConnectionString_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() =>
+                new SQLiteAuditManagement(Options.Create(new AuditStoreOptions { ConnectionString = string.Empty }))
+            )
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task Management_Constructor_WithWhitespaceConnectionString_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() => new SQLiteAuditManagement(Options.Create(new AuditStoreOptions { ConnectionString = "   " })))
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task Management_Constructor_WithValidConnectionString_CreatesInstance()
+    {
+        var options = new AuditStoreOptions { ConnectionString = ValidConnectionString };
+
+        var management = new SQLiteAuditManagement(Options.Create(options));
+
+        _ = await Assert.That(management).IsNotNull();
+    }
+
+    [Test]
+    public async Task Management_Constructor_WithInvalidTableName_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() =>
+                new SQLiteAuditManagement(
+                    Options.Create(
+                        new AuditStoreOptions { ConnectionString = ValidConnectionString, TableName = "1invalid" }
+                    )
+                )
+            )
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task AddSQLiteAuditStore_WithNullConfigurator_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() =>
+                SQLiteAuditMediatorBuilderExtensions.AddSQLiteAuditStore(
+                    null!,
+                    opts => opts.ConnectionString = ValidConnectionString
+                )
+            )
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task AddSQLiteAuditStore_WithNullConfigureOptions_ThrowsArgumentNullException()
+    {
+        var mock = Mock.Of<IMediatorBuilder>();
+        _ = mock.Services.Returns(new ServiceCollection());
+
+        _ = await Assert.That(() => mock.Object.AddSQLiteAuditStore(null!)).Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task AddSQLiteAuditStore_ReturnsConfiguratorForChaining()
+    {
+        var mock = Mock.Of<IMediatorBuilder>();
+        _ = mock.Services.Returns(new ServiceCollection());
+
+        var result = mock.Object.AddSQLiteAuditStore(opts => opts.ConnectionString = ValidConnectionString);
+
+        _ = await Assert.That(result).IsSameReferenceAs(mock.Object);
+    }
+
+    [Test]
+    public async Task AddSQLiteAuditStore_RegistersAuditStoreAsScoped()
+    {
+        var services = new ServiceCollection();
+        var mock = Mock.Of<IMediatorBuilder>();
+        _ = mock.Services.Returns(services);
+
+        _ = mock.Object.AddSQLiteAuditStore(opts => opts.ConnectionString = ValidConnectionString);
+
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IAuditStore));
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor).IsNotNull();
+            _ = await Assert.That(descriptor!.Lifetime).IsEqualTo(ServiceLifetime.Scoped);
+            _ = await Assert.That(descriptor.ImplementationType).IsEqualTo(typeof(SQLiteAuditStore));
+        }
+    }
+
+    [Test]
+    public async Task AddSQLiteAuditStore_RegistersAuditManagementAsScoped()
+    {
+        var services = new ServiceCollection();
+        var mock = Mock.Of<IMediatorBuilder>();
+        _ = mock.Services.Returns(services);
+
+        _ = mock.Object.AddSQLiteAuditStore(opts => opts.ConnectionString = ValidConnectionString);
+
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IAuditManagement));
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor).IsNotNull();
+            _ = await Assert.That(descriptor!.Lifetime).IsEqualTo(ServiceLifetime.Scoped);
+            _ = await Assert.That(descriptor.ImplementationType).IsEqualTo(typeof(SQLiteAuditManagement));
+        }
+    }
+
+    [Test]
+    public async Task AddSQLiteAuditStore_AppliesOptions()
+    {
+        var services = new ServiceCollection();
+        var mock = Mock.Of<IMediatorBuilder>();
+        _ = mock.Services.Returns(services);
+
+        _ = mock.Object.AddSQLiteAuditStore(opts =>
+        {
+            opts.ConnectionString = ValidConnectionString;
+            opts.TableName = "CustomAuditEntry";
+            opts.EnableWalMode = false;
+        });
+
+        var provider = services.BuildServiceProvider();
+        await using (provider.ConfigureAwait(false))
+        {
+            var options = provider.GetRequiredService<IOptions<AuditStoreOptions>>();
+
+            using (Assert.Multiple())
+            {
+                _ = await Assert.That(options.Value.ConnectionString).IsEqualTo(ValidConnectionString);
+                _ = await Assert.That(options.Value.TableName).IsEqualTo("CustomAuditEntry");
+                _ = await Assert.That(options.Value.EnableWalMode).IsFalse();
+            }
+        }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/SqlServer/SqlServerAuditTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/SqlServer/SqlServerAuditTests.cs
@@ -1,0 +1,220 @@
+﻿namespace NetEvolve.Pulse.Tests.Unit.SqlServer;
+
+using System;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Audit;
+using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.Audit;
+using TUnit.Core;
+using TUnit.Mocks;
+
+[TestGroup("SqlServer")]
+public sealed class SqlServerAuditTests
+{
+    private const string ValidConnectionString = "Server=.;Database=Test;Integrated Security=true;";
+
+    [Test]
+    public async Task Store_Constructor_WithNullOptions_ThrowsArgumentNullException() =>
+        _ = await Assert.That(() => new SqlServerAuditStore(null!)).Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Store_Constructor_WithNullConnectionString_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() => new SqlServerAuditStore(Options.Create(new AuditStoreOptions { ConnectionString = null })))
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Store_Constructor_WithEmptyConnectionString_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() =>
+                new SqlServerAuditStore(Options.Create(new AuditStoreOptions { ConnectionString = string.Empty }))
+            )
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task Store_Constructor_WithWhitespaceConnectionString_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() => new SqlServerAuditStore(Options.Create(new AuditStoreOptions { ConnectionString = "   " })))
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task Store_Constructor_WithValidConnectionString_CreatesInstance()
+    {
+        var store = new SqlServerAuditStore(
+            Options.Create(new AuditStoreOptions { ConnectionString = ValidConnectionString })
+        );
+
+        _ = await Assert.That(store).IsNotNull();
+    }
+
+    [Test]
+    public async Task Store_Constructor_WithCustomTableName_CreatesInstance()
+    {
+        var options = new AuditStoreOptions { ConnectionString = ValidConnectionString, TableName = "CustomAudit" };
+
+        var store = new SqlServerAuditStore(Options.Create(options));
+
+        _ = await Assert.That(store).IsNotNull();
+    }
+
+    // Defense-in-depth: pin that an attacker-controlled Schema value cannot reach the SQL
+    // builder. The constructor must fail fast when Schema contains characters that would
+    // break out of the [bracketed] identifier (e.g. ']' followed by injected SQL).
+    [Test]
+    public async Task Store_Constructor_WithMaliciousSchema_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() =>
+                new SqlServerAuditStore(
+                    Options.Create(
+                        new AuditStoreOptions { ConnectionString = ValidConnectionString, Schema = "pulse].[evil] -- " }
+                    )
+                )
+            )
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task Management_Constructor_WithNullOptions_ThrowsArgumentNullException() =>
+        _ = await Assert.That(() => new SqlServerAuditManagement(null!)).Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Management_Constructor_WithNullConnectionString_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() => new SqlServerAuditManagement(Options.Create(new AuditStoreOptions { ConnectionString = null })))
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task Management_Constructor_WithEmptyConnectionString_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() =>
+                new SqlServerAuditManagement(Options.Create(new AuditStoreOptions { ConnectionString = string.Empty }))
+            )
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task Management_Constructor_WithWhitespaceConnectionString_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() =>
+                new SqlServerAuditManagement(Options.Create(new AuditStoreOptions { ConnectionString = "   " }))
+            )
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task Management_Constructor_WithValidArguments_CreatesInstance()
+    {
+        var management = new SqlServerAuditManagement(
+            Options.Create(new AuditStoreOptions { ConnectionString = ValidConnectionString })
+        );
+
+        _ = await Assert.That(management).IsNotNull();
+    }
+
+    // Defense-in-depth: pin that an attacker-controlled Schema value cannot reach the SQL
+    // builder. The constructor must fail fast when Schema contains characters that would
+    // break out of the [bracketed] identifier (e.g. ']' followed by injected SQL).
+    [Test]
+    public async Task Management_Constructor_WithMaliciousSchema_ThrowsArgumentException() =>
+        _ = await Assert
+            .That(() =>
+                new SqlServerAuditManagement(
+                    Options.Create(
+                        new AuditStoreOptions { ConnectionString = ValidConnectionString, Schema = "pulse].[evil] -- " }
+                    )
+                )
+            )
+            .Throws<ArgumentException>();
+
+    [Test]
+    public async Task AddSqlServerAuditStore_WithNullConfigurator_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() =>
+                SqlServerAuditMediatorBuilderExtensions.AddSqlServerAuditStore(
+                    null!,
+                    opts => opts.ConnectionString = ValidConnectionString
+                )
+            )
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task AddSqlServerAuditStore_WithNullConfigureOptions_ThrowsArgumentNullException()
+    {
+        var mock = Mock.Of<IMediatorBuilder>();
+        _ = mock.Services.Returns(new ServiceCollection());
+
+        _ = await Assert.That(() => mock.Object.AddSqlServerAuditStore(null!)).Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task AddSqlServerAuditStore_WithValidOptions_ReturnsConfiguratorForChaining()
+    {
+        var mock = Mock.Of<IMediatorBuilder>();
+        _ = mock.Services.Returns(new ServiceCollection());
+
+        var result = mock.Object.AddSqlServerAuditStore(opts => opts.ConnectionString = ValidConnectionString);
+
+        _ = await Assert.That(result).IsSameReferenceAs(mock.Object);
+    }
+
+    [Test]
+    public async Task AddSqlServerAuditStore_RegistersAuditStoreAsScoped()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddPulse(config =>
+            config.AddSqlServerAuditStore(opts => opts.ConnectionString = ValidConnectionString)
+        );
+
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IAuditStore));
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor).IsNotNull();
+            _ = await Assert.That(descriptor!.Lifetime).IsEqualTo(ServiceLifetime.Scoped);
+            _ = await Assert.That(descriptor.ImplementationType).IsEqualTo(typeof(SqlServerAuditStore));
+        }
+    }
+
+    [Test]
+    public async Task AddSqlServerAuditStore_RegistersAuditManagementAsScoped()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddPulse(config =>
+            config.AddSqlServerAuditStore(opts => opts.ConnectionString = ValidConnectionString)
+        );
+
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IAuditManagement));
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(descriptor).IsNotNull();
+            _ = await Assert.That(descriptor!.Lifetime).IsEqualTo(ServiceLifetime.Scoped);
+            _ = await Assert.That(descriptor.ImplementationType).IsEqualTo(typeof(SqlServerAuditManagement));
+        }
+    }
+
+    [Test]
+    public async Task AddSqlServerAuditStore_WithConfigureOptions_AppliesOptions()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddPulse(config =>
+            config.AddSqlServerAuditStore(opts =>
+            {
+                opts.ConnectionString = ValidConnectionString;
+                opts.TableName = "CustomAudit";
+            })
+        );
+
+        var provider = services.BuildServiceProvider();
+        await using (provider.ConfigureAwait(false))
+        {
+            var options = provider.GetRequiredService<IOptions<AuditStoreOptions>>();
+
+            using (Assert.Multiple())
+            {
+                _ = await Assert.That(options.Value.ConnectionString).IsEqualTo(ValidConnectionString);
+                _ = await Assert.That(options.Value.TableName).IsEqualTo("CustomAudit");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `AuditEntrySchema`/`AuditRecord`/`AuditStatistics`, `IAuditStore`, `IAuditManagement` (`AuditFilter`), and `IAuditUserAccessor` (`NetEvolve.Pulse.Extensibility`).
- Adds `AuditRequestInterceptor` + `AddAudit()`: records commands (and optionally queries, via `AuditOptions.AuditQueries`) to `IAuditStore` when registered — success/failure, elapsed time (via `TimeProvider`, not `Stopwatch`, matching this repo's existing interceptor convention), current user (via `IAuditUserAccessor`), and optionally the serialized payload (`AuditOptions.CapturePayload`). Excluded types and unregistered stores are pure pass-through; the original exception always propagates.
- Adds `HttpContextAuditUserAccessor` + `AddHttpContextAuditUserAccessor()` (`NetEvolve.Pulse.AspNetCore`) reading the current user from `HttpContext.User.Identity.Name`.
- Adds `AuditStoreOptions` (`NetEvolve.Pulse`) and five store implementations, each with its own `Add*AuditStore()` registration extension:
  - **Entity Framework Core** — reuses `AuditRecord` directly as the EF entity (matching the `OutboxMessage`/`CommandDeadLetterEntry` precedent), with SQL Server/PostgreSQL/SQLite/MySQL/InMemory `IEntityTypeConfiguration` derivations wired into `ModelBuilderExtensions.ApplyPulseConfiguration`.
  - **SQL Server / PostgreSQL / SQLite / MySQL** — native ADO.NET providers with DDL scripts, following this repo's established provider conventions (parameterized SQL, dynamic filter WHERE clause for `QueryAsync`, provider-appropriate paging syntax).
- Unit tests for every layer (interceptor, extension, AspNetCore accessor, EF Core store + management, all four ADO.NET providers).

Note: the underlying issues contain the same kind of inaccuracy the just-completed Command Dead Letter PR did — issue #276 names a separate "AuditEntry" POCO, but there is exactly one shared `AuditRecord` type, reused directly as the EF entity. Issue #275 asks for `Stopwatch`-based timing; this uses `TimeProvider` instead, matching `LoggingRequestInterceptor`'s established convention.

Closes #274
Closes #275
Closes #276
Closes #277
Closes #278
Closes #279
Closes #280
Closes #281

## Test plan
- [x] `dotnet build` clean on net8.0/net9.0/net10.0 (all 20 projects)
- [x] `dotnet test` — full `NetEvolve.Pulse.Tests.Unit` suite passes (1924 tests)
- [x] `csharpier format .`

Based on the Command Dead Letter PR (#680), the ADO.NET provider unit tests likely won't reach the patch-coverage threshold on their own (no live database) — a follow-up commit adding integration tests (mirroring `CommandDeadLetterTestsBase` et al.) is expected before merge, same as that PR.