### PR TITLE
feat(aspnetcore): outbox, command dead letter, and audit inspector endpoints; opt-in OpenAPI metadata

### DIFF
--- a/src/NetEvolve.Pulse.AspNetCore/AspNetCoreOptions.cs
+++ b/src/NetEvolve.Pulse.AspNetCore/AspNetCoreOptions.cs
@@ -1,0 +1,16 @@
+namespace NetEvolve.Pulse;
+
+/// <summary>
+/// Provides configuration options for the ASP.NET Core Minimal API integration of the Pulse
+/// mediator, such as the endpoints mapped via <see cref="EndpointRouteBuilderExtensions"/>.
+/// </summary>
+public sealed class AspNetCoreOptions
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether OpenAPI metadata (summary, description, tags,
+    /// and produced response types) is automatically applied to endpoints mapped via
+    /// <see cref="EndpointRouteBuilderExtensions"/>.
+    /// Defaults to <see langword="false"/>.
+    /// </summary>
+    public bool OpenApiMetadataEnabled { get; set; }
+}

--- a/src/NetEvolve.Pulse.AspNetCore/Audit/AuditInspectorEndpoints.cs
+++ b/src/NetEvolve.Pulse.AspNetCore/Audit/AuditInspectorEndpoints.cs
@@ -1,0 +1,143 @@
+namespace NetEvolve.Pulse;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using NetEvolve.Pulse.Extensibility.Audit;
+
+/// <summary>
+/// Provides extension methods for <see cref="IEndpointRouteBuilder"/> to map read-only HTTP
+/// endpoints for inspecting audit trail records.
+/// </summary>
+public static class AuditInspectorEndpoints
+{
+    /// <summary>
+    /// Maps the audit inspector endpoints, backed by <see cref="IAuditManagement"/>, as a route
+    /// group under <see cref="AuditInspectorOptions.BasePath"/>.
+    /// </summary>
+    /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/> to add the endpoints to.</param>
+    /// <param name="configure">
+    /// An optional delegate to configure the <see cref="AuditInspectorOptions"/> used to map the
+    /// endpoints. When <see langword="null"/>, the default options are used.
+    /// </param>
+    /// <returns>
+    /// An <see cref="IEndpointConventionBuilder"/> representing the mapped route group, which
+    /// callers can further configure, for example to require authorization.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="endpoints"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para><strong>Endpoints:</strong></para>
+    /// <list type="bullet">
+    /// <item><description><c>GET {BasePath}/stats</c> — aggregate audit result counts.</description></item>
+    /// <item><description><c>GET {BasePath}/entries</c> — paginated, filterable audit records.</description></item>
+    /// </list>
+    /// <para><strong>Read-only:</strong></para>
+    /// This method maps strictly read-only endpoints. No replay, dismiss, or other mutating
+    /// operations are exposed, and no built-in authorization is applied. Callers are responsible
+    /// for securing the returned route group, for example via <c>RequireAuthorization()</c>.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// // Default base path "/pulse/audit"
+    /// app.MapAuditInspector();
+    ///
+    /// // Custom base path and group name, with authorization applied by the caller
+    /// app.MapAuditInspector(options =>
+    /// {
+    ///     options.BasePath = "/admin/audit";
+    ///     options.RouteGroupName = "Admin Audit Inspector";
+    /// }).RequireAuthorization();
+    /// </code>
+    /// </example>
+    public static IEndpointConventionBuilder MapAuditInspector(
+        [NotNull] this IEndpointRouteBuilder endpoints,
+        Action<AuditInspectorOptions>? configure = null
+    )
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+
+        var options = new AuditInspectorOptions();
+        configure?.Invoke(options);
+
+        var group = endpoints.MapGroup(options.BasePath).WithGroupName(options.RouteGroupName);
+
+        _ = group.MapGet("/stats", GetStatisticsAsync);
+        _ = group.MapGet("/entries", GetEntriesAsync);
+
+        return group;
+    }
+
+    private static async Task<IResult> GetStatisticsAsync(
+        IAuditManagement auditManagement,
+        CancellationToken cancellationToken
+    ) => TypedResults.Ok(await auditManagement.GetStatisticsAsync(cancellationToken).ConfigureAwait(false));
+
+    private static async Task<IResult> GetEntriesAsync(
+        [AsParameters] AuditEntriesQuery query,
+        IAuditManagement auditManagement,
+        CancellationToken cancellationToken
+    ) => TypedResults.Ok(await auditManagement.QueryAsync(query.ToFilter(), cancellationToken).ConfigureAwait(false));
+
+    /// <summary>
+    /// Query-string binding target for <c>GET {BasePath}/entries</c>.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="AuditFilter"/>, <see cref="Take"/> and <see cref="Skip"/> are nullable
+    /// here. Minimal API <c>[AsParameters]</c> binding treats non-nullable value-type properties
+    /// as required regardless of any C# property initializer, so binding <see cref="AuditFilter"/>
+    /// directly would make <c>take</c> and <c>skip</c> mandatory query parameters and reject every
+    /// request that omits them. This type restores <see cref="AuditFilter"/>'s own defaults for
+    /// omitted values via <see cref="ToFilter"/>.
+    /// </remarks>
+    // Properties are set by ASP.NET Core's [AsParameters] query-string model binder via
+    // reflection, which static analysis cannot observe, hence they appear "unassigned" and their
+    // setters appear "unused".
+#pragma warning disable S3459 // Remove unassigned auto-property, or set its value.
+#pragma warning disable S1144 // Remove the unused private set accessor.
+    private sealed class AuditEntriesQuery
+    {
+        public string? CommandType { get; set; }
+
+        public string? UserId { get; set; }
+
+        public DateTimeOffset? From { get; set; }
+
+        public DateTimeOffset? To { get; set; }
+
+        public AuditResult? Result { get; set; }
+
+        public int? Take { get; set; }
+
+        public int? Skip { get; set; }
+
+        public AuditFilter ToFilter()
+        {
+            var filter = new AuditFilter
+            {
+                CommandType = CommandType,
+                UserId = UserId,
+                From = From,
+                To = To,
+                Result = Result,
+            };
+
+            if (Take.HasValue)
+            {
+                filter.Take = Take.Value;
+            }
+
+            if (Skip.HasValue)
+            {
+                filter.Skip = Skip.Value;
+            }
+
+            return filter;
+        }
+    }
+#pragma warning restore S1144
+#pragma warning restore S3459
+}

--- a/src/NetEvolve.Pulse.AspNetCore/Audit/AuditInspectorOptions.cs
+++ b/src/NetEvolve.Pulse.AspNetCore/Audit/AuditInspectorOptions.cs
@@ -1,0 +1,20 @@
+namespace NetEvolve.Pulse;
+
+/// <summary>
+/// Provides configuration options for the audit inspector endpoints mapped via
+/// <see cref="AuditInspectorEndpoints.MapAuditInspector"/>.
+/// </summary>
+public sealed class AuditInspectorOptions
+{
+    /// <summary>
+    /// Gets or sets the base route path under which the audit inspector endpoints are mapped.
+    /// Defaults to <c>/pulse/audit</c>.
+    /// </summary>
+    public string BasePath { get; set; } = "/pulse/audit";
+
+    /// <summary>
+    /// Gets or sets the endpoint group name assigned to the mapped route group.
+    /// Defaults to <c>Pulse Audit Inspector</c>.
+    /// </summary>
+    public string RouteGroupName { get; set; } = "Pulse Audit Inspector";
+}

--- a/src/NetEvolve.Pulse.AspNetCore/DeadLetter/CommandDeadLetterInspectorEndpoints.cs
+++ b/src/NetEvolve.Pulse.AspNetCore/DeadLetter/CommandDeadLetterInspectorEndpoints.cs
@@ -1,0 +1,113 @@
+namespace NetEvolve.Pulse;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+
+/// <summary>
+/// Provides extension methods for <see cref="IEndpointRouteBuilder"/> to map read/administrative
+/// HTTP endpoints for inspecting and replaying command dead-letter entries.
+/// </summary>
+public static class CommandDeadLetterInspectorEndpoints
+{
+    /// <summary>
+    /// Maps the command dead letter inspector endpoints, backed by
+    /// <see cref="ICommandDeadLetterManagement"/>, as a route group under
+    /// <see cref="CommandDeadLetterInspectorOptions.BasePath"/>.
+    /// </summary>
+    /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/> to add the endpoints to.</param>
+    /// <param name="configure">
+    /// An optional delegate to configure the <see cref="CommandDeadLetterInspectorOptions"/> used
+    /// to map the endpoints. When <see langword="null"/>, the default options are used.
+    /// </param>
+    /// <returns>
+    /// An <see cref="IEndpointConventionBuilder"/> representing the mapped route group, which
+    /// callers can further configure, for example to require authorization.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="endpoints"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para><strong>Endpoints:</strong></para>
+    /// <list type="bullet">
+    /// <item><description><c>GET {BasePath}/stats</c> — dead letter statistics.</description></item>
+    /// <item><description><c>GET {BasePath}/entries?count=50</c> — pending dead-letter entries.</description></item>
+    /// <item><description><c>POST {BasePath}/entries/{{id:guid}}/replay</c> — replays a dead-letter entry.</description></item>
+    /// <item><description><c>POST {BasePath}/entries/{{id:guid}}/dismiss</c> — dismisses a dead-letter entry.</description></item>
+    /// </list>
+    /// <para><strong>Authorization:</strong></para>
+    /// No authorization is applied by this method. Callers are responsible for securing the
+    /// returned route group, for example via <c>RequireAuthorization()</c>.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// // Default base path "/pulse/commands"
+    /// app.MapCommandDeadLetterInspector();
+    ///
+    /// // Custom base path and group name, with authorization applied by the caller
+    /// app.MapCommandDeadLetterInspector(options =>
+    /// {
+    ///     options.BasePath = "/admin/commands";
+    ///     options.RouteGroupName = "Admin Command Dead Letter Inspector";
+    /// }).RequireAuthorization();
+    /// </code>
+    /// </example>
+    public static IEndpointConventionBuilder MapCommandDeadLetterInspector(
+        [NotNull] this IEndpointRouteBuilder endpoints,
+        Action<CommandDeadLetterInspectorOptions>? configure = null
+    )
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+
+        var options = new CommandDeadLetterInspectorOptions();
+        configure?.Invoke(options);
+
+        var group = endpoints.MapGroup(options.BasePath).WithGroupName(options.RouteGroupName);
+
+        _ = group.MapGet("/stats", GetStatisticsAsync);
+        _ = group.MapGet("/entries", GetPendingEntriesAsync);
+        _ = group.MapPost("/entries/{id:guid}/replay", ReplayEntryAsync);
+        _ = group.MapPost("/entries/{id:guid}/dismiss", DismissEntryAsync);
+
+        return group;
+    }
+
+    private static async Task<IResult> GetStatisticsAsync(
+        ICommandDeadLetterManagement commandDeadLetterManagement,
+        CancellationToken cancellationToken
+    ) => TypedResults.Ok(await commandDeadLetterManagement.GetStatisticsAsync(cancellationToken).ConfigureAwait(false));
+
+    private static async Task<IResult> GetPendingEntriesAsync(
+        ICommandDeadLetterManagement commandDeadLetterManagement,
+        CancellationToken cancellationToken,
+        int count = 50
+    ) =>
+        TypedResults.Ok(
+            await commandDeadLetterManagement.GetPendingAsync(count, cancellationToken).ConfigureAwait(false)
+        );
+
+    private static async Task<IResult> ReplayEntryAsync(
+        Guid id,
+        ICommandDeadLetterManagement commandDeadLetterManagement,
+        CancellationToken cancellationToken
+    )
+    {
+        await commandDeadLetterManagement.ReplayAsync(id, cancellationToken).ConfigureAwait(false);
+
+        return TypedResults.NoContent();
+    }
+
+    private static async Task<IResult> DismissEntryAsync(
+        Guid id,
+        ICommandDeadLetterManagement commandDeadLetterManagement,
+        CancellationToken cancellationToken
+    )
+    {
+        await commandDeadLetterManagement.DismissAsync(id, cancellationToken).ConfigureAwait(false);
+
+        return TypedResults.NoContent();
+    }
+}

