### PR TITLE
fix(tests): use non-obsolete KafkaBuilder constructor

### DIFF
--- a/tests/NetEvolve.Pulse.Tests.Integration/Kafka/KafkaContainerFixture.cs
+++ b/tests/NetEvolve.Pulse.Tests.Integration/Kafka/KafkaContainerFixture.cs
@@ -1,4 +1,4 @@
-namespace NetEvolve.Pulse.Tests.Integration.Kafka;
+﻿namespace NetEvolve.Pulse.Tests.Integration.Kafka;
 
 using Microsoft.Extensions.Logging.Abstractions;
 using Testcontainers.Kafka;
@@ -9,7 +9,9 @@ using TUnit.Core.Interfaces;
 /// </summary>
 public sealed class KafkaContainerFixture : IAsyncDisposable, IAsyncInitializer
 {
-    private readonly KafkaContainer _container = new KafkaBuilder()
+    private readonly KafkaContainer _container = new KafkaBuilder(
+        /*dockerimage*/"confluentinc/cp-kafka:7.6.12"
+    )
         .WithLogger(NullLogger.Instance)
         // Disabled so that "topic missing" scenarios (AutoCreateTopics = false on the transport)
         // exercise a real UnknownTopicOrPartition failure instead of the broker silently


### PR DESCRIPTION
## Summary
- Replace the obsolete parameterless `KafkaBuilder()` with the constructor overload that takes the image explicitly, matching the guidance in testcontainers-dotnet discussion #1470.
- Removes the CS0618 obsolete-constructor build warning that showed up for the net8.0/net9.0/net10.0 test targets.

## Test plan
- [x] `dotnet build tests/NetEvolve.Pulse.Tests.Integration/NetEvolve.Pulse.Tests.Integration.csproj` produces no CS0618 warning for this file