### PR TITLE
fix(deps): pin SSH.NET to 2026.0.0 to resolve GHSA-q939-rpr3-3284

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -60,6 +60,7 @@
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.13.0" />
     <PackageVersion Include="Testcontainers.RabbitMq" Version="4.13.0" />
     <PackageVersion Include="Testcontainers.Redis" Version="4.13.0" />
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
     <PackageVersion Include="TUnit" Version="1.63.0" />
     <PackageVersion Include="TUnit.AspNetCore" Version="1.63.0" />
     <PackageVersion Include="TUnit.Mocks" Version="1.63.0" />


### PR DESCRIPTION
## Summary
Pins the transitive `SSH.NET` dependency (pulled in via Testcontainers) to 2026.0.0, fixing a high severity vulnerability (NU1903 / GHSA-q939-rpr3-3284) reported in 2025.1.0.

## Testing
- `dotnet restore` on the integration test project no longer reports NU1903 for SSH.NET.