--- a/src/NetEvolve.Pulse.AspNetCore/DeadLetter/CommandDeadLetterInspectorOptions.cs
+++ b/src/NetEvolve.Pulse.AspNetCore/DeadLetter/CommandDeadLetterInspectorOptions.cs
@@ -1,0 +1,20 @@
+namespace NetEvolve.Pulse;
+
+/// <summary>
+/// Provides configuration options for the command dead letter inspector endpoints mapped via
+/// <see cref="CommandDeadLetterInspectorEndpoints.MapCommandDeadLetterInspector"/>.
+/// </summary>
+public sealed class CommandDeadLetterInspectorOptions
+{
+    /// <summary>
+    /// Gets or sets the base route path under which the command dead letter inspector endpoints
+    /// are mapped. Defaults to <c>/pulse/commands</c>.
+    /// </summary>
+    public string BasePath { get; set; } = "/pulse/commands";
+
+    /// <summary>
+    /// Gets or sets the endpoint group name assigned to the mapped route group.
+    /// Defaults to <c>Pulse Command Dead Letter Inspector</c>.
+    /// </summary>
+    public string RouteGroupName { get; set; } = "Pulse Command Dead Letter Inspector";
+}

--- a/src/NetEvolve.Pulse.AspNetCore/EndpointRouteBuilderExtensions.cs
+++ b/src/NetEvolve.Pulse.AspNetCore/EndpointRouteBuilderExtensions.cs
@@ -6,6 +6,8 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 using NetEvolve.Pulse.Extensibility;
@@ -63,7 +65,7 @@ public static class EndpointRouteBuilderExtensions
         ArgumentNullException.ThrowIfNull(endpoints);
         ArgumentNullException.ThrowIfNull(pattern);
 
-        return endpoints.MapMethods(
+        var routeBuilder = endpoints.MapMethods(
             pattern,
             [httpMethod.ToHttpMethodString()],
             async ([FromBody] TCommand command, IMediator mediator, CancellationToken cancellationToken) =>
@@ -71,6 +73,10 @@ public static class EndpointRouteBuilderExtensions
                     await mediator.SendAsync<TCommand, TResponse>(command, cancellationToken).ConfigureAwait(false)
                 )
         );
+
+        ApplyOpenApiMetadata<TCommand, TResponse>(endpoints, routeBuilder);
+
+        return routeBuilder;
     }
 
     /// <summary>
@@ -109,7 +115,7 @@ public static class EndpointRouteBuilderExtensions
         ArgumentNullException.ThrowIfNull(endpoints);
         ArgumentNullException.ThrowIfNull(pattern);
 
-        return endpoints.MapMethods(
+        var routeBuilder = endpoints.MapMethods(
             pattern,
             [httpMethod.ToHttpMethodString()],
             async ([FromBody] TCommand command, IMediator mediator, CancellationToken cancellationToken) =>
@@ -118,6 +124,10 @@ public static class EndpointRouteBuilderExtensions
                 return TypedResults.NoContent();
             }
         );
+
+        ApplyOpenApiMetadata<TCommand>(endpoints, routeBuilder);
+
+        return routeBuilder;
     }
 
     /// <summary>
@@ -147,13 +157,17 @@ public static class EndpointRouteBuilderExtensions
         ArgumentNullException.ThrowIfNull(endpoints);
         ArgumentNullException.ThrowIfNull(pattern);
 
-        return endpoints.MapGet(
+        var routeBuilder = endpoints.MapGet(
             pattern,
             async ([AsParameters] TQuery query, IMediator mediator, CancellationToken cancellationToken) =>
                 TypedResults.Ok(
                     await mediator.QueryAsync<TQuery, TResponse>(query, cancellationToken).ConfigureAwait(false)
                 )
         );
+
+        ApplyOpenApiMetadata<TQuery, TResponse>(endpoints, routeBuilder);
+
+        return routeBuilder;
     }
 
     /// <summary>
@@ -188,7 +202,7 @@ public static class EndpointRouteBuilderExtensions
         ArgumentNullException.ThrowIfNull(endpoints);
         ArgumentNullException.ThrowIfNull(pattern);
 
-        return endpoints.MapGet(
+        var routeBuilder = endpoints.MapGet(
             pattern,
             (
                 [AsParameters] TQuery query,
@@ -223,6 +237,48 @@ public static class EndpointRouteBuilderExtensions
 #endif
             }
         );
+
+        ApplyStreamOpenApiMetadata<TQuery>(endpoints, routeBuilder);
+
+        return routeBuilder;
+    }
+
+    private static void ApplyOpenApiMetadata<TRequest, TResponse>(
+        IEndpointRouteBuilder endpoints,
+        RouteHandlerBuilder routeBuilder
+    )
+    {
+        var options = endpoints.ServiceProvider.GetService<IOptions<AspNetCoreOptions>>();
+        if (options?.Value.OpenApiMetadataEnabled == true)
+        {
+            _ = routeBuilder.WithPulseSummary<TRequest>();
+            _ = routeBuilder.WithPulseProduces<TResponse>();
+        }
+    }
+
+    private static void ApplyOpenApiMetadata<TRequest>(
+        IEndpointRouteBuilder endpoints,
+        RouteHandlerBuilder routeBuilder
+    )
+    {
+        var options = endpoints.ServiceProvider.GetService<IOptions<AspNetCoreOptions>>();
+        if (options?.Value.OpenApiMetadataEnabled == true)
+        {
+            _ = routeBuilder.WithPulseSummary<TRequest>();
+        }
+    }
+
+    private static void ApplyStreamOpenApiMetadata<TQuery>(
+        IEndpointRouteBuilder endpoints,
+        RouteHandlerBuilder routeBuilder
+    )
+    {
+        var options = endpoints.ServiceProvider.GetService<IOptions<AspNetCoreOptions>>();
+        if (options?.Value.OpenApiMetadataEnabled == true)
+        {
+            _ = routeBuilder.WithPulseSummary<TQuery>();
+            _ = routeBuilder.WithPulseStreamProduces();
+        }
     }
 
     private static bool AcceptsNdjson(StringValues acceptHeader) =>

--- a/src/NetEvolve.Pulse.AspNetCore/Internals/TypeJsonConverter.cs
+++ b/src/NetEvolve.Pulse.AspNetCore/Internals/TypeJsonConverter.cs
@@ -1,0 +1,33 @@
+namespace NetEvolve.Pulse.AspNetCore.Internals;
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NetEvolve.Pulse.Extensibility.Outbox;
+
+/// <summary>
+/// Serializes a <see cref="Type"/> as its outbox event type identifier string (see
+/// <see cref="TypeExtensions.ToOutboxEventTypeName"/>), so that response models such as
+/// <see cref="NetEvolve.Pulse.Extensibility.Outbox.OutboxMessage"/> — whose
+/// <see cref="NetEvolve.Pulse.Extensibility.Outbox.OutboxMessage.EventType"/> is a raw
+/// <see cref="Type"/> — can be written as JSON.
+/// </summary>
+/// <remarks>
+/// This converter is write-only: it is used exclusively to serialize inspector responses.
+/// Reading is not supported because these endpoints never accept an <see cref="OutboxMessage"/> as input.
+/// </remarks>
+internal sealed class TypeJsonConverter : JsonConverter<Type>
+{
+    /// <inheritdoc />
+    public override Type Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+        throw new NotSupportedException($"Deserializing a '{nameof(Type)}' value is not supported.");
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, Type value, JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(value);
+
+        writer.WriteStringValue(value.ToOutboxEventTypeName());
+    }
+}

--- a/src/NetEvolve.Pulse.AspNetCore/Internals/XmlDocumentationReader.cs
+++ b/src/NetEvolve.Pulse.AspNetCore/Internals/XmlDocumentationReader.cs
@@ -1,0 +1,104 @@
+namespace NetEvolve.Pulse.AspNetCore.Internals;
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+/// <summary>
+/// Reads <c>&lt;summary&gt;</c> text for a <see cref="Type"/> from its assembly's generated
+/// XML documentation file.
+/// </summary>
+internal static class XmlDocumentationReader
+{
+    private static readonly ConcurrentDictionary<string, IReadOnlyDictionary<string, string>?> DocumentationCache = new(
+        StringComparer.OrdinalIgnoreCase
+    );
+
+    private static readonly ConcurrentDictionary<Type, string?> SummaryCache = new();
+
+    /// <summary>
+    /// Attempts to retrieve the <c>&lt;summary&gt;</c> documentation text for <paramref name="type"/>
+    /// from the XML documentation file generated for its declaring assembly.
+    /// </summary>
+    /// <param name="type">The type to look up.</param>
+    /// <param name="summary">
+    /// When this method returns <see langword="true"/>, contains the trimmed summary text;
+    /// otherwise, <see langword="null"/>.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if a summary was found for <paramref name="type"/>; otherwise, <see langword="false"/>.
+    /// </returns>
+    internal static bool TryGetSummary(Type type, out string? summary)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+
+        summary = SummaryCache.GetOrAdd(
+            type,
+            static t =>
+            {
+                var assemblyLocation = t.Assembly.Location;
+                if (string.IsNullOrEmpty(assemblyLocation))
+                {
+                    return null;
+                }
+
+                var xmlPath = Path.ChangeExtension(assemblyLocation, ".xml");
+                var members = LoadDocumentation(xmlPath);
+                if (members is null)
+                {
+                    return null;
+                }
+
+                var memberId = "T:" + t.FullName;
+                return members.TryGetValue(memberId, out var value) ? value : null;
+            }
+        );
+
+        return summary is not null;
+    }
+
+    /// <summary>
+    /// Loads and caches the <c>&lt;summary&gt;</c> documentation entries contained in the XML
+    /// documentation file located at <paramref name="xmlPath"/>, keyed by their <c>name</c>
+    /// attribute (e.g. <c>T:Namespace.TypeName</c>).
+    /// </summary>
+    /// <param name="xmlPath">The full path to the XML documentation file.</param>
+    /// <returns>
+    /// A read-only dictionary of member id to trimmed summary text, or <see langword="null"/>
+    /// when the file does not exist or contains no usable documentation.
+    /// </returns>
+    internal static IReadOnlyDictionary<string, string>? LoadDocumentation(string xmlPath) =>
+        DocumentationCache.GetOrAdd(
+            xmlPath,
+            static path =>
+            {
+                if (!File.Exists(path))
+                {
+                    return null;
+                }
+
+                try
+                {
+                    var document = XDocument.Load(path);
+                    var members = document
+                        .Descendants("member")
+                        .Select(member => new
+                        {
+                            Name = (string?)member.Attribute("name"),
+                            Summary = member.Element("summary")?.Value,
+                        })
+                        .Where(entry => entry.Name is not null && entry.Summary is not null)
+                        .ToDictionary(entry => entry.Name!, entry => entry.Summary!.Trim(), StringComparer.Ordinal);
+
+                    return members.Count > 0 ? members : null;
+                }
+                catch (Exception ex) when (ex is IOException or System.Xml.XmlException or UnauthorizedAccessException)
+                {
+                    return null;
+                }
+            }
+        );
+}

--- a/src/NetEvolve.Pulse.AspNetCore/NetEvolve.Pulse.AspNetCore.csproj
+++ b/src/NetEvolve.Pulse.AspNetCore/NetEvolve.Pulse.AspNetCore.csproj
@@ -4,6 +4,7 @@
     <Description>ASP.NET Core Minimal API integration for the Pulse CQRS mediator. Provides IEndpointRouteBuilder extension methods that map mediator commands and queries directly to HTTP endpoints, eliminating boilerplate endpoint handlers that only forward to IMediator. Commands are mapped using the CommandHttpMethod enum (Post, Put, Patch, Delete) with full CancellationToken propagation and OpenAPI compatibility. Queries are mapped to GET endpoints with route and query-string binding via [AsParameters].</Description>
     <PackageTags>$(PackageTags);aspnetcore;minimal-api;endpoints;</PackageTags>
     <RootNamespace>NetEvolve.Pulse</RootNamespace>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NetEvolve.Pulse.AspNetCore/OpenApiMediatorBuilderExtensions.cs
+++ b/src/NetEvolve.Pulse.AspNetCore/OpenApiMediatorBuilderExtensions.cs
@@ -1,0 +1,40 @@
+namespace NetEvolve.Pulse;
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using NetEvolve.Pulse.Extensibility;
+
+/// <summary>
+/// Provides extension methods for enabling automatic OpenAPI metadata generation for endpoints
+/// mapped via <see cref="EndpointRouteBuilderExtensions"/>.
+/// </summary>
+/// <seealso cref="AspNetCoreOptions"/>
+public static class OpenApiMediatorBuilderExtensions
+{
+    /// <summary>
+    /// Enables automatic OpenAPI metadata (summary and produced response types) for endpoints
+    /// mapped via <see cref="EndpointRouteBuilderExtensions.MapCommand{TCommand, TResponse}"/>,
+    /// <see cref="EndpointRouteBuilderExtensions.MapCommand{TCommand}"/>,
+    /// <see cref="EndpointRouteBuilderExtensions.MapQuery{TQuery, TResponse}"/>, and
+    /// <see cref="EndpointRouteBuilderExtensions.MapStreamQuery{TQuery, TResponse}"/>.
+    /// </summary>
+    /// <param name="builder">The mediator builder.</param>
+    /// <returns>The builder for method chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> is <see langword="null"/>.</exception>
+    /// <example>
+    /// <code>
+    /// services.AddPulse(builder =>
+    /// {
+    ///     builder.EnableOpenApiMetadata();
+    /// });
+    /// </code>
+    /// </example>
+    public static IMediatorBuilder EnableOpenApiMetadata(this IMediatorBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        _ = builder.Services.Configure<AspNetCoreOptions>(options => options.OpenApiMetadataEnabled = true);
+
+        return builder;
+    }
+}

--- a/src/NetEvolve.Pulse.AspNetCore/Outbox/OutboxInspectorEndpoints.cs
+++ b/src/NetEvolve.Pulse.AspNetCore/Outbox/OutboxInspectorEndpoints.cs
@@ -1,0 +1,153 @@
+namespace NetEvolve.Pulse;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using NetEvolve.Pulse.AspNetCore.Internals;
+using NetEvolve.Pulse.Extensibility.Outbox;
+
+/// <summary>
+/// Provides extension methods for <see cref="IEndpointRouteBuilder"/> to map read/administrative
+/// HTTP endpoints for inspecting and replaying outbox dead-letter messages.
+/// </summary>
+public static class OutboxInspectorEndpoints
+{
+    /// <summary>
+    /// Maps the outbox inspector endpoints, backed by <see cref="IOutboxManagement"/>, as a route
+    /// group under <see cref="OutboxInspectorOptions.BasePath"/>.
+    /// </summary>
+    /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/> to add the endpoints to.</param>
+    /// <param name="configure">
+    /// An optional delegate to configure the <see cref="OutboxInspectorOptions"/> used to map the
+    /// endpoints. When <see langword="null"/>, the default options are used.
+    /// </param>
+    /// <returns>
+    /// An <see cref="IEndpointConventionBuilder"/> representing the mapped route group, which
+    /// callers can further configure, for example to require authorization.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="endpoints"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para><strong>Endpoints:</strong></para>
+    /// <list type="bullet">
+    /// <item><description><c>GET {BasePath}/stats</c> — outbox statistics.</description></item>
+    /// <item><description><c>GET {BasePath}/dead-letters</c> — paginated dead-letter messages.</description></item>
+    /// <item><description><c>GET {BasePath}/dead-letters/count</c> — dead-letter message count.</description></item>
+    /// <item><description><c>GET {BasePath}/dead-letters/{{id:guid}}</c> — a single dead-letter message.</description></item>
+    /// <item><description><c>POST {BasePath}/dead-letters/{{id:guid}}/replay</c> — replays a single dead-letter message.</description></item>
+    /// <item><description><c>POST {BasePath}/dead-letters/replay-all</c> — replays all dead-letter messages.</description></item>
+    /// </list>
+    /// <para><strong>Authorization:</strong></para>
+    /// No authorization is applied by this method. Callers are responsible for securing the
+    /// returned route group, for example via <c>RequireAuthorization()</c>.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// // Default base path "/pulse/outbox"
+    /// app.MapOutboxInspector();
+    ///
+    /// // Custom base path and group name, with authorization applied by the caller
+    /// app.MapOutboxInspector(options =>
+    /// {
+    ///     options.BasePath = "/admin/outbox";
+    ///     options.RouteGroupName = "Admin Outbox Inspector";
+    /// }).RequireAuthorization();
+    /// </code>
+    /// </example>
+    public static IEndpointConventionBuilder MapOutboxInspector(
+        [NotNull] this IEndpointRouteBuilder endpoints,
+        Action<OutboxInspectorOptions>? configure = null
+    )
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+
+        var options = new OutboxInspectorOptions();
+        configure?.Invoke(options);
+
+        var group = endpoints.MapGroup(options.BasePath).WithGroupName(options.RouteGroupName);
+
+        _ = group.MapGet("/stats", GetStatisticsAsync);
+        _ = group.MapGet("/dead-letters", GetDeadLetterMessagesAsync);
+        _ = group.MapGet("/dead-letters/count", GetDeadLetterCountAsync);
+        _ = group.MapGet("/dead-letters/{id:guid}", GetDeadLetterMessageAsync);
+        _ = group.MapPost("/dead-letters/{id:guid}/replay", ReplayMessageAsync);
+        _ = group.MapPost("/dead-letters/replay-all", ReplayAllDeadLetterAsync);
+
+        return group;
+    }
+
+    /// <summary>
+    /// JSON options used to write <see cref="OutboxMessage"/> responses, since the type of
+    /// <see cref="OutboxMessage.EventType"/> is not serializable by <see cref="JsonSerializer"/> by default.
+    /// </summary>
+    private static readonly JsonSerializerOptions OutboxMessageSerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new TypeJsonConverter() },
+    };
+
+    private static async Task<IResult> GetStatisticsAsync(
+        IOutboxManagement outboxManagement,
+        CancellationToken cancellationToken
+    ) => TypedResults.Ok(await outboxManagement.GetStatisticsAsync(cancellationToken).ConfigureAwait(false));
+
+    private static async Task<IResult> GetDeadLetterMessagesAsync(
+        IOutboxManagement outboxManagement,
+        CancellationToken cancellationToken,
+        int pageSize = 50,
+        int page = 0
+    )
+    {
+        var messages = await outboxManagement
+            .GetDeadLetterMessagesAsync(pageSize, page, cancellationToken)
+            .ConfigureAwait(false);
+
+        return TypedResults.Json(messages, OutboxMessageSerializerOptions);
+    }
+
+    private static async Task<IResult> GetDeadLetterCountAsync(
+        IOutboxManagement outboxManagement,
+        CancellationToken cancellationToken
+    ) => TypedResults.Ok(await outboxManagement.GetDeadLetterCountAsync(cancellationToken).ConfigureAwait(false));
+
+    private static async Task<IResult> GetDeadLetterMessageAsync(
+        Guid id,
+        IOutboxManagement outboxManagement,
+        CancellationToken cancellationToken
+    )
+    {
+        var message = await outboxManagement.GetDeadLetterMessageAsync(id, cancellationToken).ConfigureAwait(false);
+
+        return message is null ? TypedResults.NotFound() : TypedResults.Json(message, OutboxMessageSerializerOptions);
+    }
+
+    private static async Task<IResult> ReplayMessageAsync(
+        Guid id,
+        IOutboxManagement outboxManagement,
+        CancellationToken cancellationToken
+    )
+    {
+        var replayed = await outboxManagement.ReplayMessageAsync(id, cancellationToken).ConfigureAwait(false);
+
+        return replayed ? TypedResults.NoContent() : TypedResults.NotFound();
+    }
+
+    private static async Task<IResult> ReplayAllDeadLetterAsync(
+        IOutboxManagement outboxManagement,
+        CancellationToken cancellationToken
+    )
+    {
+        var count = await outboxManagement.ReplayAllDeadLetterAsync(cancellationToken).ConfigureAwait(false);
+
+        return TypedResults.Ok(new OutboxReplayAllResult(count));
+    }
+
+    /// <summary>
+    /// Represents the result payload of the replay-all dead-letter operation.
+    /// </summary>
+    /// <param name="Count">The number of dead-letter messages that were reset for replay.</param>
+    private sealed record OutboxReplayAllResult(int Count);
+}

--- a/src/NetEvolve.Pulse.AspNetCore/Outbox/OutboxInspectorOptions.cs
+++ b/src/NetEvolve.Pulse.AspNetCore/Outbox/OutboxInspectorOptions.cs
@@ -1,0 +1,20 @@
+namespace NetEvolve.Pulse;
+
+/// <summary>
+/// Provides configuration options for the outbox inspector endpoints mapped via
+/// <see cref="OutboxInspectorEndpoints.MapOutboxInspector"/>.
+/// </summary>
+public sealed class OutboxInspectorOptions
+{
+    /// <summary>
+    /// Gets or sets the base route path under which the outbox inspector endpoints are mapped.
+    /// Defaults to <c>/pulse/outbox</c>.
+    /// </summary>
+    public string BasePath { get; set; } = "/pulse/outbox";
+
+    /// <summary>
+    /// Gets or sets the endpoint group name assigned to the mapped route group.
+    /// Defaults to <c>Pulse Outbox Inspector</c>.
+    /// </summary>
+    public string RouteGroupName { get; set; } = "Pulse Outbox Inspector";
+}

--- a/src/NetEvolve.Pulse.AspNetCore/RouteHandlerBuilderExtensions.cs
+++ b/src/NetEvolve.Pulse.AspNetCore/RouteHandlerBuilderExtensions.cs
@@ -1,0 +1,133 @@
+namespace NetEvolve.Pulse;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using NetEvolve.Pulse.AspNetCore.Internals;
+
+/// <summary>
+/// Provides opt-in extension methods for <see cref="RouteHandlerBuilder"/> to attach OpenAPI
+/// metadata to endpoints mapped via <see cref="EndpointRouteBuilderExtensions"/>.
+/// </summary>
+public static class RouteHandlerBuilderExtensions
+{
+    /// <summary>
+    /// Applies an OpenAPI summary derived from the <c>&lt;summary&gt;</c> XML documentation
+    /// comment of <typeparamref name="T"/>. When no XML documentation is found, falls back to
+    /// <c><see langword="typeof"/>(T).Name</c>.
+    /// </summary>
+    /// <typeparam name="T">The type whose XML documentation summary is used.</typeparam>
+    /// <param name="builder">The <see cref="RouteHandlerBuilder"/> to configure.</param>
+    /// <returns>The <paramref name="builder"/> for method chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="builder"/> is <see langword="null"/>.</exception>
+    /// <example>
+    /// <code>
+    /// app.MapCommand&lt;CreateOrderCommand, OrderResult&gt;("/orders")
+    ///     .WithPulseSummary&lt;CreateOrderCommand&gt;();
+    /// </code>
+    /// </example>
+    public static RouteHandlerBuilder WithPulseSummary<T>([NotNull] this RouteHandlerBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        var summary = XmlDocumentationReader.TryGetSummary(typeof(T), out var xmlSummary)
+            ? xmlSummary!
+            : typeof(T).Name;
+
+        return builder.WithSummary(summary);
+    }
+
+    /// <summary>
+    /// Applies an OpenAPI description to the endpoint.
+    /// </summary>
+    /// <param name="builder">The <see cref="RouteHandlerBuilder"/> to configure.</param>
+    /// <param name="description">The description text.</param>
+    /// <returns>The <paramref name="builder"/> for method chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="builder"/> or <paramref name="description"/> is <see langword="null"/>.
+    /// </exception>
+    /// <example>
+    /// <code>
+    /// app.MapCommand&lt;CreateOrderCommand, OrderResult&gt;("/orders")
+    ///     .WithPulseDescription("Creates a new order.");
+    /// </code>
+    /// </example>
+    public static RouteHandlerBuilder WithPulseDescription(
+        [NotNull] this RouteHandlerBuilder builder,
+        [NotNull] string description
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(description);
+
+        return builder.WithDescription(description);
+    }
+
+    /// <summary>
+    /// Applies an OpenAPI tag to the endpoint.
+    /// </summary>
+    /// <param name="builder">The <see cref="RouteHandlerBuilder"/> to configure.</param>
+    /// <param name="tag">The tag name.</param>
+    /// <returns>The <paramref name="builder"/> for method chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="builder"/> or <paramref name="tag"/> is <see langword="null"/>.
+    /// </exception>
+    /// <example>
+    /// <code>
+    /// app.MapCommand&lt;CreateOrderCommand, OrderResult&gt;("/orders")
+    ///     .WithPulseTag("Orders");
+    /// </code>
+    /// </example>
+    public static RouteHandlerBuilder WithPulseTag([NotNull] this RouteHandlerBuilder builder, [NotNull] string tag)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(tag);
+
+        return builder.WithTags(tag);
+    }
+
+    /// <summary>
+    /// Declares that the endpoint produces <typeparamref name="TResponse"/> with status code
+    /// <c>200 OK</c>.
+    /// </summary>
+    /// <typeparam name="TResponse">The response type produced by the endpoint.</typeparam>
+    /// <param name="builder">The <see cref="RouteHandlerBuilder"/> to configure.</param>
+    /// <returns>The <paramref name="builder"/> for method chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="builder"/> is <see langword="null"/>.</exception>
+    /// <example>
+    /// <code>
+    /// app.MapCommand&lt;CreateOrderCommand, OrderResult&gt;("/orders")
+    ///     .WithPulseProduces&lt;OrderResult&gt;();
+    /// </code>
+    /// </example>
+    public static RouteHandlerBuilder WithPulseProduces<TResponse>([NotNull] this RouteHandlerBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        return builder.Produces<TResponse>(StatusCodes.Status200OK);
+    }
+
+    /// <summary>
+    /// Declares that the endpoint produces <c>text/event-stream</c> or <c>application/x-ndjson</c>
+    /// content with status code <c>200 OK</c>, matching the content negotiation performed by
+    /// <see cref="EndpointRouteBuilderExtensions.MapStreamQuery{TQuery, TResponse}"/>.
+    /// </summary>
+    /// <param name="builder">The <see cref="RouteHandlerBuilder"/> to configure.</param>
+    /// <returns>The <paramref name="builder"/> for method chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="builder"/> is <see langword="null"/>.</exception>
+    /// <example>
+    /// <code>
+    /// app.MapStreamQuery&lt;GetOrdersStreamQuery, OrderDto&gt;("/orders/stream")
+    ///     .WithPulseStreamProduces();
+    /// </code>
+    /// </example>
+    public static RouteHandlerBuilder WithPulseStreamProduces([NotNull] this RouteHandlerBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        _ = builder.Produces(StatusCodes.Status200OK, contentType: "text/event-stream");
+
+        return builder.Produces(StatusCodes.Status200OK, contentType: "application/x-ndjson");
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/AspNetCore/AuditInspectorEndpointsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/AspNetCore/AuditInspectorEndpointsTests.cs
@@ -1,0 +1,301 @@
+namespace NetEvolve.Pulse.Tests.Unit.AspNetCore;
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility.Audit;
+using TUnit.Core;
+using PulseEndpoints = AuditInspectorEndpoints;
+
+[TestGroup("AspNetCore")]
+public sealed class AuditInspectorEndpointsTests
+{
+    // MapAuditInspector — null-argument guard
+
+    [Test]
+    public void MapAuditInspector_WithNullEndpoints_ThrowsArgumentNullException() =>
+        _ = Assert.Throws<ArgumentNullException>(() => PulseEndpoints.MapAuditInspector(null!));
+
+    // MapAuditInspector — default registration
+
+    [Test]
+    public async Task MapAuditInspector_ReturnsEndpointConventionBuilder()
+    {
+        var endpoints = WebApplication.CreateBuilder().Build();
+        await using (endpoints.ConfigureAwait(false))
+        {
+            var builder = endpoints.MapAuditInspector();
+
+            _ = await Assert.That(builder).IsNotNull();
+        }
+    }
+
+    // GET {base}/stats
+
+    [Test]
+    public async Task GetStatistics_ReturnsOkWithMockedStatistics(CancellationToken cancellationToken)
+    {
+        var statistics = new AuditStatistics(3, 2);
+
+        var mock = Mock.Of<IAuditManagement>();
+        _ = mock.GetStatisticsAsync(Arg.Any<CancellationToken>()).Returns(statistics);
+
+        using var host = await CreateTestHostAsync(mock.Object, null, cancellationToken).ConfigureAwait(false);
+        var client = host.GetTestClient();
+
+        using var response = await client
+            .GetAsync(new Uri("/pulse/audit/stats", UriKind.Relative), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var payload = await response
+            .Content.ReadFromJsonAsync<AuditStatistics>(cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(payload).IsNotNull();
+        _ = await Assert.That(payload!.SuccessCount).IsEqualTo(3);
+        _ = await Assert.That(payload.FailureCount).IsEqualTo(2);
+        _ = await Assert.That(payload.TotalCount).IsEqualTo(5);
+    }
+
+    // GET {base}/entries — no filter
+
+    [Test]
+    public async Task GetEntries_ReturnsOkWithMockedList(CancellationToken cancellationToken)
+    {
+        var recordId = Guid.NewGuid();
+        var records = new[]
+        {
+            new AuditRecord
+            {
+                Id = recordId,
+                CommandType = "TestCommand",
+                Result = AuditResult.Success,
+            },
+        };
+
+        var mock = Mock.Of<IAuditManagement>();
+        _ = mock.QueryAsync(Arg.Any<AuditFilter>(), Arg.Any<CancellationToken>()).Returns(records);
+
+        using var host = await CreateTestHostAsync(mock.Object, null, cancellationToken).ConfigureAwait(false);
+        var client = host.GetTestClient();
+
+        using var response = await client
+            .GetAsync(new Uri("/pulse/audit/entries", UriKind.Relative), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<AuditRecord[]>(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(payload).IsNotNull();
+        _ = await Assert.That(payload!.Length).IsEqualTo(1);
+        _ = await Assert.That(payload[0].Id).IsEqualTo(recordId);
+    }
+
+    // GET {base}/entries — filter parameter binding
+
+    [Test]
+    public async Task GetEntries_WithCommandTypeFilter_BindsCommandTypeOntoFilter(CancellationToken cancellationToken)
+    {
+        var mock = Mock.Of<IAuditManagement>();
+        _ = mock.QueryAsync(Arg.Is<AuditFilter>(f => f?.CommandType == "MyCommand"), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<AuditRecord>());
+
+        using var host = await CreateTestHostAsync(mock.Object, null, cancellationToken).ConfigureAwait(false);
+        var client = host.GetTestClient();
+
+        using var response = await client
+            .GetAsync(new Uri("/pulse/audit/entries?commandType=MyCommand", UriKind.Relative), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task GetEntries_WithUserIdFilter_BindsUserIdOntoFilter(CancellationToken cancellationToken)
+    {
+        var mock = Mock.Of<IAuditManagement>();
+        _ = mock.QueryAsync(Arg.Is<AuditFilter>(f => f?.UserId == "user-42"), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<AuditRecord>());
+
+        using var host = await CreateTestHostAsync(mock.Object, null, cancellationToken).ConfigureAwait(false);
+        var client = host.GetTestClient();
+
+        using var response = await client
+            .GetAsync(new Uri("/pulse/audit/entries?userId=user-42", UriKind.Relative), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task GetEntries_WithFromFilter_BindsFromOntoFilter(CancellationToken cancellationToken)
+    {
+        var from = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        var mock = Mock.Of<IAuditManagement>();
+        _ = mock.QueryAsync(Arg.Is<AuditFilter>(f => f?.From == from), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<AuditRecord>());
+
+        using var host = await CreateTestHostAsync(mock.Object, null, cancellationToken).ConfigureAwait(false);
+        var client = host.GetTestClient();
+
+        using var response = await client
+            .GetAsync(
+                new Uri($"/pulse/audit/entries?from={Uri.EscapeDataString(from.ToString("O"))}", UriKind.Relative),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task GetEntries_WithToFilter_BindsToOntoFilter(CancellationToken cancellationToken)
+    {
+        var to = new DateTimeOffset(2026, 2, 1, 0, 0, 0, TimeSpan.Zero);
+
+        var mock = Mock.Of<IAuditManagement>();
+        _ = mock.QueryAsync(Arg.Is<AuditFilter>(f => f?.To == to), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<AuditRecord>());
+
+        using var host = await CreateTestHostAsync(mock.Object, null, cancellationToken).ConfigureAwait(false);
+        var client = host.GetTestClient();
+
+        using var response = await client
+            .GetAsync(
+                new Uri($"/pulse/audit/entries?to={Uri.EscapeDataString(to.ToString("O"))}", UriKind.Relative),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task GetEntries_WithResultFilter_BindsResultOntoFilter(CancellationToken cancellationToken)
+    {
+        var mock = Mock.Of<IAuditManagement>();
+        _ = mock.QueryAsync(Arg.Is<AuditFilter>(f => f?.Result == AuditResult.Failure), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<AuditRecord>());
+
+        using var host = await CreateTestHostAsync(mock.Object, null, cancellationToken).ConfigureAwait(false);
+        var client = host.GetTestClient();
+
+        using var response = await client
+            .GetAsync(new Uri("/pulse/audit/entries?result=Failure", UriKind.Relative), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task GetEntries_WithTakeFilter_BindsTakeOntoFilter(CancellationToken cancellationToken)
+    {
+        var mock = Mock.Of<IAuditManagement>();
+        _ = mock.QueryAsync(Arg.Is<AuditFilter>(f => f?.Take == 10), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<AuditRecord>());
+
+        using var host = await CreateTestHostAsync(mock.Object, null, cancellationToken).ConfigureAwait(false);
+        var client = host.GetTestClient();
+
+        using var response = await client
+            .GetAsync(new Uri("/pulse/audit/entries?take=10", UriKind.Relative), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task GetEntries_WithSkipFilter_BindsSkipOntoFilter(CancellationToken cancellationToken)
+    {
+        var mock = Mock.Of<IAuditManagement>();
+        _ = mock.QueryAsync(Arg.Is<AuditFilter>(f => f?.Skip == 20), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<AuditRecord>());
+
+        using var host = await CreateTestHostAsync(mock.Object, null, cancellationToken).ConfigureAwait(false);
+        var client = host.GetTestClient();
+
+        using var response = await client
+            .GetAsync(new Uri("/pulse/audit/entries?skip=20", UriKind.Relative), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+    }
+
+    // MapAuditInspector — custom BasePath applied correctly
+
+    [Test]
+    public async Task MapAuditInspector_WithCustomBasePath_UsesConfiguredPrefix(CancellationToken cancellationToken)
+    {
+        var statistics = new AuditStatistics(1, 0);
+
+        var mock = Mock.Of<IAuditManagement>();
+        _ = mock.GetStatisticsAsync(Arg.Any<CancellationToken>()).Returns(statistics);
+
+        using var host = await CreateTestHostAsync(
+                mock.Object,
+                options => options.BasePath = "/admin/audit",
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+        var client = host.GetTestClient();
+
+        using var defaultPathResponse = await client
+            .GetAsync(new Uri("/pulse/audit/stats", UriKind.Relative), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(defaultPathResponse.StatusCode).IsEqualTo(HttpStatusCode.NotFound);
+
+        using var customPathResponse = await client
+            .GetAsync(new Uri("/admin/audit/stats", UriKind.Relative), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(customPathResponse.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var payload = await customPathResponse
+            .Content.ReadFromJsonAsync<AuditStatistics>(cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(payload).IsNotNull();
+        _ = await Assert.That(payload!.SuccessCount).IsEqualTo(1);
+    }
+
+    private static async Task<IHost> CreateTestHostAsync(
+        IAuditManagement auditManagement,
+        Action<AuditInspectorOptions>? configure,
+        CancellationToken cancellationToken
+    )
+    {
+        var host = new HostBuilder()
+            .ConfigureWebHost(webBuilder =>
+            {
+                _ = webBuilder.UseTestServer();
+                _ = webBuilder.ConfigureServices(services =>
+                {
+                    _ = services.AddRouting();
+                    _ = services.AddSingleton(auditManagement);
+                });
+                _ = webBuilder.Configure(app =>
+                {
+                    _ = app.UseRouting();
+                    _ = app.UseEndpoints(endpoints => endpoints.MapAuditInspector(configure));
+                });
+            })
+            .Build();
+
+        await host.StartAsync(cancellationToken).ConfigureAwait(false);
+        return host;
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/AspNetCore/CommandDeadLetterInspectorEndpointsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/AspNetCore/CommandDeadLetterInspectorEndpointsTests.cs
@@ -1,0 +1,243 @@
+namespace NetEvolve.Pulse.Tests.Unit.AspNetCore;
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+using TUnit.Core;
+using PulseEndpoints = CommandDeadLetterInspectorEndpoints;
+
+[TestGroup("AspNetCore")]
+public sealed class CommandDeadLetterInspectorEndpointsTests
+{
+    // MapCommandDeadLetterInspector — null-argument guard
+
+    [Test]
+    public void MapCommandDeadLetterInspector_WithNullEndpoints_ThrowsArgumentNullException() =>
+        _ = Assert.Throws<ArgumentNullException>(() => PulseEndpoints.MapCommandDeadLetterInspector(null!));
+
+    // MapCommandDeadLetterInspector — default registration
+
+    [Test]
+    public async Task MapCommandDeadLetterInspector_ReturnsEndpointConventionBuilder()
+    {
+        var endpoints = WebApplication.CreateBuilder().Build();
+        await using (endpoints.ConfigureAwait(false))
+        {
+            var builder = endpoints.MapCommandDeadLetterInspector();
+
+            _ = await Assert.That(builder).IsNotNull();
+        }
+    }
+
+    // GET {base}/stats
+
+    [Test]
+    public async Task GetStatistics_ReturnsOkWithMockedStatistics(CancellationToken cancellationToken)
+    {
+        var statistics = new CommandDeadLetterStatistics(
+            NewCount: 1,
+            ReplayingCount: 2,
+            ResolvedCount: 3,
+            DismissedCount: 4
+        );
+
+        var mock = Mock.Of<ICommandDeadLetterManagement>();
+        _ = mock.GetStatisticsAsync(Arg.Any<CancellationToken>()).Returns(statistics);
+
+        using var host = await CreateTestHostAsync(mock.Object, null, cancellationToken).ConfigureAwait(false);
+        var client = host.GetTestClient();
+
+        using var response = await client
+            .GetAsync(new Uri("/pulse/commands/stats", UriKind.Relative), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var payload = await response
+            .Content.ReadFromJsonAsync<CommandDeadLetterStatistics>(cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(payload).IsNotNull();
+        _ = await Assert.That(payload!.NewCount).IsEqualTo(1);
+        _ = await Assert.That(payload.ReplayingCount).IsEqualTo(2);
+        _ = await Assert.That(payload.ResolvedCount).IsEqualTo(3);
+        _ = await Assert.That(payload.DismissedCount).IsEqualTo(4);
+    }
+
+    // GET {base}/entries
+
+    [Test]
+    public async Task GetPendingEntries_ReturnsOkWithMockedList(CancellationToken cancellationToken)
+    {
+        var entryId = Guid.NewGuid();
+        var entries = new[]
+        {
+            new CommandDeadLetterEntry
+            {
+                Id = entryId,
+                CommandType = typeof(string).AssemblyQualifiedName!,
+                Payload = "{}",
+                Status = CommandDeadLetterStatus.New,
+            },
+        };
+
+        var mock = Mock.Of<ICommandDeadLetterManagement>();
+        _ = mock.GetPendingAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(entries);
+
+        using var host = await CreateTestHostAsync(mock.Object, null, cancellationToken).ConfigureAwait(false);
+        var client = host.GetTestClient();
+
+        using var response = await client
+            .GetAsync(new Uri("/pulse/commands/entries", UriKind.Relative), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var payload = await response
+            .Content.ReadFromJsonAsync<CommandDeadLetterEntry[]>(cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(payload).IsNotNull();
+        _ = await Assert.That(payload!.Length).IsEqualTo(1);
+        _ = await Assert.That(payload[0].Id).IsEqualTo(entryId);
+    }
+
+    // GET {base}/entries — respects the count query parameter
+
+    [Test]
+    public async Task GetPendingEntries_WithCountQueryParameter_PassesCountThrough(CancellationToken cancellationToken)
+    {
+        var mock = Mock.Of<ICommandDeadLetterManagement>();
+        _ = mock.GetPendingAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<CommandDeadLetterEntry>());
+
+        using var host = await CreateTestHostAsync(mock.Object, null, cancellationToken).ConfigureAwait(false);
+        var client = host.GetTestClient();
+
+        using var response = await client
+            .GetAsync(new Uri("/pulse/commands/entries?count=7", UriKind.Relative), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        mock.GetPendingAsync(7, Arg.Any<CancellationToken>()).WasCalled(Times.Once);
+    }
+
+    // POST {base}/entries/{id:guid}/replay
+
+    [Test]
+    public async Task ReplayEntry_ReturnsNoContent(CancellationToken cancellationToken)
+    {
+        var entryId = Guid.NewGuid();
+
+        var mock = Mock.Of<ICommandDeadLetterManagement>();
+
+        using var host = await CreateTestHostAsync(mock.Object, null, cancellationToken).ConfigureAwait(false);
+        var client = host.GetTestClient();
+
+        using var response = await client
+            .PostAsync(
+                new Uri($"/pulse/commands/entries/{entryId}/replay", UriKind.Relative),
+                content: null,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.NoContent);
+
+        mock.ReplayAsync(entryId, Arg.Any<CancellationToken>()).WasCalled(Times.Once);
+    }
+
+    // POST {base}/entries/{id:guid}/dismiss
+
+    [Test]
+    public async Task DismissEntry_ReturnsNoContent(CancellationToken cancellationToken)
+    {
+        var entryId = Guid.NewGuid();
+
+        var mock = Mock.Of<ICommandDeadLetterManagement>();
+
+        using var host = await CreateTestHostAsync(mock.Object, null, cancellationToken).ConfigureAwait(false);
+        var client = host.GetTestClient();
+
+        using var response = await client
+            .PostAsync(
+                new Uri($"/pulse/commands/entries/{entryId}/dismiss", UriKind.Relative),
+                content: null,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.NoContent);
+
+        mock.DismissAsync(entryId, Arg.Any<CancellationToken>()).WasCalled(Times.Once);
+    }
+
+    // MapCommandDeadLetterInspector — custom BasePath applied correctly
+
+    [Test]
+    public async Task MapCommandDeadLetterInspector_WithCustomBasePath_UsesConfiguredPrefix(
+        CancellationToken cancellationToken
+    )
+    {
+        var mock = Mock.Of<ICommandDeadLetterManagement>();
+        _ = mock.GetStatisticsAsync(Arg.Any<CancellationToken>()).Returns(new CommandDeadLetterStatistics(0, 0, 0, 0));
+
+        using var host = await CreateTestHostAsync(
+                mock.Object,
+                options => options.BasePath = "/admin/commands",
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+        var client = host.GetTestClient();
+
+        using var defaultPathResponse = await client
+            .GetAsync(new Uri("/pulse/commands/stats", UriKind.Relative), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(defaultPathResponse.StatusCode).IsEqualTo(HttpStatusCode.NotFound);
+
+        using var customPathResponse = await client
+            .GetAsync(new Uri("/admin/commands/stats", UriKind.Relative), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(customPathResponse.StatusCode).IsEqualTo(HttpStatusCode.OK);
+    }
+
+    private static async Task<IHost> CreateTestHostAsync(
+        ICommandDeadLetterManagement commandDeadLetterManagement,
+        Action<CommandDeadLetterInspectorOptions>? configure,
+        CancellationToken cancellationToken
+    )
+    {
+        var host = new HostBuilder()
+            .ConfigureWebHost(webBuilder =>
+            {
+                _ = webBuilder.UseTestServer();
+                _ = webBuilder.ConfigureServices(services =>
+                {
+                    _ = services.AddRouting();
+                    _ = services.AddSingleton(commandDeadLetterManagement);
+                });
+                _ = webBuilder.Configure(app =>
+                {
+                    _ = app.UseRouting();
+                    _ = app.UseEndpoints(endpoints => endpoints.MapCommandDeadLetterInspector(configure));
+                });
+            })
+            .Build();
+
+        await host.StartAsync(cancellationToken).ConfigureAwait(false);
+        return host;
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/AspNetCore/EndpointRouteBuilderExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/AspNetCore/EndpointRouteBuilderExtensionsTests.cs
@@ -535,25 +535,25 @@ public sealed class EndpointRouteBuilderExtensionsTests
         return host;
     }
 
-    private sealed record TestCommand(string Value) : ICommand<string>
+    internal sealed record TestCommand(string Value) : ICommand<string>
     {
         public string? CausationId { get; set; }
         public string? CorrelationId { get; set; }
     }
 
-    private sealed record VoidTestCommand(string Value) : ICommand
+    internal sealed record VoidTestCommand(string Value) : ICommand
     {
         public string? CausationId { get; set; }
         public string? CorrelationId { get; set; }
     }
 
-    private sealed record TestQuery(string Id) : IQuery<string>
+    internal sealed record TestQuery(string Id) : IQuery<string>
     {
         public string? CausationId { get; set; }
         public string? CorrelationId { get; set; }
     }
 
-    private sealed record TestStreamQuery : IStreamQuery<string>
+    internal sealed record TestStreamQuery : IStreamQuery<string>
     {
         public string? CausationId { get; set; }
         public string? CorrelationId { get; set; }

--- a/tests/NetEvolve.Pulse.Tests.Unit/AspNetCore/OpenApiMediatorBuilderExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/AspNetCore/OpenApiMediatorBuilderExtensionsTests.cs
@@ -1,0 +1,147 @@
+namespace NetEvolve.Pulse.Tests.Unit.AspNetCore;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility;
+using TUnit.Core;
+
+[TestGroup("AspNetCore")]
+public sealed class OpenApiMediatorBuilderExtensionsTests
+{
+    [Test]
+    public void EnableOpenApiMetadata_WithNullBuilder_ThrowsArgumentNullException() =>
+        _ = Assert.Throws<ArgumentNullException>(() => OpenApiMediatorBuilderExtensions.EnableOpenApiMetadata(null!));
+
+    [Test]
+    public async Task EnableOpenApiMetadata_SetsOpenApiMetadataEnabledOnOptions()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddPulse(builder => builder.EnableOpenApiMetadata());
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<AspNetCoreOptions>>();
+
+        _ = await Assert.That(options.Value.OpenApiMetadataEnabled).IsTrue();
+    }
+
+    [Test]
+    public async Task EnableOpenApiMetadata_WhenNotCalled_OptionsDefaultToDisabled()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddPulse(_ => { });
+
+        using var provider = services.BuildServiceProvider();
+
+        // Mirrors the production consumption in EndpointRouteBuilderExtensions: when
+        // EnableOpenApiMetadata() was never called, nothing registered IOptions<AspNetCoreOptions>,
+        // so it resolves to null and metadata application is skipped (treated as disabled).
+        var options = provider.GetService<IOptions<AspNetCoreOptions>>();
+
+        _ = await Assert.That(options?.Value.OpenApiMetadataEnabled ?? false).IsFalse();
+    }
+
+    [Test]
+    public async Task EnableOpenApiMetadata_MapCommandWithResponse_AutoAppliesSummaryAndProduces()
+    {
+        var builder = WebApplication.CreateBuilder();
+        _ = builder.Services.AddPulse(b => b.EnableOpenApiMetadata());
+        var app = builder.Build();
+
+        await using (app.ConfigureAwait(false))
+        {
+            _ = app.MapCommand<EndpointRouteBuilderExtensionsTests.TestCommand, string>("/commands");
+
+            IEndpointRouteBuilder endpoints = app;
+            var endpoint = endpoints
+                .DataSources.SelectMany(dataSource => dataSource.Endpoints)
+                .Single(e => ((RouteEndpoint)e).RoutePattern.RawText == "/commands");
+
+            var summary = endpoint.Metadata.GetMetadata<IEndpointSummaryMetadata>();
+            var produces = endpoint.Metadata.OfType<IProducesResponseTypeMetadata>().ToList();
+
+            _ = await Assert.That(summary?.Summary).IsEqualTo(nameof(EndpointRouteBuilderExtensionsTests.TestCommand));
+            _ = await Assert.That(produces.Any(p => p.Type == typeof(string))).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task EnableOpenApiMetadata_MapQuery_AutoAppliesSummaryAndProduces()
+    {
+        var builder = WebApplication.CreateBuilder();
+        _ = builder.Services.AddPulse(b => b.EnableOpenApiMetadata());
+        var app = builder.Build();
+
+        await using (app.ConfigureAwait(false))
+        {
+            _ = app.MapQuery<EndpointRouteBuilderExtensionsTests.TestQuery, string>("/queries/{id}");
+
+            IEndpointRouteBuilder endpoints = app;
+            var endpoint = endpoints
+                .DataSources.SelectMany(dataSource => dataSource.Endpoints)
+                .Single(e => ((RouteEndpoint)e).RoutePattern.RawText == "/queries/{id}");
+
+            var summary = endpoint.Metadata.GetMetadata<IEndpointSummaryMetadata>();
+            var produces = endpoint.Metadata.OfType<IProducesResponseTypeMetadata>().ToList();
+
+            _ = await Assert.That(summary?.Summary).IsEqualTo(nameof(EndpointRouteBuilderExtensionsTests.TestQuery));
+            _ = await Assert.That(produces.Any(p => p.Type == typeof(string))).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task EnableOpenApiMetadata_MapStreamQuery_AutoAppliesSummaryAndStreamProduces()
+    {
+        var builder = WebApplication.CreateBuilder();
+        _ = builder.Services.AddPulse(b => b.EnableOpenApiMetadata());
+        var app = builder.Build();
+
+        await using (app.ConfigureAwait(false))
+        {
+            _ = app.MapStreamQuery<EndpointRouteBuilderExtensionsTests.TestStreamQuery, string>("/queries/stream");
+
+            IEndpointRouteBuilder endpoints = app;
+            var endpoint = endpoints
+                .DataSources.SelectMany(dataSource => dataSource.Endpoints)
+                .Single(e => ((RouteEndpoint)e).RoutePattern.RawText == "/queries/stream");
+
+            var summary = endpoint.Metadata.GetMetadata<IEndpointSummaryMetadata>();
+            var produces = endpoint.Metadata.OfType<IProducesResponseTypeMetadata>().ToList();
+            var contentTypes = produces.SelectMany(p => p.ContentTypes).ToList();
+
+            _ = await Assert
+                .That(summary?.Summary)
+                .IsEqualTo(nameof(EndpointRouteBuilderExtensionsTests.TestStreamQuery));
+            _ = await Assert.That(contentTypes).Contains("text/event-stream");
+            _ = await Assert.That(contentTypes).Contains("application/x-ndjson");
+        }
+    }
+
+    [Test]
+    public async Task WithoutEnableOpenApiMetadata_MapCommand_DoesNotApplyMetadata()
+    {
+        var builder = WebApplication.CreateBuilder();
+        _ = builder.Services.AddPulse(_ => { });
+        var app = builder.Build();
+
+        await using (app.ConfigureAwait(false))
+        {
+            _ = app.MapCommand<EndpointRouteBuilderExtensionsTests.VoidTestCommand>("/commands/void");
+
+            IEndpointRouteBuilder endpoints = app;
+            var endpoint = endpoints
+                .DataSources.SelectMany(dataSource => dataSource.Endpoints)
+                .Single(e => ((RouteEndpoint)e).RoutePattern.RawText == "/commands/void");
+
+            var summary = endpoint.Metadata.GetMetadata<IEndpointSummaryMetadata>();
+
+            _ = await Assert.That(summary).IsNull();
+        }
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/AspNetCore/OutboxInspectorEndpointsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/AspNetCore/OutboxInspectorEndpointsTests.cs
@@ -1,0 +1,340 @@
+namespace NetEvolve.Pulse.Tests.Unit.AspNetCore;
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.Extensibility.Outbox;
+using TUnit.Core;
+using PulseEndpoints = OutboxInspectorEndpoints;
+
+[TestGroup("AspNetCore")]
+public sealed class OutboxInspectorEndpointsTests
+{
+    // MapOutboxInspector — null-argument guard
+
+    [Test]
+    public void MapOutboxInspector_WithNullEndpoints_ThrowsArgumentNullException() =>
+        _ = Assert.Throws<ArgumentNullException>(() => PulseEndpoints.MapOutboxInspector(null!));
+
+    // MapOutboxInspector — default registration
+
+    [Test]
+    public async Task MapOutboxInspector_ReturnsEndpointConventionBuilder()
+    {
+        var endpoints = WebApplication.CreateBuilder().Build();
+        await using (endpoints.ConfigureAwait(false))
+        {
+            var builder = endpoints.MapOutboxInspector();
+
+            _ = await Assert.That(builder).IsNotNull();
+        }
+    }
+
+    // GET {base}/stats
+
+    [Test]
+    public async Task GetStatistics_ReturnsOkWithMockedStatistics(CancellationToken cancellationToken)
+    {
+        var statistics = new OutboxStatistics
+        {
+            Pending = 1,
+            Processing = 2,
+            Completed = 3,
+            Failed = 4,
+            DeadLetter = 5,
+        };
+
+        var mock = Mock.Of<IOutboxManagement>();
+        _ = mock.GetStatisticsAsync(Arg.Any<CancellationToken>()).Returns(statistics);
+
+        using var host = await CreateTestHostAsync(mock.Object, null, cancellationToken).ConfigureAwait(false);
+        var client = host.GetTestClient();
+
+        using var response = await client
+            .GetAsync(new Uri("/pulse/outbox/stats", UriKind.Relative), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var payload = await response
+            .Content.ReadFromJsonAsync<OutboxStatistics>(cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(payload).IsNotNull();
+        _ = await Assert.That(payload!.Pending).IsEqualTo(1);
+        _ = await Assert.That(payload.Processing).IsEqualTo(2);
+        _ = await Assert.That(payload.Completed).IsEqualTo(3);
+        _ = await Assert.That(payload.Failed).IsEqualTo(4);
+        _ = await Assert.That(payload.DeadLetter).IsEqualTo(5);
+    }
+
+    // GET {base}/dead-letters
+
+    [Test]
+    public async Task GetDeadLetterMessages_ReturnsOkWithMockedList(CancellationToken cancellationToken)
+    {
+        var messageId = Guid.NewGuid();
+        var messages = new[]
+        {
+            new OutboxMessage
+            {
+                Id = messageId,
+                EventType = typeof(string),
+                Payload = "{}",
+                Status = OutboxMessageStatus.DeadLetter,
+            },
+        };
+
+        var mock = Mock.Of<IOutboxManagement>();
+        _ = mock.GetDeadLetterMessagesAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(messages);
+
+        using var host = await CreateTestHostAsync(mock.Object, null, cancellationToken).ConfigureAwait(false);
+        var client = host.GetTestClient();
+
+        using var response = await client
+            .GetAsync(new Uri("/pulse/outbox/dead-letters", UriKind.Relative), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var payload = await response
+            .Content.ReadFromJsonAsync<OutboxMessageResponse[]>(cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(payload).IsNotNull();
+        _ = await Assert.That(payload!.Length).IsEqualTo(1);
+        _ = await Assert.That(payload[0].Id).IsEqualTo(messageId);
+        _ = await Assert.That(payload[0].EventType).IsEqualTo(typeof(string).ToOutboxEventTypeName());
+    }
+
+    // GET {base}/dead-letters/count
+
+    [Test]
+    public async Task GetDeadLetterCount_ReturnsOkWithMockedCount(CancellationToken cancellationToken)
+    {
+        var mock = Mock.Of<IOutboxManagement>();
+        _ = mock.GetDeadLetterCountAsync(Arg.Any<CancellationToken>()).Returns(42L);
+
+        using var host = await CreateTestHostAsync(mock.Object, null, cancellationToken).ConfigureAwait(false);
+        var client = host.GetTestClient();
+
+        using var response = await client
+            .GetAsync(new Uri("/pulse/outbox/dead-letters/count", UriKind.Relative), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<long>(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(payload).IsEqualTo(42L);
+    }
+
+    // GET {base}/dead-letters/{id:guid} — found
+
+    [Test]
+    public async Task GetDeadLetterMessage_WhenFound_ReturnsOkWithMockedMessage(CancellationToken cancellationToken)
+    {
+        var messageId = Guid.NewGuid();
+        var message = new OutboxMessage
+        {
+            Id = messageId,
+            EventType = typeof(string),
+            Payload = "{}",
+            Status = OutboxMessageStatus.DeadLetter,
+        };
+
+        var mock = Mock.Of<IOutboxManagement>();
+        _ = mock.GetDeadLetterMessageAsync(messageId, Arg.Any<CancellationToken>()).Returns(message);
+
+        using var host = await CreateTestHostAsync(mock.Object, null, cancellationToken).ConfigureAwait(false);
+        var client = host.GetTestClient();
+
+        using var response = await client
+            .GetAsync(new Uri($"/pulse/outbox/dead-letters/{messageId}", UriKind.Relative), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var payload = await response
+            .Content.ReadFromJsonAsync<OutboxMessageResponse>(cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(payload).IsNotNull();
+        _ = await Assert.That(payload!.Id).IsEqualTo(messageId);
+        _ = await Assert.That(payload.EventType).IsEqualTo(typeof(string).ToOutboxEventTypeName());
+    }
+
+    // GET {base}/dead-letters/{id:guid} — not found
+
+    [Test]
+    public async Task GetDeadLetterMessage_WhenNotFound_ReturnsNotFound(CancellationToken cancellationToken)
+    {
+        var messageId = Guid.NewGuid();
+
+        var mock = Mock.Of<IOutboxManagement>();
+        _ = mock.GetDeadLetterMessageAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns((OutboxMessage?)null);
+
+        using var host = await CreateTestHostAsync(mock.Object, null, cancellationToken).ConfigureAwait(false);
+        var client = host.GetTestClient();
+
+        using var response = await client
+            .GetAsync(new Uri($"/pulse/outbox/dead-letters/{messageId}", UriKind.Relative), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.NotFound);
+    }
+
+    // POST {base}/dead-letters/{id:guid}/replay — success
+
+    [Test]
+    public async Task ReplayMessage_WhenSucceeds_ReturnsNoContent(CancellationToken cancellationToken)
+    {
+        var messageId = Guid.NewGuid();
+
+        var mock = Mock.Of<IOutboxManagement>();
+        _ = mock.ReplayMessageAsync(messageId, Arg.Any<CancellationToken>()).Returns(true);
+
+        using var host = await CreateTestHostAsync(mock.Object, null, cancellationToken).ConfigureAwait(false);
+        var client = host.GetTestClient();
+
+        using var response = await client
+            .PostAsync(
+                new Uri($"/pulse/outbox/dead-letters/{messageId}/replay", UriKind.Relative),
+                content: null,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.NoContent);
+    }
+
+    // POST {base}/dead-letters/{id:guid}/replay — not found
+
+    [Test]
+    public async Task ReplayMessage_WhenNotFound_ReturnsNotFound(CancellationToken cancellationToken)
+    {
+        var messageId = Guid.NewGuid();
+
+        var mock = Mock.Of<IOutboxManagement>();
+        _ = mock.ReplayMessageAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(false);
+
+        using var host = await CreateTestHostAsync(mock.Object, null, cancellationToken).ConfigureAwait(false);
+        var client = host.GetTestClient();
+
+        using var response = await client
+            .PostAsync(
+                new Uri($"/pulse/outbox/dead-letters/{messageId}/replay", UriKind.Relative),
+                content: null,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.NotFound);
+    }
+
+    // POST {base}/dead-letters/replay-all
+
+    [Test]
+    public async Task ReplayAllDeadLetter_ReturnsOkWithMockedCount(CancellationToken cancellationToken)
+    {
+        var mock = Mock.Of<IOutboxManagement>();
+        _ = mock.ReplayAllDeadLetterAsync(Arg.Any<CancellationToken>()).Returns(7);
+
+        using var host = await CreateTestHostAsync(mock.Object, null, cancellationToken).ConfigureAwait(false);
+        var client = host.GetTestClient();
+
+        using var response = await client
+            .PostAsync(
+                new Uri("/pulse/outbox/dead-letters/replay-all", UriKind.Relative),
+                content: null,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var payload = await response
+            .Content.ReadFromJsonAsync<ReplayAllResponse>(cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(payload).IsNotNull();
+        _ = await Assert.That(payload!.Count).IsEqualTo(7);
+    }
+
+    // MapOutboxInspector — custom BasePath applied correctly
+
+    [Test]
+    public async Task MapOutboxInspector_WithCustomBasePath_UsesConfiguredPrefix(CancellationToken cancellationToken)
+    {
+        var mock = Mock.Of<IOutboxManagement>();
+        _ = mock.GetDeadLetterCountAsync(Arg.Any<CancellationToken>()).Returns(3L);
+
+        using var host = await CreateTestHostAsync(
+                mock.Object,
+                options => options.BasePath = "/admin/outbox",
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+        var client = host.GetTestClient();
+
+        using var defaultPathResponse = await client
+            .GetAsync(new Uri("/pulse/outbox/dead-letters/count", UriKind.Relative), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(defaultPathResponse.StatusCode).IsEqualTo(HttpStatusCode.NotFound);
+
+        using var customPathResponse = await client
+            .GetAsync(new Uri("/admin/outbox/dead-letters/count", UriKind.Relative), cancellationToken)
+            .ConfigureAwait(false);
+
+        _ = await Assert.That(customPathResponse.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var payload = await customPathResponse.Content.ReadFromJsonAsync<long>(cancellationToken).ConfigureAwait(false);
+
+        _ = await Assert.That(payload).IsEqualTo(3L);
+    }
+
+    private static async Task<IHost> CreateTestHostAsync(
+        IOutboxManagement outboxManagement,
+        Action<OutboxInspectorOptions>? configure,
+        CancellationToken cancellationToken
+    )
+    {
+        var host = new HostBuilder()
+            .ConfigureWebHost(webBuilder =>
+            {
+                _ = webBuilder.UseTestServer();
+                _ = webBuilder.ConfigureServices(services =>
+                {
+                    _ = services.AddRouting();
+                    _ = services.AddSingleton(outboxManagement);
+                });
+                _ = webBuilder.Configure(app =>
+                {
+                    _ = app.UseRouting();
+                    _ = app.UseEndpoints(endpoints => endpoints.MapOutboxInspector(configure));
+                });
+            })
+            .Build();
+
+        await host.StartAsync(cancellationToken).ConfigureAwait(false);
+        return host;
+    }
+
+    private sealed record ReplayAllResponse(int Count);
+
+    // The wire shape of OutboxMessage as written by the outbox inspector, where EventType is
+    // serialized as its outbox event type identifier string (see TypeJsonConverter), rather than
+    // the raw System.Type on the domain model, which System.Text.Json cannot serialize.
+    private sealed record OutboxMessageResponse(Guid Id, string EventType);
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/AspNetCore/RouteHandlerBuilderExtensionsTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/AspNetCore/RouteHandlerBuilderExtensionsTests.cs
@@ -1,0 +1,174 @@
+namespace NetEvolve.Pulse.Tests.Unit.AspNetCore;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Routing;
+using NetEvolve.Extensions.TUnit;
+using TUnit.Core;
+
+[TestGroup("AspNetCore")]
+public sealed class RouteHandlerBuilderExtensionsTests
+{
+    // WithPulseSummary<T> — null-guard
+
+    [Test]
+    public async Task WithPulseSummary_WithNullBuilder_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() => RouteHandlerBuilderExtensions.WithPulseSummary<TestDocumentedType>(null!))
+            .Throws<ArgumentNullException>();
+
+    // WithPulseSummary<T> — behavior
+
+    [Test]
+    public async Task WithPulseSummary_WithoutXmlDocumentation_FallsBackToTypeName()
+    {
+        var summary = await MapAndGetMetadataAsync<IEndpointSummaryMetadata>(builder =>
+            builder.WithPulseSummary<TestDocumentedType>()
+        );
+
+        _ = await Assert.That(summary?.Summary).IsEqualTo(nameof(TestDocumentedType));
+    }
+
+    // WithPulseDescription — null-guards
+
+    [Test]
+    public async Task WithPulseDescription_WithNullBuilder_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() => RouteHandlerBuilderExtensions.WithPulseDescription(null!, "description"))
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task WithPulseDescription_WithNullDescription_ThrowsArgumentNullException()
+    {
+        await using var app = CreateApp();
+
+        _ = await Assert
+            .That(() => app.MapGet("/test", () => "ok").WithPulseDescription(null!))
+            .Throws<ArgumentNullException>();
+    }
+
+    // WithPulseDescription — behavior
+
+    [Test]
+    public async Task WithPulseDescription_AppliesDescriptionMetadata()
+    {
+        var description = await MapAndGetMetadataAsync<IEndpointDescriptionMetadata>(builder =>
+            builder.WithPulseDescription("A description.")
+        );
+
+        _ = await Assert.That(description?.Description).IsEqualTo("A description.");
+    }
+
+    // WithPulseTag — null-guards
+
+    [Test]
+    public async Task WithPulseTag_WithNullBuilder_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() => RouteHandlerBuilderExtensions.WithPulseTag(null!, "tag"))
+            .Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task WithPulseTag_WithNullTag_ThrowsArgumentNullException()
+    {
+        await using var app = CreateApp();
+
+        _ = await Assert
+            .That(() => app.MapGet("/test", () => "ok").WithPulseTag(null!))
+            .Throws<ArgumentNullException>();
+    }
+
+    // WithPulseTag — behavior
+
+    [Test]
+    public async Task WithPulseTag_AppliesTagMetadata()
+    {
+        var tags = await MapAndGetMetadataAsync<ITagsMetadata>(builder => builder.WithPulseTag("Orders"));
+
+        _ = await Assert.That(tags?.Tags.Contains("Orders")).IsTrue();
+    }
+
+    // WithPulseProduces<TResponse> — null-guard
+
+    [Test]
+    public async Task WithPulseProduces_WithNullBuilder_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() => RouteHandlerBuilderExtensions.WithPulseProduces<string>(null!))
+            .Throws<ArgumentNullException>();
+
+    // WithPulseProduces<TResponse> — behavior
+
+    [Test]
+    public async Task WithPulseProduces_AppliesProducesResponseTypeMetadata()
+    {
+        var metadata = await MapAndGetMetadataListAsync<IProducesResponseTypeMetadata>(builder =>
+            builder.WithPulseProduces<string>()
+        );
+
+        _ = await Assert
+            .That(metadata.Any(m => m.StatusCode == StatusCodes.Status200OK && m.Type == typeof(string)))
+            .IsTrue();
+    }
+
+    // WithPulseStreamProduces — null-guard
+
+    [Test]
+    public async Task WithPulseStreamProduces_WithNullBuilder_ThrowsArgumentNullException() =>
+        _ = await Assert
+            .That(() => RouteHandlerBuilderExtensions.WithPulseStreamProduces(null!))
+            .Throws<ArgumentNullException>();
+
+    // WithPulseStreamProduces — behavior
+
+    [Test]
+    public async Task WithPulseStreamProduces_AppliesBothStreamContentTypes()
+    {
+        var metadata = await MapAndGetMetadataListAsync<IProducesResponseTypeMetadata>(builder =>
+            builder.WithPulseStreamProduces()
+        );
+
+        var contentTypes = metadata
+            .Where(m => m.StatusCode == StatusCodes.Status200OK)
+            .SelectMany(m => m.ContentTypes)
+            .ToList();
+
+        _ = await Assert.That(contentTypes).Contains("text/event-stream");
+        _ = await Assert.That(contentTypes).Contains("application/x-ndjson");
+    }
+
+    private static WebApplication CreateApp() => WebApplication.CreateBuilder().Build();
+
+    private static async Task<TMetadata?> MapAndGetMetadataAsync<TMetadata>(
+        Func<RouteHandlerBuilder, RouteHandlerBuilder> configure
+    )
+        where TMetadata : class
+    {
+        var list = await MapAndGetMetadataListAsync<TMetadata>(configure).ConfigureAwait(false);
+        return list.LastOrDefault();
+    }
+
+    private static async Task<List<TMetadata>> MapAndGetMetadataListAsync<TMetadata>(
+        Func<RouteHandlerBuilder, RouteHandlerBuilder> configure
+    )
+        where TMetadata : class
+    {
+        await using var app = CreateApp();
+
+        _ = configure(app.MapGet("/test", () => "ok"));
+
+        IEndpointRouteBuilder endpoints = app;
+        var endpoint = endpoints
+            .DataSources.SelectMany(dataSource => dataSource.Endpoints)
+            .Single(e => ((RouteEndpoint)e).RoutePattern.RawText == "/test");
+
+        return endpoint.Metadata.OfType<TMetadata>().ToList();
+    }
+
+#pragma warning disable S2094 // Empty type intentionally used only to exercise the typeof(T).Name fallback.
+    private sealed class TestDocumentedType;
+#pragma warning restore S2094
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/AspNetCore/XmlDocumentationReaderTests.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/AspNetCore/XmlDocumentationReaderTests.cs
@@ -1,0 +1,90 @@
+namespace NetEvolve.Pulse.Tests.Unit.AspNetCore;
+
+using System;
+using System.IO;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.Pulse.AspNetCore.Internals;
+using TUnit.Core;
+
+[TestGroup("AspNetCore")]
+public sealed class XmlDocumentationReaderTests
+{
+    [Test]
+    public async Task LoadDocumentation_WithExistingFileAndKnownMember_ReturnsSummary()
+    {
+        var path = CreateTempXmlDocumentationFile("T:Some.Namespace.SomeType", "Test summary.");
+
+        try
+        {
+            var members = XmlDocumentationReader.LoadDocumentation(path);
+
+            _ = await Assert.That(members).IsNotNull();
+            _ = await Assert.That(members!["T:Some.Namespace.SomeType"]).IsEqualTo("Test summary.");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task LoadDocumentation_WithMissingFile_ReturnsNull()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.xml");
+
+        var members = XmlDocumentationReader.LoadDocumentation(path);
+
+        _ = await Assert.That(members).IsNull();
+    }
+
+    [Test]
+    public async Task LoadDocumentation_WithSameFileTwiceAfterDeletion_UsesCachedResult()
+    {
+        var path = CreateTempXmlDocumentationFile("T:Some.Namespace.CachedType", "Cached summary.");
+
+        var firstResult = XmlDocumentationReader.LoadDocumentation(path);
+        File.Delete(path);
+
+        var secondResult = XmlDocumentationReader.LoadDocumentation(path);
+
+        _ = await Assert.That(firstResult).IsNotNull();
+        _ = await Assert.That(secondResult).IsNotNull();
+        _ = await Assert.That(secondResult!["T:Some.Namespace.CachedType"]).IsEqualTo("Cached summary.");
+    }
+
+    [Test]
+    public async Task TryGetSummary_WithNullType_ThrowsArgumentNullException() =>
+        _ = await Assert.That(() => XmlDocumentationReader.TryGetSummary(null!, out _)).Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task TryGetSummary_WithTypeWhoseAssemblyHasNoXmlDocFile_ReturnsFalse()
+    {
+        var found = XmlDocumentationReader.TryGetSummary(typeof(XmlDocumentationReaderTests), out var summary);
+
+        _ = await Assert.That(found).IsFalse();
+        _ = await Assert.That(summary).IsNull();
+    }
+
+    private static string CreateTempXmlDocumentationFile(string memberName, string summary)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.xml");
+
+        File.WriteAllText(
+            path,
+            $"""
+            <?xml version="1.0"?>
+            <doc>
+              <members>
+                <member name="{memberName}">
+                  <summary>
+                  {summary}
+                  </summary>
+                </member>
+              </members>
+            </doc>
+            """
+        );
+
+        return path;
+    }
+}

--- a/tests/NetEvolve.Pulse.Tests.Unit/Mocks.cs
+++ b/tests/NetEvolve.Pulse.Tests.Unit/Mocks.cs
@@ -1,7 +1,13 @@
 ﻿using Microsoft.AspNetCore.Http;
 using NetEvolve.Pulse.Extensibility;
+using NetEvolve.Pulse.Extensibility.Audit;
+using NetEvolve.Pulse.Extensibility.DeadLetter;
+using NetEvolve.Pulse.Extensibility.Outbox;
 using StackExchange.Redis;
 
 [assembly: GenerateMock(typeof(IHttpContextAccessor))]
 [assembly: GenerateMock(typeof(IConnectionMultiplexer))]
 [assembly: GenerateMock(typeof(IMediatorBuilder))]
+[assembly: GenerateMock(typeof(IOutboxManagement))]
+[assembly: GenerateMock(typeof(ICommandDeadLetterManagement))]
+[assembly: GenerateMock(typeof(IAuditManagement))]


### PR DESCRIPTION
## Summary

Combines the four ready-to-implement inspector/OpenAPI feature+test issue pairs into one PR:

- **Outbox Inspector** (#290, #291) — `MapOutboxInspector`: stats, dead-letter listing/count/lookup, single and bulk replay against `IOutboxManagement`.
- **Command Dead Letter Inspector** (#292, #293) — `MapCommandDeadLetterInspector`: stats, pending entries, replay and dismiss against `ICommandDeadLetterManagement`.
- **Audit Inspector** (#294, #295) — `MapAuditInspector`: read-only stats and filtered entry queries against `IAuditManagement`.
- **OpenAPI metadata extensions** (#288, #289) — opt-in `WithPulseSummary`/`WithPulseDescription`/`WithPulseTag`/`WithPulseProduces`/`WithPulseStreamProduces` on `RouteHandlerBuilder`, plus `EnableOpenApiMetadata()` on `IMediatorBuilder` to auto-apply summary/produces metadata across `MapCommand`/`MapQuery`/`MapStreamQuery`.

## Deviations from the original issue text

The three inspector issues describe endpoints against an idealized management API that doesn't match what `IOutboxManagement`, `ICommandDeadLetterManagement`, and `IAuditManagement` actually expose today. Rather than fabricating behavior, the endpoint sets were adapted to the real interfaces:

- **Command Dead Letter Inspector**: no `GET /entries/{id}` (no get-by-id method on the interface). `replay`/`dismiss` return `204 No Content` unconditionally — `ReplayAsync`/`DismissAsync` return `Task`, not `bool`, so there's no "not found" signal to surface as 404.
- **Audit Inspector**: no `GET /entries/{id}` — `IAuditManagement` exposes only `QueryAsync(AuditFilter)` and `GetStatisticsAsync()`.
- **Outbox Inspector**: no generic "pending messages" listing or dismiss endpoint — `IOutboxManagement` only exposes dead-letter operations.

## Notes

- `GenerateDocumentationFile` enabled on `NetEvolve.Pulse.AspNetCore.csproj` only (required for `XmlDocumentationReader` to have anything to read); no changes to `Directory.Build.props`/`Directory.Packages.props`/`.editorconfig`.
- Found and fixed two real production defects surfaced while wiring this up: `OutboxMessage.EventType` (a raw `Type`) wasn't JSON-serializable, and `AuditFilter`'s non-nullable `Take`/`Skip` made `[AsParameters]` binding treat them as required, rejecting requests without explicit `take`/`skip` query values.

## Testing

- `dotnet build Pulse.slnx` — 0 warnings, 0 errors (net8.0/net9.0/net10.0).
- `dotnet test` (`NetEvolve.Pulse.Tests.Unit`, net10.0) — 1979 passed, 0 failed, 0 skipped.
- `dotnet format --verify-no-changes` clean on all touched files.

Closes #288, #289, #290, #291, #292, #293, #294, #295
